### PR TITLE
Fix whitespace issues

### DIFF
--- a/tectonic/Engine.cpp
+++ b/tectonic/Engine.cpp
@@ -164,7 +164,7 @@ Normalizer::process()
 		if (T != 0)
 			generateChar(TBase + T);
 	}
-	
+
 	return 0;
 }
 
@@ -192,7 +192,7 @@ Normalizer::decomposeOne(UInt32& c)
 	UInt32	plane = c >> 16;
 	UInt32	page = (c >> 8) & 0xff;
 	UInt32	ch = c & 0xff;
-	
+
 	UInt16	charIndex = dcCharIndex[dcPageMaps[dcPlaneMap[plane]][page]][ch];
 	if (charIndex == 0)
 		return 0xffff;
@@ -210,7 +210,7 @@ Normalizer::generateChar(UInt32 c)
 		UInt32	ch = c & 0xff;
 		combClass = ccCharClass[ccPageMaps[ccPlaneMap[plane]][page]][ch];
 	}
-	
+
 	if (combClass != 0) {
 		// combiners are always buffered for sorting and possible composition
 		if (prevCombClass <= combClass) {
@@ -291,7 +291,7 @@ Normalizer::insertChar(UInt32 insCh, int insCombClass)
 			break;
 	}
 	++i;
-	
+
 	for (UInt32 j = oBufEnd; j > i; --j)
 		oBuffer[j] = oBuffer[j - 1];
 
@@ -358,7 +358,7 @@ Normalizer::compose()
 	    }
 	    oBufEnd = compPos;
 	}
-	    
+
     // update oBufSafe to pass any chars that definitely can't compose
 	if (lastClass != 0)
 		oBufSafe = oBufEnd;
@@ -412,7 +412,7 @@ Pass::Pass(const TableHeader* inTable, Converter* cnv)
 		pageBase += 20;
 		numPageMaps = READ(*(planeMap + 17));
 	}
-	
+
 	iBufSize = (READ(inTable->maxMatch) + READ(inTable->maxPre) + READ(inTable->maxPost) + 7) & ~0x0003;
 	iBuffer = new UInt32[iBufSize];
 
@@ -693,7 +693,7 @@ cerr << "info[" << index << "].matchedSpan.start = " << textLoc << "\n";
 		int		classIndex;
 		bool	matches;
 		UInt32	inChar;
-		
+
 		// start of group: try each alternative in turn
 		if (type == kMatchElem_Type_BGroup) {
 			// try matching one of the alternatives in the group (again)
@@ -738,14 +738,14 @@ cerr << "group returning matchYes; info[" << index << "].matchedSpan.limit = " <
 			// otherwise just backtrack
 			RETURN(matchNo);
 		}
-		
+
 		// reached end of an alternative
 		else if (type == kMatchElem_Type_OR || type == kMatchElem_Type_EGroup) {
 			int	startIndex = index - READ(m.value.egroup.dStart);
 			mr = match(startIndex, info[startIndex].groupRepeats + 1, textLoc);
 			RETURN(mr);
 		}
-		
+
 		// not a group, so we loop rather than recurse until optionality strikes
 		else {
 			// ensure that item matches at least repeatMin times
@@ -758,18 +758,18 @@ cerr << "group returning matchYes; info[" << index << "].matchedSpan.limit = " <
 					case 0:	// literal
 						matches = (READ(m.value.usv.data) & kUSVMask) == inChar;
 						break;
-					
+
 					case kMatchElem_Type_Class:
 						classIndex = classMatch(READ(m.value.cls.index), inChar);
 						matches = (classIndex != -1);
 						if (matches && repeats == 0 && index < infoLimit)
 							info[index].classIndex = classIndex;
 						break;
-					
+
 					case kMatchElem_Type_ANY:
 						matches = (inChar != kEndOfText);
 						break;
-					
+
 					case kMatchElem_Type_EOS:
 						matches = (inChar == kEndOfText);
 						break;
@@ -780,7 +780,7 @@ cerr << "group returning matchYes; info[" << index << "].matchedSpan.limit = " <
 				++repeats;
 				textLoc += direction;
 			}
-			
+
 			if (index < infoLimit) {
 				info[index].matchedSpan.limit = textLoc;
 #ifdef TRACING
@@ -794,7 +794,7 @@ cerr << "info[" << index << "].matchedSpan.limit = " << textLoc << "\n";
 				repeats = 0;
 				goto RESTART;
 			}
-			
+
 			// try for another repeat if allowed
 			if (repeats < repeatMax) {
 				inChar = inputChar(textLoc);
@@ -805,18 +805,18 @@ cerr << "info[" << index << "].matchedSpan.limit = " << textLoc << "\n";
 					case 0:	// literal
 						matches = (READ(m.value.usv.data) & kUSVMask) == inChar;
 						break;
-					
+
 					case kMatchElem_Type_Class:
 						classIndex = classMatch(READ(m.value.cls.index), inChar);
 						matches = (classIndex != -1);
 						if (matches && repeats == 0 && index < infoLimit)
 							info[index].classIndex = classIndex;
 						break;
-					
+
 					case kMatchElem_Type_ANY:
 						matches = (inChar != kEndOfText);
 						break;
-					
+
 					case kMatchElem_Type_EOS:
 						matches = (inChar == kEndOfText);
 						break;
@@ -828,7 +828,7 @@ cerr << "info[" << index << "].matchedSpan.limit = " << textLoc << "\n";
 						RETURN(mr);
 				}
 			}
-			
+
 			// otherwise try to match the remainder of the pattern
 			mr = match(index + 1, 0, textLoc);
 			RETURN(mr);
@@ -1081,7 +1081,7 @@ if (traceLevel > 0) {
 			// clear junk...
 			for (int i = 0; i < infoLimit; ++i)
 				info[i].matchedSpan.start = info[i].matchedSpan.limit = 0;
-                        
+
 			UInt32	mr = match(0, 0, 0);
 			if (mr == matchYes) {
 				if (matchedLength == 0 && allowInsertion == false)
@@ -1101,13 +1101,13 @@ if (traceLevel > 0) {
 	cerr << "** MATCHED:";
 	printMatch(rule);
 	cerr << "\n";
-	
+
 	cerr << "** RANGES:";
 	for (int i = 0; i < READ(rule->matchLength); ++i) {
 		cerr << " <" << info[i].matchedSpan.start << ":" << info[i].matchedSpan.limit << ">";
 	}
 	cerr << "\n";
-	
+
 	cerr << "** REPLACEMENT:";
 	printRep(rule);
 	cerr << "\n";
@@ -1264,7 +1264,7 @@ if (traceLevel > 0)
 				outputChar(READ(lookup->bytes.data[i]));
 		}
 	}
-	
+
 	advanceInput(matchedLength);
 	return 0;
 }
@@ -1300,7 +1300,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 			}
 			fh = (const FileHeader*)table;
 		}
-		
+
 		if (READ(fh->type) != kMagicNumber) {
 			status = kStatus_InvalidMapping;
 			return;
@@ -1327,7 +1327,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 			tableBase += numTables;
 			numTables = READ(fh->numRevTables);
 		}
-		
+
 		// check that the outputForm matches the output of the mapping
 		UInt32	targetFlags = forward ? READ(fh->formFlagsRHS) : READ(fh->formFlagsLHS);
 		if ((targetFlags & kFlags_Unicode) != 0) {
@@ -1342,7 +1342,7 @@ Converter::Converter(const Byte* inTable, UInt32 inTableSize, bool inForward,
 				return;
 			}
 		}
-		
+
 		// if converting from Unicode, prefix a Normalizer if the mapping wants it
 		UInt32	sourceFlags = forward ? READ(fh->formFlagsLHS) : READ(fh->formFlagsRHS);
 		if ((sourceFlags & kFlags_Unicode) != 0) {
@@ -1441,7 +1441,7 @@ static UInt32
 offsetsFromUTF8[6] =	{
 	0x00000000UL,
 	0x00003080UL,
-	0x000E2080UL, 
+	0x000E2080UL,
 	0x03C82080UL,
 	0xFA082080UL,
 	0x82082080UL
@@ -1490,10 +1490,10 @@ Converter::_getCharFn()
 //
 //	if (dataPtr >= dataLen)
 //		return inputComplete ? kEndOfText : kNeedMoreInput;
-//	
+//
 //	if (inputForm == kForm_Bytes)
 //		return data[dataPtr++];
-	
+
 	UInt32	rval = 0;
 
 	if (savedCount > 0) {	// the less efficient version is only called if really needed
@@ -1510,7 +1510,7 @@ Converter::_getCharFn()
 			return kNeedMoreInput;	\
 		}							\
 	}
-	
+
 	switch (inputForm) {
 		case kForm_UTF8:
 			{
@@ -1660,12 +1660,12 @@ Converter::_getCharWithSavedBytes()
 			rval += DATA(dataPtr) << 24; dataPtr++;
 			break;
 	}
-	
+
 	if (dataPtr >= savedCount) {
 		dataPtr -= savedCount;
 		savedCount = 0;
 	}
-	
+
 	return rval;
 }
 
@@ -1730,13 +1730,13 @@ Converter::ConvertBufferOpt(
 #define RETURN(returnStatus)	rval = returnStatus; goto RETURN_LABEL
 
 	UInt32	outPtr = 0;
-	
+
 	data = inBuffer;
 	dataLen = inLength;
 	dataPtr = 0;
 	inputComplete = ((inOptions & kOptionsMask_InputComplete) == kOptionsComplete_InputIsComplete);
 	unmappedBehavior = (inOptions & kOptionsMask_UnmappedBehavior);
-	
+
 	UInt32	c;
 	if (pendingOutputChar != kInvalidChar) {
 		c = pendingOutputChar;
@@ -1886,7 +1886,7 @@ RETURN_LABEL:
 	rval |= warningStatus;
 	if ((rval & kStatusMask_Basic) == kStatus_NoError)
 		Reset();
-	
+
 	return rval;
 }
 

--- a/tectonic/Engine.h
+++ b/tectonic/Engine.h
@@ -35,11 +35,11 @@ class Stage
 public:
 						Stage();
 	virtual				~Stage();
-	
+
 	virtual UInt32		getChar() = 0;
-	
+
 	virtual void		Reset() = 0;
-	
+
 	virtual UInt32		lookaheadCount() const;
 
 protected:
@@ -64,12 +64,12 @@ public:
 
 	virtual void		Reset();
 
-protected:	
+protected:
 	UInt32				process();
-	
+
 	void				decompose(UInt32 c);
 	UInt32				decomposeOne(UInt32& c);
-	
+
 	void				compose();
 	void				generateChar(UInt32 c);
 	void				appendChar(UInt32 c);
@@ -78,7 +78,7 @@ protected:
 
 	int					prevCombClass;
 	long				oBufSafe;
-	
+
 	bool				bCompose;
 };
 
@@ -88,7 +88,7 @@ class Pass
 public:
 						Pass(const TableHeader* inTable, Converter* cnv);
 	virtual				~Pass();
-	
+
 	virtual UInt32		getChar();
 
 	virtual void		Reset();
@@ -198,9 +198,9 @@ protected:
 	void				_savePendingBytes();
 
 	Byte*				table;
-	
+
 	Stage*				finalStage;
-	
+
 	const Byte*			data;
 	UInt32				dataPtr;
 	UInt32				dataLen;
@@ -217,7 +217,7 @@ protected:
 
 	UInt32				pendingOutputChar;
 	long				status;
-	
+
 	UInt32				warningStatus;
 };
 

--- a/tectonic/TECkit_Compiler.h
+++ b/tectonic/TECkit_Compiler.h
@@ -1,10 +1,10 @@
 /*
 	TECkit_Compiler.h
-	
+
 	Public API to the TECkit compiler library.
 
 	18-Jan-2008		jk	added EXPORTED to declarations, for mingw32 cross-build
-	
+
 	Jonathan Kew	22-Dec-2001
 					14-May-2002		added WINAPI to function declarations
 					 5-Jul-2002		corrected placement of WINAPI/CALLBACK to keep MS compiler happy

--- a/tectonic/TECkit_Engine.h
+++ b/tectonic/TECkit_Engine.h
@@ -14,9 +14,9 @@ Description:
 
 /*
 	TECkit_Engine.h
-	
+
 	Public API to the TECkit encoding conversion library.
-	
+
 	18-Jan-2008		jk	added EXPORTED to declarations, for mingw32 cross-build
 	18-Mar-2005		jk	moved version number to TECkit_Common.h as it is shared with the compiler
 	19-Mar-2004		jk	updated minor version for 2.2 engine (improved matching functionality)

--- a/tectonic/TECkit_Format.h
+++ b/tectonic/TECkit_Format.h
@@ -151,7 +151,7 @@ union MatchElem {
 #endif
 	struct {
 		UInt8	repeat;				/* repeat count: (min << 4) + max */
-		UInt8	type;				/* 
+		UInt8	type;				/*
 										0x80:	negate flag (not allowed with group)
 										0x40:	non-literal flag--if set, bits 0x3f indicate specific type (value must not be zero)
 												Note that if 'non-literal' flag is NOT set, remaining bits are not used as type code

--- a/tectonic/XeTeXFontMgr.cpp
+++ b/tectonic/XeTeXFontMgr.cpp
@@ -403,7 +403,7 @@ XeTeXFontMgr::getFullName(PlatformFontRef font) const
 {
     std::map<PlatformFontRef,Font*>::const_iterator i = m_platformRefToFont.find(font);
     if (i == m_platformRefToFont.end())
-	_tt_abort("internal error %d in XeTeXFontMgr", 2);
+        _tt_abort("internal error %d in XeTeXFontMgr", 2);
     if (i->second->m_fullName != NULL)
         return i->second->m_fullName->c_str();
     else

--- a/tectonic/XeTeXFontMgr_FC.cpp
+++ b/tectonic/XeTeXFontMgr_FC.cpp
@@ -103,7 +103,7 @@ XeTeXFontMgr_FC::readNames(FcPattern* pat)
 
     // for sfnt containers, we'll read the name table ourselves, not rely on Fontconfig
     if (FT_IS_SFNT(face)) {
-	unsigned int i;
+        unsigned int i;
         std::list<std::string>  familyNames;
         std::list<std::string>  subFamilyNames;
         FT_SfntName nameRec;
@@ -310,7 +310,7 @@ void
 XeTeXFontMgr_FC::initialize()
 {
     if (FcInit() == FcFalse)
-	_tt_abort("fontconfig initialization failed");
+        _tt_abort("fontconfig initialization failed");
 
     if (gFreeTypeLibrary == 0 && FT_Init_FreeType(&gFreeTypeLibrary) != 0)
         _tt_abort("FreeType initialization failed");
@@ -320,7 +320,7 @@ XeTeXFontMgr_FC::initialize()
     utf16beConv = ucnv_open("UTF16BE", &err);
     utf8Conv = ucnv_open("UTF8", &err);
     if (err)
-	_tt_abort("cannot read font names");
+        _tt_abort("cannot read font names");
 
     FcPattern* pat = FcNameParse((const FcChar8*)":outline=true");
     FcObjectSet* os = FcObjectSetBuild(FC_FAMILY, FC_STYLE, FC_FILE, FC_INDEX,
@@ -337,15 +337,15 @@ XeTeXFontMgr_FC::terminate()
 {
     if (macRomanConv != NULL) {
         ucnv_close(macRomanConv);
-	macRomanConv = NULL;
+        macRomanConv = NULL;
     }
     if (utf16beConv != NULL) {
         ucnv_close(utf16beConv);
-	utf16beConv = NULL;
+        utf16beConv = NULL;
     }
     if (utf8Conv != NULL) {
         ucnv_close(utf8Conv);
-	utf8Conv = NULL;
+        utf8Conv = NULL;
     }
 }
 

--- a/tectonic/XeTeXFontMgr_Mac.mm
+++ b/tectonic/XeTeXFontMgr_Mac.mm
@@ -91,7 +91,7 @@ XeTeXFontMgr_Mac::readNames(CTFontDescriptorRef fontRef)
     NSAutoreleasePool *pool = [NSAutoreleasePool new];
 
     names->m_psName = [(NSString *) psName UTF8String];
-    CFRelease(psName); 
+    CFRelease(psName);
 
     CTFontRef font = CTFontCreateWithFontDescriptor(fontRef, 0.0, 0);
     appendNameToList(font, &names->m_fullNames,   kCTFontFullNameKey);
@@ -179,7 +179,7 @@ XeTeXFontMgr_Mac::searchForHostPlatformFonts(const std::string& name)
             return;
         }
     }
-    
+
     matched = findFontWithName(nameStr, kCTFontNameAttribute);
     if (matched) {
         addFontAndSiblingsToCaches(matched);

--- a/tectonic/XeTeXLayoutInterface.cpp
+++ b/tectonic/XeTeXLayoutInterface.cpp
@@ -744,7 +744,7 @@ layoutChars(XeTeXLayoutEngine engine, uint16_t chars[], int32_t offset, int32_t 
             engine->shaper = strdup(hb_shape_plan_get_shaper(shape_plan));
             hb_buffer_set_content_type(engine->hbBuffer, HB_BUFFER_CONTENT_TYPE_GLYPHS);
         } else {
-	    _tt_abort("all shapers failed");
+            _tt_abort("all shapers failed");
         }
     }
 

--- a/tectonic/XeTeX_ext.c
+++ b/tectonic/XeTeX_ext.c
@@ -108,7 +108,7 @@ linebreak_start(int f, integer localeStrNum, uint16_t* text, integer textLength)
     }
 
     if (brkIter == NULL)
-	_tt_abort ("failed to create linebreak iterator, status=%d", (int) status);
+        _tt_abort ("failed to create linebreak iterator, status=%d", (int) status);
 
     ubrk_setText(brkIter, (UChar*) text, textLength, &status);
 }
@@ -196,24 +196,24 @@ load_mapping_file(const char* s, const char* e, char byteMapping)
 
     map = ttstub_input_open (buffer, kpse_miscfonts_format, 0);
     if (map) {
-	size_t mappingSize = ttstub_input_get_size (map);
-	Byte *mapping = (Byte*) xmalloc(mappingSize);
+        size_t mappingSize = ttstub_input_get_size (map);
+        Byte *mapping = (Byte*) xmalloc(mappingSize);
 
-	if (ttstub_input_read(map, mapping, mappingSize) != mappingSize)
-	    _tt_abort("could not read mapping file \"%s\"", buffer);
+        if (ttstub_input_read(map, mapping, mappingSize) != mappingSize)
+            _tt_abort("could not read mapping file \"%s\"", buffer);
 
-	ttstub_input_close(map);
+        ttstub_input_close(map);
 
-	if (byteMapping != 0)
-	    TECkit_CreateConverter(mapping, mappingSize,
-				   false,
-				   UTF16_NATIVE, kForm_Bytes,
-				   &cnv);
-	else
-	    TECkit_CreateConverter(mapping, mappingSize,
-				   true,
-				   UTF16_NATIVE, UTF16_NATIVE,
-				   &cnv);
+        if (byteMapping != 0)
+            TECkit_CreateConverter(mapping, mappingSize,
+                                   false,
+                                   UTF16_NATIVE, kForm_Bytes,
+                                   &cnv);
+        else
+            TECkit_CreateConverter(mapping, mappingSize,
+                                   true,
+                                   UTF16_NATIVE, UTF16_NATIVE,
+                                   &cnv);
 
         if (cnv == NULL)
             font_mapping_warning(buffer, strlen(buffer), 2); /* not loadable */
@@ -750,43 +750,43 @@ find_native_font(unsigned char* uname, integer scaled_size)
 
     // check for "[filename]" form, don't search maps in this case
     if (nameString[0] == '[') {
-	if (scaled_size < 0) {
-	    font = createFontFromFile(nameString + 1, index, 655360L);
-	    if (font != NULL) {
-		Fixed dsize = D2Fix(getDesignSize(font));
-		if (scaled_size == -1000)
-		    scaled_size = dsize;
-		else
-		    scaled_size = xn_over_d(dsize, -scaled_size, 1000);
-		deleteFont(font);
-	    }
-	}
-	font = createFontFromFile(nameString + 1, index, scaled_size);
-	if (font != NULL) {
-	    loaded_font_design_size = D2Fix(getDesignSize(font));
+        if (scaled_size < 0) {
+            font = createFontFromFile(nameString + 1, index, 655360L);
+            if (font != NULL) {
+                Fixed dsize = D2Fix(getDesignSize(font));
+                if (scaled_size == -1000)
+                    scaled_size = dsize;
+                else
+                    scaled_size = xn_over_d(dsize, -scaled_size, 1000);
+                deleteFont(font);
+            }
+        }
+        font = createFontFromFile(nameString + 1, index, scaled_size);
+        if (font != NULL) {
+            loaded_font_design_size = D2Fix(getDesignSize(font));
 
-	    /* This is duplicated in XeTeXFontMgr::findFont! */
-	    setReqEngine(0);
-	    if (varString) {
-		if (strncmp(varString, "/AAT", 4) == 0)
-		    setReqEngine('A');
-		else if ((strncmp(varString, "/OT", 3) == 0) || (strncmp(varString, "/ICU", 4) == 0))
-		    setReqEngine('O');
-		else if (strncmp(varString, "/GR", 3) == 0)
-		    setReqEngine('G');
-	    }
+            /* This is duplicated in XeTeXFontMgr::findFont! */
+            setReqEngine(0);
+            if (varString) {
+                if (strncmp(varString, "/AAT", 4) == 0)
+                    setReqEngine('A');
+                else if ((strncmp(varString, "/OT", 3) == 0) || (strncmp(varString, "/ICU", 4) == 0))
+                    setReqEngine('O');
+                else if (strncmp(varString, "/GR", 3) == 0)
+                    setReqEngine('G');
+            }
 
-	    rval = loadOTfont(0, font, scaled_size, featString);
-	    if (rval == NULL)
-		deleteFont(font);
-	    if (rval != NULL && get_tracing_fonts_state() > 0) {
-		begin_diagnostic();
-		print_nl(' ');
-		print_c_string("-> ");
-		print_c_string(nameString + 1);
-		end_diagnostic(0);
-	    }
-	}
+            rval = loadOTfont(0, font, scaled_size, featString);
+            if (rval == NULL)
+                deleteFont(font);
+            if (rval != NULL && get_tracing_fonts_state() > 0) {
+                begin_diagnostic();
+                print_nl(' ');
+                print_c_string("-> ");
+                print_c_string(nameString + 1);
+                end_diagnostic(0);
+            }
+        }
     } else {
         fontRef = findFontByName(nameString, varString, Fix2D(scaled_size));
 
@@ -1208,7 +1208,7 @@ make_font_def(integer f)
 
         size = D2Fix(getPointSize(engine));
     } else {
-	_tt_abort("bad native font flag in `make_font_def`");
+        _tt_abort("bad native font flag in `make_font_def`");
     }
 
     filenameLen = strlen(filename);
@@ -1363,7 +1363,7 @@ get_native_char_height_depth(integer font, integer ch, scaled* height, scaled* d
         int gid = mapCharToGlyph(engine, ch);
         getGlyphHeightDepth(engine, gid, &ht, &dp);
     } else {
-	_tt_abort("bad native font flag in `get_native_char_height_depth`");
+        _tt_abort("bad native font flag in `get_native_char_height_depth`");
     }
 
     *height = D2Fix(ht);
@@ -1439,7 +1439,7 @@ get_glyph_bounds(integer font, integer edge, integer gid)
         else
             getGlyphHeightDepth(engine, gid, &a, &b);
     } else {
-	_tt_abort("bad native font flag in `get_glyph_bounds`");
+        _tt_abort("bad native font flag in `get_glyph_bounds`");
     }
     return D2Fix((edge <= 2) ? a : b);
 }
@@ -1471,7 +1471,7 @@ getnativecharwd(integer f, integer c)
         int gid = mapCharToGlyph(engine, c);
         wd = D2Fix(getGlyphWidthFromEngine(engine, gid));
     } else {
-	_tt_abort("bad native font flag in `get_native_char_wd`");
+        _tt_abort("bad native font flag in `get_native_char_wd`");
     }
     return wd;
 }
@@ -1692,7 +1692,7 @@ measure_native_node(void* pNode, int use_glyph_metrics)
         }
         free(glyphAdvances);
     } else {
-	_tt_abort("bad native font flag in `measure_native_node`");
+        _tt_abort("bad native font flag in `measure_native_node`");
     }
 
     if (use_glyph_metrics == 0 || native_glyph_count(node) == 0) {
@@ -1804,7 +1804,7 @@ measure_native_glyph(void* pNode, int use_glyph_metrics)
         if (use_glyph_metrics)
             getGlyphHeightDepth(engine, gid, &ht, &dp);
     } else {
-	_tt_abort("bad native font flag in `measure_native_glyph`");
+        _tt_abort("bad native font flag in `measure_native_glyph`");
     }
 
     if (use_glyph_metrics) {
@@ -1829,7 +1829,7 @@ map_char_to_glyph(integer font, integer ch)
     if (font_area[font] == OTGR_FONT_FLAG)
         return mapCharToGlyph((XeTeXLayoutEngine)(font_layout_engine[font]), ch);
     else {
-	_tt_abort("bad native font flag in `map_char_to_glyph`");
+        _tt_abort("bad native font flag in `map_char_to_glyph`");
     }
 }
 
@@ -1845,7 +1845,7 @@ map_glyph_to_index(integer font)
     if (font_area[font] == OTGR_FONT_FLAG)
         return mapGlyphToIndex((XeTeXLayoutEngine)(font_layout_engine[font]), (const char*)name_of_file + 1);
     else
-	_tt_abort("bad native font flag in `map_glyph_to_index`");
+        _tt_abort("bad native font flag in `map_glyph_to_index`");
 }
 
 integer
@@ -1859,7 +1859,7 @@ get_font_char_range(integer font, int first)
     if (font_area[font] == OTGR_FONT_FLAG)
         return getFontCharRange((XeTeXLayoutEngine)(font_layout_engine[font]), first);
     else
-	_tt_abort("bad native font flag in `get_font_char_range'`");
+        _tt_abort("bad native font flag in `get_font_char_range'`");
 }
 
 Fixed D2Fix(double d)
@@ -2118,7 +2118,7 @@ print_glyph_name(integer font, integer gid)
         XeTeXLayoutEngine engine = (XeTeXLayoutEngine)font_layout_engine[font];
         s = getGlyphName(getFont(engine), gid, &len);
     } else {
-	_tt_abort("bad native font flag in `print_glyph_name`");
+        _tt_abort("bad native font flag in `print_glyph_name`");
     }
     while (len-- > 0)
         print_char(*s++);
@@ -2133,7 +2133,7 @@ path_is_absolute (const_string filename)
 
     absolute = IS_DIR_SEP (*filename);
     explicit_relative = (*filename == '.' && (IS_DIR_SEP (filename[1])
-					      || (filename[1] == '.' && IS_DIR_SEP (filename[2]))));
+                                              || (filename[1] == '.' && IS_DIR_SEP (filename[2]))));
     return absolute || explicit_relative;
 }
 

--- a/tectonic/XeTeX_ext.c
+++ b/tectonic/XeTeX_ext.c
@@ -62,8 +62,8 @@ authorization from the copyright holders.
 
 
 /* OT-related constants we need */
-#define kGSUB   HB_TAG('G','S','U','B')
-#define kGPOS   HB_TAG('G','P','O','S')
+#define kGSUB HB_TAG('G','S','U','B')
+#define kGPOS HB_TAG('G','P','O','S')
 
 
 static UBreakIterator* brkIter = NULL;
@@ -527,7 +527,7 @@ loadOTfont(PlatformFontRef fontRef, XeTeXFont font, Fixed scaled_size, char* cp1
                 ++cp1;
             while ((*cp1 == ' ') || (*cp1 == '\t')) /* skip leading whitespace */
                 ++cp1;
-            if (*cp1 == 0)  /* break if end of string */
+            if (*cp1 == 0) /* break if end of string */
                 break;
 
             cp2 = cp1;

--- a/tectonic/XeTeX_ext.h
+++ b/tectonic/XeTeX_ext.h
@@ -111,13 +111,13 @@ void print_chars(const unsigned short* str, int len);
 void* find_native_font(unsigned char* name, integer scaled_size);
 void release_font_engine(void* engine, int type_flag);
 int readCommonFeatures(const char* feat, const char* end, float* extend,
-		       float* slant, float* embolden, float* letterspace, uint32_t* rgbValue);
+                       float* slant, float* embolden, float* letterspace, uint32_t* rgbValue);
 
 /* the metrics params here are really TeX 'scaled' values, but that typedef
  * isn't available every place this is included */
 
 void ot_get_font_metrics(void* engine, integer* ascent, integer* descent, integer* xheight,
-			 integer* capheight, integer* slant);
+                         integer* capheight, integer* slant);
 void get_native_char_height_depth(integer font, integer ch, integer* height, integer* depth);
 void get_native_char_sidebearings(integer font, integer ch, integer* lsb, integer* rsb);
 

--- a/tectonic/XeTeX_mac.c
+++ b/tectonic/XeTeX_mac.c
@@ -698,10 +698,10 @@ loadAATfont(CTFontDescriptorRef descriptor, integer scaled_size, const char* cp1
     }
 
     if ((loaded_font_flags & FONT_FLAGS_COLORED) != 0) {
-        CGFloat red  = ((rgbValue & 0xFF000000) >> 24) / 255.0;
-        CGFloat green   = ((rgbValue & 0x00FF0000) >> 16) / 255.0;
-        CGFloat blue    = ((rgbValue & 0x0000FF00) >> 8 ) / 255.0;
-        CGFloat alpha   = ((rgbValue & 0x000000FF)  ) / 255.0;
+        CGFloat red   = ((rgbValue & 0xFF000000) >> 24) / 255.0;
+        CGFloat green = ((rgbValue & 0x00FF0000) >> 16) / 255.0;
+        CGFloat blue  = ((rgbValue & 0x0000FF00) >> 8 ) / 255.0;
+        CGFloat alpha = ((rgbValue & 0x000000FF)) / 255.0;
         CGColorRef color = CGColorCreateGenericRGB(red, green, blue, alpha);
         CFDictionaryAddValue(stringAttributes, kCTForegroundColorAttributeName, color);
         CGColorRelease(color);

--- a/tectonic/XeTeX_mac.c
+++ b/tectonic/XeTeX_mac.c
@@ -101,7 +101,7 @@ DoAATLayout(void* p, int justify)
 
     unsigned f = native_font(node);
     if (font_area[f] != AAT_FONT_FLAG)
-	_tt_abort("DoAATLayout called for non-AAT font");
+        _tt_abort("DoAATLayout called for non-AAT font");
 
     txtLen = native_length(node);
     txtPtr = (UniChar*)(node + NATIVE_NODE_SIZE);
@@ -428,7 +428,7 @@ getFileNameFromCTFont(CTFontRef ctFontRef, uint32_t *index)
             if (!gFreeTypeLibrary) {
                 error = FT_Init_FreeType(&gFreeTypeLibrary);
                 if (error)
-		    _tt_abort("FreeType initialization failed; error %d", error);
+                    _tt_abort("FreeType initialization failed; error %d", error);
             }
 
             error = FT_New_Face(gFreeTypeLibrary, (char *) pathname, 0, &face);

--- a/tectonic/XeTeX_pic.c
+++ b/tectonic/XeTeX_pic.c
@@ -54,7 +54,7 @@ count_pdf_file_pages (void)
 
     handle = ttstub_input_open (name_of_file + 1, kpse_pict_format, 0);
     if (handle == NULL)
-	return 0;
+        return 0;
 
     pages = pdf_count_pages(handle);
     ttstub_input_close(handle);
@@ -70,16 +70,16 @@ get_image_size_in_inches (rust_input_handle_t handle, float *width, float *heigh
     double xdensity, ydensity;
 
     if (check_for_jpeg(handle))
-	err = jpeg_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
+        err = jpeg_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
     else if (check_for_bmp(handle))
-	err = bmp_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
+        err = bmp_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
     else if (check_for_png(handle))
-	err = png_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
+        err = png_get_bbox(handle, &width_pix, &height_pix, &xdensity, &ydensity);
 
     if (err) {
-	*width = -1;
-	*height = -1;
-	return err;
+        *width = -1;
+        *height = -1;
+        return err;
     }
 
     /* xdvipdfmx defines density = 72 / dpi, so ... */
@@ -106,19 +106,19 @@ find_pic_file (char **path, real_rect *bounds, int pdfBoxType, int page)
     bounds->x = bounds->y = bounds->wd = bounds->ht = 0.0;
 
     if (handle == NULL)
-	return 1;
+        return 1;
 
     if (pdfBoxType != 0) {
-	/* if cmd was \XeTeXpdffile, use xpdflib to read it */
-	err = pdf_get_rect (handle, page, pdfBoxType, bounds);
+        /* if cmd was \XeTeXpdffile, use xpdflib to read it */
+        err = pdf_get_rect (handle, page, pdfBoxType, bounds);
     } else {
-	err = get_image_size_in_inches (handle, &bounds->wd, &bounds->ht);
-	bounds->wd *= 72.27;
-	bounds->ht *= 72.27;
+        err = get_image_size_in_inches (handle, &bounds->wd, &bounds->ht);
+        bounds->wd *= 72.27;
+        bounds->ht *= 72.27;
     }
 
     if (err == 0)
-	*path = xstrdup(in_path);
+        *path = xstrdup(in_path);
 
     ttstub_input_close (handle);
 

--- a/tectonic/XeTeXswap.h
+++ b/tectonic/XeTeXswap.h
@@ -39,9 +39,9 @@ static inline uint16_t
 SWAP16(const uint16_t p)
 {
 #if U_IS_BIG_ENDIAN
-	return p;
+        return p;
 #else
-	return (p >> 8) + (p << 8);
+        return (p >> 8) + (p << 8);
 #endif
 }
 
@@ -49,9 +49,9 @@ static inline uint32_t
 SWAP32(const uint32_t p)
 {
 #if U_IS_BIG_ENDIAN
-	return p;
+        return p;
 #else
-	return (p >> 24) + ((p >> 8) & 0x0000ff00) + ((p << 8) & 0x00ff0000) + (p << 24);
+        return (p >> 24) + ((p >> 8) & 0x0000ff00) + ((p << 8) & 0x00ff0000) + (p << 24);
 #endif
 }
 
@@ -60,25 +60,25 @@ SWAP32(const uint32_t p)
 static inline uint16_t
 SWAP(uint16_t p)
 {
-	return SWAP16(p);
+        return SWAP16(p);
 }
 
 static inline uint32_t
 SWAP(uint32_t p)
 {
-	return SWAP32(p);
+        return SWAP32(p);
 }
 
 static inline int16_t
 SWAP(int16_t p)
 {
-	return (int16_t)SWAP16((uint16_t)p);
+        return (int16_t)SWAP16((uint16_t)p);
 }
 
 static inline int32_t
 SWAP(int32_t p)
 {
-	return (int32_t)SWAP32((uint32_t)p);
+        return (int32_t)SWAP32((uint32_t)p);
 }
 #endif
 

--- a/tectonic/bibtex.c
+++ b/tectonic/bibtex.c
@@ -2862,7 +2862,7 @@ boolean von_token_found(void)
                     name_bf_ptr = name_bf_ptr + 1;
                 }
                 goto exit;
-            } else              /*401: */
+            } else /*401: */
                 while (((nm_brace_level > 0) && (name_bf_ptr < name_bf_xptr))) {
 
                     if ((sv_buffer[name_bf_ptr] == 125 /*right_brace */ ))

--- a/tectonic/dpx-agl.c
+++ b/tectonic/dpx-agl.c
@@ -109,10 +109,10 @@ agl_chop_suffix (const char *glyphname, char **suffix)
       strncpy(name, glyphname, len);
       name[len] = '\0';
       if (p[0] == '\0') {
-	*suffix = NULL;
+        *suffix = NULL;
       } else {
-	*suffix = NEW(strlen(p) + 1, char);
-	strcpy(*suffix, p);
+        *suffix = NEW(strlen(p) + 1, char);
+        strcpy(*suffix, p);
       }
     }
   } else {
@@ -151,21 +151,21 @@ skip_capital (const char **p, const char *endptr)
     *p  += 2;
     slen = 2;
   } else if (len >= 3 &&
-	     **p     == 'E' &&
-	     *(*p+1) == 't' &&
-	     *(*p+2) == 'h') {
+             **p     == 'E' &&
+             *(*p+1) == 't' &&
+             *(*p+2) == 'h') {
     *p  += 3;
     slen = 3;
   } else if (len >= 5 &&
-	     **p     == 'T' &&
-	     *(*p+1) == 'h' &&
-	     *(*p+2) == 'o' &&
-	     *(*p+3) == 'r' &&
-	     *(*p+4) == 'n') {
+             **p     == 'T' &&
+             *(*p+1) == 'h' &&
+             *(*p+2) == 'o' &&
+             *(*p+3) == 'r' &&
+             *(*p+4) == 'n') {
     *p  += 5;
     slen = 5;
   } else if (len >= 1 &&
-	     **p >= 'A' && **p <= 'Z') {
+             **p >= 'A' && **p <= 'Z') {
     *p  += 1;
     slen = 1;
   }
@@ -183,7 +183,7 @@ skip_modifier (const char **p, const char *endptr)
 
   for (i = 0; modifiers[i] != NULL; i++) {
     if ((len >= strlen(modifiers[i]) &&
-	 !memcmp(*p, modifiers[i], len))) {
+         !memcmp(*p, modifiers[i], len))) {
       slen = strlen(modifiers[i]);
       *p  += slen;
       break;
@@ -273,7 +273,7 @@ agl_suffix_to_otltag (const char *suffix)
     if (!strcmp(suffix, var_list[i].key))
       return var_list[i].otl_tag;
     if (var_list[i].otl_tag &&
-	!strcmp(suffix, var_list[i].otl_tag))
+        !strcmp(suffix, var_list[i].otl_tag))
       return var_list[i].otl_tag;
   }
 
@@ -291,8 +291,8 @@ agl_guess_name (const char *glyphname)
   len = strlen(glyphname);
   for (i = 1; var_list[i].key != NULL; i++) {
     if (len > strlen(var_list[i].key) &&
-	!strcmp(glyphname+len-strlen(var_list[i].key), var_list[i].key)
-	) {
+        !strcmp(glyphname+len-strlen(var_list[i].key), var_list[i].key)
+        ) {
       return i;
     }
   }
@@ -328,7 +328,7 @@ agl_normalized_name (char *glyphname)
     agln->name   = NEW(n+1, char);
     for (i = 0; i < n; i++) {
       agln->name[i] = isupper((unsigned char)glyphname[i]) ?
-	(glyphname[i] + 32) : glyphname[i];
+        (glyphname[i] + 32) : glyphname[i];
     }
     agln->name[n] = '\0';
   } else {
@@ -540,11 +540,11 @@ agl_name_is_unicode (const char *glyphname)
     else
       return 0;
   } else if (len <= 7 && len >= 5 &&
-	     glyphname[0] == 'u') {
+             glyphname[0] == 'u') {
     for (i = 1; i < len - 1; i++) {
       c = glyphname[i];
       if (!isdigit((unsigned char)c) && (c < 'A' || c > 'F'))
-	return 0;
+        return 0;
     }
     return 1;
   }
@@ -622,7 +622,7 @@ xtol (const char *start, int len)
 
 static int32_t
 put_unicode_glyph (const char *name,
-		   unsigned char **dstpp, unsigned char *limptr)
+                   unsigned char **dstpp, unsigned char *limptr)
 {
   const char *p;
   int32_t len = 0, ucv;
@@ -648,8 +648,8 @@ put_unicode_glyph (const char *name,
 
 int32_t
 agl_sput_UTF16BE (const char *glyphstr,
-		  unsigned char **dstpp, unsigned char *limptr,
-		  int *fail_count)
+                  unsigned char **dstpp, unsigned char *limptr,
+                  int *fail_count)
 {
   int32_t len   = 0;
   int   count = 0;
@@ -678,7 +678,7 @@ agl_sput_UTF16BE (const char *glyphstr,
       dpx_warning("Invalid glyph name component in \"%s\".", glyphstr);
       count++;
       if (fail_count)
-	*fail_count = count;
+        *fail_count = count;
       return len; /* Cannot continue */
     } else if (!delim || delim > endptr) {
       delim = endptr;
@@ -692,33 +692,33 @@ agl_sput_UTF16BE (const char *glyphstr,
     if (agl_name_is_unicode(name)) {
       sub_len = put_unicode_glyph(name, dstpp, limptr);
       if (sub_len > 0)
-	len += sub_len;
+        len += sub_len;
       else {
-	count++;
+        count++;
       }
     } else {
       agln1 = agl_lookup_list(name);
       if (!agln1 || (agln1->n_components == 1 &&
-		     IS_PUA(agln1->unicodes[0]))) {
-	agln0 = agl_normalized_name(name);
-	if (agln0) {
-	  if (verbose > 1 && agln0->suffix) {
-	    dpx_warning("agl: fix %s --> %s.%s",
-		 name, agln0->name, agln0->suffix);
-	  }
-	  agln1 = agl_lookup_list(agln0->name);
-	  agl_release_name(agln0);
-	}
+                     IS_PUA(agln1->unicodes[0]))) {
+        agln0 = agl_normalized_name(name);
+        if (agln0) {
+          if (verbose > 1 && agln0->suffix) {
+            dpx_warning("agl: fix %s --> %s.%s",
+                 name, agln0->name, agln0->suffix);
+          }
+          agln1 = agl_lookup_list(agln0->name);
+          agl_release_name(agln0);
+        }
       }
       if (agln1) {
-	for (i = 0; i < agln1->n_components; i++) {
-	  len += UC_UTF16BE_encode_char(agln1->unicodes[i], dstpp, limptr);
-	}
+        for (i = 0; i < agln1->n_components; i++) {
+          len += UC_UTF16BE_encode_char(agln1->unicodes[i], dstpp, limptr);
+        }
       } else {
-	if (verbose) {
-	  dpx_warning("No Unicode mapping for glyph name \"%s\" found.", name);
-	}
-	count++;
+        if (verbose) {
+          dpx_warning("No Unicode mapping for glyph name \"%s\" found.", name);
+        }
+        count++;
       }
     }
     free(name);
@@ -732,7 +732,7 @@ agl_sput_UTF16BE (const char *glyphstr,
 
 int
 agl_get_unicodes (const char *glyphstr,
-		  int32_t *unicodes, int max_unicodes)
+                  int32_t *unicodes, int max_unicodes)
 {
   int   count = 0;
   const char *p, *endptr;
@@ -769,50 +769,50 @@ agl_get_unicodes (const char *glyphstr,
     if (agl_name_is_unicode(name)) {
       p  = name;
       if (p[1] != 'n') { /* uXXXXXXXX */
-	if (count >= max_unicodes) {
-	  free(name);
-	  return -1;
-	}
-	p++;
-	unicodes[count++] = xtol(p, strlen(p));
+        if (count >= max_unicodes) {
+          free(name);
+          return -1;
+        }
+        p++;
+        unicodes[count++] = xtol(p, strlen(p));
       } else {
-	p += 3;
-	while (*p != '\0') {
-	  if (count >= max_unicodes) {
-	    free(name);
-	    return -1;
-	  }
-	  unicodes[count++] = xtol(p, 4);
-	  p += 4;
-	}
+        p += 3;
+        while (*p != '\0') {
+          if (count >= max_unicodes) {
+            free(name);
+            return -1;
+          }
+          unicodes[count++] = xtol(p, 4);
+          p += 4;
+        }
       }
     } else {
       agln1 = agl_lookup_list(name);
       if (!agln1 || (agln1->n_components == 1 &&
-		     IS_PUA(agln1->unicodes[0]))) {
-	agln0 = agl_normalized_name(name);
-	if (agln0) {
-	  if (verbose > 1 && agln0->suffix) {
-	    dpx_warning("agl: fix %s --> %s.%s",
-		 name, agln0->name, agln0->suffix);
-	  }
-	  agln1 = agl_lookup_list(agln0->name);
-	  agl_release_name(agln0);
-	}
+                     IS_PUA(agln1->unicodes[0]))) {
+        agln0 = agl_normalized_name(name);
+        if (agln0) {
+          if (verbose > 1 && agln0->suffix) {
+            dpx_warning("agl: fix %s --> %s.%s",
+                 name, agln0->name, agln0->suffix);
+          }
+          agln1 = agl_lookup_list(agln0->name);
+          agl_release_name(agln0);
+        }
       }
       if (agln1) {
-	if (count + agln1->n_components > max_unicodes) {
-	  free(name);
-	  return -1;
-	}
-	for (i = 0; i < agln1->n_components; i++) {
-	  unicodes[count++] = agln1->unicodes[i];
-	}
+        if (count + agln1->n_components > max_unicodes) {
+          free(name);
+          return -1;
+        }
+        for (i = 0; i < agln1->n_components; i++) {
+          unicodes[count++] = agln1->unicodes[i];
+        }
       } else {
-	if (verbose > 1)
-	  dpx_warning("No Unicode mapping for glyph name \"%s\" found.", name);
-	free(name);
-	return -1;
+        if (verbose > 1)
+          dpx_warning("No Unicode mapping for glyph name \"%s\" found.", name);
+        free(name);
+        return -1;
       }
     }
     free(name);

--- a/tectonic/dpx-agl.c
+++ b/tectonic/dpx-agl.c
@@ -127,7 +127,7 @@ agl_chop_suffix (const char *glyphname, char **suffix)
 static const char * const modifiers[] = {
   "acute", "breve", "caron", "cedilla", "circumflex",
   "dieresis", "dotaccent", "grave", "hungarumlaut",
-  "macron", "ogonek", "ring", "tilde", "commaaccent", 
+  "macron", "ogonek", "ring", "tilde", "commaaccent",
   "slash",
 
   /* The following entries are not accent nor something
@@ -264,11 +264,11 @@ const char *
 agl_suffix_to_otltag (const char *suffix)
 {
   int i, j;
-  
+
   for (i = 0; var_list[i].key; i++) {
     for (j = 0; var_list[i].suffixes[j]; j++) {
       if (!strcmp(suffix, var_list[i].suffixes[j]))
-        return var_list[i].otl_tag; 
+        return var_list[i].otl_tag;
     }
     if (!strcmp(suffix, var_list[i].key))
       return var_list[i].otl_tag;
@@ -276,7 +276,7 @@ agl_suffix_to_otltag (const char *suffix)
 	!strcmp(suffix, var_list[i].otl_tag))
       return var_list[i].otl_tag;
   }
-  
+
   return NULL;
 }
 
@@ -354,7 +354,7 @@ agl_normalized_name (char *glyphname)
     memcpy(agln->name, glyphname, n);
     agln->name[n] = '\0';
   }
-  
+
   return agln;
 }
 

--- a/tectonic/dpx-agl.h
+++ b/tectonic/dpx-agl.h
@@ -41,11 +41,11 @@ typedef struct agl_name agl_name;
 extern char *agl_chop_suffix  (const char *glyphname, char **suffix);
 
 extern int32_t agl_sput_UTF16BE (const char *name,
-			       unsigned char **dstpp,
-			       unsigned char *limptr, int *num_fails);
+                               unsigned char **dstpp,
+                               unsigned char *limptr, int *num_fails);
 
 extern int   agl_get_unicodes (const char *glyphstr,
-			       int32_t *unicodes, int max_uncodes);
+                               int32_t *unicodes, int max_uncodes);
 
 extern int      agl_name_is_unicode      (const char *glyphname);
 extern int32_t  agl_name_convert_unicode (const char *glyphname);

--- a/tectonic/dpx-bmpimage.h
+++ b/tectonic/dpx-bmpimage.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
 
-	
+
 #ifndef _BMPIMAGE_H_
 #define _BMPIMAGE_H_
 

--- a/tectonic/dpx-cff_dict.c
+++ b/tectonic/dpx-cff_dict.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cff_dict.c
+++ b/tectonic/dpx-cff_dict.c
@@ -72,8 +72,8 @@ void cff_release_dict (cff_dict *dict)
     if (dict->entries) {
       int i;
       for (i=0;i<dict->count;i++) {
-	if ((dict->entries)[i].values)
-	  free((dict->entries)[i].values);
+        if ((dict->entries)[i].values)
+          free((dict->entries)[i].values);
       }
       free(dict->entries);
     }
@@ -245,7 +245,7 @@ static double get_real(card8 **data, card8 *endptr, int *status)
     } else if (nibble == 0x0b || nibble == 0x0c) { /* E, E- */
       work_buffer[len++] = 'e';
       if (nibble == 0x0c)
-	work_buffer[len++] = '-';
+        work_buffer[len++] = '-';
     } else if (nibble == 0x0e) { /* `-' */
       work_buffer[len++] = '-';
     } else if (nibble == 0x0d) { /* skip */
@@ -253,7 +253,7 @@ static double get_real(card8 **data, card8 *endptr, int *status)
     } else if (nibble == 0x0f) { /* end */
       work_buffer[len++] = '\0';
       if (((pos % 2) == 0) && (**data != 0xff)) {
-	fail = 1;
+        fail = 1;
       }
       break;
     } else { /* invalid */
@@ -278,7 +278,7 @@ static double get_real(card8 **data, card8 *endptr, int *status)
 
 /* operators */
 static void add_dict (cff_dict *dict,
-		      card8 **data, card8 *endptr, int *status)
+                      card8 **data, card8 *endptr, int *status)
 {
   int id, argtype;
 
@@ -286,7 +286,7 @@ static void add_dict (cff_dict *dict,
   if (id == 0x0c) {
     *data += 1;
     if (*data >= endptr ||
-	(id = **data + CFF_LAST_DICT_OP1) >= CFF_LAST_DICT_OP) {
+        (id = **data + CFF_LAST_DICT_OP1) >= CFF_LAST_DICT_OP) {
       *status = CFF_ERROR_PARSE_ERROR;
       return;
     }
@@ -361,19 +361,19 @@ cff_dict *cff_dict_unpack (card8 *data, card8 *endptr)
       add_dict(dict, &data, endptr, &status);
     } else if (*data == 30) { /* real - First byte of a sequence (variable) */
       if (stack_top < CFF_DICT_STACK_LIMIT) {
-	arg_stack[stack_top] = get_real(&data, endptr, &status);
-	stack_top++;
+        arg_stack[stack_top] = get_real(&data, endptr, &status);
+        stack_top++;
       } else {
-	status = CFF_ERROR_STACK_OVERFLOW;
+        status = CFF_ERROR_STACK_OVERFLOW;
       }
     } else if (*data == 255 || (*data >= 22 && *data <= 27)) { /* reserved */
       data++;
     } else { /* everything else are integer */
       if (stack_top < CFF_DICT_STACK_LIMIT) {
-	arg_stack[stack_top] = get_integer(&data, endptr, &status);
-	stack_top++;
+        arg_stack[stack_top] = get_integer(&data, endptr, &status);
+        stack_top++;
       } else {
-	status = CFF_ERROR_STACK_OVERFLOW;
+        status = CFF_ERROR_STACK_OVERFLOW;
       }
     }
   }
@@ -496,8 +496,8 @@ static int pack_real (card8 *dest, int destlen, double value)
 }
 
 static int cff_dict_put_number (double value,
-				 card8 *dest, int destlen,
-				 int type)
+                                 card8 *dest, int destlen,
+                                 int type)
 {
   int    len = 0;
   double nearint;
@@ -517,7 +517,7 @@ static int cff_dict_put_number (double value,
     dest[4] = lvalue         & 0xff;
     len = 5;
   } else if (value > CFF_INT_MAX || value < CFF_INT_MIN ||
-	     (fabs(value - nearint) > 1.0e-5)) { /* real */
+             (fabs(value - nearint) > 1.0e-5)) { /* real */
     len = pack_real(dest, destlen, value);
   } else { /* integer */
     len = pack_integer(dest, destlen, (int) nearint);
@@ -528,7 +528,7 @@ static int cff_dict_put_number (double value,
 
 static int
 put_dict_entry (cff_dict_entry *de,
-		card8 *dest, int destlen)
+                card8 *dest, int destlen)
 {
   int  len = 0;
   int  i, type, id;
@@ -536,23 +536,23 @@ put_dict_entry (cff_dict_entry *de,
   if (de->count > 0) {
     id = de->id;
     if (dict_operator[id].argtype == CFF_TYPE_OFFSET ||
-	dict_operator[id].argtype == CFF_TYPE_SZOFF) {
+        dict_operator[id].argtype == CFF_TYPE_SZOFF) {
       type = CFF_TYPE_OFFSET;
     } else {
       type = CFF_TYPE_NUMBER;
     }
     for (i = 0; i < de->count; i++) {
       len += cff_dict_put_number(de->values[i],
-				 dest+len,
-				 destlen-len, type);
+                                 dest+len,
+                                 destlen-len, type);
     }
     if (id >= 0 && id < CFF_LAST_DICT_OP1) {
       if (len + 1 > destlen)
-	_tt_abort("%s: Buffer overflow.", CFF_DEBUG_STR);
+        _tt_abort("%s: Buffer overflow.", CFF_DEBUG_STR);
       dest[len++] = id;
     } else if (id >= 0 && id < CFF_LAST_DICT_OP) {
       if (len + 2 > destlen)
-	_tt_abort("in cff_dict_pack(): Buffer overflow");
+        _tt_abort("in cff_dict_pack(): Buffer overflow");
       dest[len++] = 12;
       dest[len++] = id - CFF_LAST_DICT_OP1;
     } else {
@@ -589,7 +589,7 @@ void cff_dict_add (cff_dict *dict, const char *key, int count)
 
   for (id=0;id<CFF_LAST_DICT_OP;id++) {
     if (key && dict_operator[id].opname &&
-	strcmp(dict_operator[id].opname, key) == 0)
+        strcmp(dict_operator[id].opname, key) == 0)
       break;
   }
 
@@ -599,7 +599,7 @@ void cff_dict_add (cff_dict *dict, const char *key, int count)
   for (i=0;i<dict->count;i++) {
     if ((dict->entries)[i].id == id) {
       if ((dict->entries)[i].count != count)
-	_tt_abort("%s: Inconsistent DICT argument number.", CFF_DEBUG_STR);
+        _tt_abort("%s: Inconsistent DICT argument number.", CFF_DEBUG_STR);
       return;
     }
   }
@@ -615,7 +615,7 @@ void cff_dict_add (cff_dict *dict, const char *key, int count)
   if (count > 0) {
     (dict->entries)[dict->count].values = NEW(count, double);
     memset((dict->entries)[dict->count].values,
-	   0, sizeof(double)*count);
+           0, sizeof(double)*count);
   } else {
     (dict->entries)[dict->count].values = NULL;
   }
@@ -631,7 +631,7 @@ void cff_dict_remove (cff_dict *dict, const char *key)
     if (key && strcmp(key, (dict->entries)[i].key) == 0) {
       (dict->entries)[i].count = 0;
       if ((dict->entries)[i].values)
-	free((dict->entries)[i].values);
+        free((dict->entries)[i].values);
       (dict->entries)[i].values = NULL;
     }
   }
@@ -643,7 +643,7 @@ int cff_dict_known (cff_dict *dict, const char *key)
 
   for (i = 0; i < dict->count; i++) {
     if (key && strcmp(key, (dict->entries)[i].key) == 0
-	&& (dict->entries)[i].count > 0)
+        && (dict->entries)[i].count > 0)
       return 1;
   }
 
@@ -660,9 +660,9 @@ double cff_dict_get (cff_dict *dict, const char *key, int idx)
   for (i = 0; i < dict->count; i++) {
     if (strcmp(key, (dict->entries)[i].key) == 0) {
       if ((dict->entries)[i].count > idx)
-	value = (dict->entries)[i].values[idx];
+        value = (dict->entries)[i].values[idx];
       else
-	_tt_abort("%s: Invalid index number.", CFF_DEBUG_STR);
+        _tt_abort("%s: Invalid index number.", CFF_DEBUG_STR);
       break;
     }
   }
@@ -682,9 +682,9 @@ void cff_dict_set (cff_dict *dict, const char *key, int idx, double value)
   for (i = 0 ; i < dict->count; i++) {
     if (strcmp(key, (dict->entries)[i].key) == 0) {
       if ((dict->entries)[i].count > idx)
-	(dict->entries)[i].values[idx] = value;
+        (dict->entries)[i].values[idx] = value;
       else
-	_tt_abort("%s: Invalid index number.", CFF_DEBUG_STR);
+        _tt_abort("%s: Invalid index number.", CFF_DEBUG_STR);
       break;
     }
   }
@@ -704,16 +704,16 @@ void cff_dict_update (cff_dict *dict, cff_font *cff)
 
       id = (dict->entries)[i].id;
       if (dict_operator[id].argtype == CFF_TYPE_SID) {
-	str = cff_get_string(cff, (dict->entries)[i].values[0]);
-	(dict->entries)[i].values[0] = cff_add_string(cff, str, 1);
-	free(str);
+        str = cff_get_string(cff, (dict->entries)[i].values[0]);
+        (dict->entries)[i].values[0] = cff_add_string(cff, str, 1);
+        free(str);
       } else if (dict_operator[id].argtype == CFF_TYPE_ROS) {
-	str = cff_get_string(cff, (dict->entries)[i].values[0]);
-	(dict->entries)[i].values[0] = cff_add_string(cff, str, 1);
-	free(str);
-	str = cff_get_string(cff, (dict->entries)[i].values[1]);
-	(dict->entries)[i].values[1] = cff_add_string(cff, str, 1);
-	free(str);
+        str = cff_get_string(cff, (dict->entries)[i].values[0]);
+        (dict->entries)[i].values[0] = cff_add_string(cff, str, 1);
+        free(str);
+        str = cff_get_string(cff, (dict->entries)[i].values[1]);
+        (dict->entries)[i].values[1] = cff_add_string(cff, str, 1);
+        free(str);
       }
     }
   }

--- a/tectonic/dpx-cff_dict.h
+++ b/tectonic/dpx-cff_dict.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cff_limits.h
+++ b/tectonic/dpx-cff_limits.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cff_stdstr.h
+++ b/tectonic/dpx-cff_stdstr.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cff_types.h
+++ b/tectonic/dpx-cff_types.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cff_types.h
+++ b/tectonic/dpx-cff_types.h
@@ -49,7 +49,7 @@
 typedef unsigned char  card8;     /* 1-byte unsigned number */
 typedef unsigned short card16;    /* 2-byte unsigned number */
 typedef unsigned char  c_offsize; /* 1-byte unsigned number specifies the size
-				     of an Offset field or fields, range 1-4 */
+                                     of an Offset field or fields, range 1-4 */
 typedef uint32_t       l_offset;  /* 1, 2, 3, or 4-byte offset */
 typedef unsigned short s_SID;       /* 2-byte string identifier  */
 

--- a/tectonic/dpx-cid.c
+++ b/tectonic/dpx-cid.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -60,8 +60,8 @@ static struct {
    */
   int   supplement[16];
 } CIDFont_stdcc_def[] = {
-  {"Adobe", "UCS",      {-1, -1, 0, 0, 0, 0, 0, 0}}, 
-  {"Adobe", "GB1",      {-1, -1, 0, 2, 4, 4, 4, 4}}, 
+  {"Adobe", "UCS",      {-1, -1, 0, 0, 0, 0, 0, 0}},
+  {"Adobe", "GB1",      {-1, -1, 0, 2, 4, 4, 4, 4}},
   {"Adobe", "CNS1",     {-1, -1, 0, 0, 3, 4, 4, 4}},
   {"Adobe", "Japan1",   {-1, -1, 2, 2, 4, 5, 6, 6}},
   {"Adobe", "Korea1",   {-1, -1, 1, 1, 2, 2, 2, 2}},

--- a/tectonic/dpx-cid.h
+++ b/tectonic/dpx-cid.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cidtype0.c
+++ b/tectonic/dpx-cidtype0.c
@@ -539,7 +539,7 @@ CIDFontInfo_close (CIDType0Info *info)
         sfnt_close(info->sfont);
 
     if (info->handle)
-	ttstub_input_close(info->handle);
+        ttstub_input_close(info->handle);
 
     CIDFontInfo_init(info);
 }
@@ -850,15 +850,15 @@ CIDFont_type0_open (CIDFont *font, const char *name,
     }
 
     if (expect_type1_font)
-	handle = dpx_open_type1_file (name);
+        handle = dpx_open_type1_file (name);
     else
-	handle = dpx_open_opentype_file (name);
+        handle = dpx_open_opentype_file (name);
 
     if (!expect_type1_font) {
         if (!handle) {
             handle = dpx_open_truetype_file(name);
             if (!handle)
-		return -1;
+                return -1;
         }
 
         sfont = sfnt_open(handle);
@@ -906,7 +906,7 @@ CIDFont_type0_open (CIDFont *font, const char *name,
             ttstub_input_close(handle);
             return -1;
         }
-	ttstub_input_close(handle);
+        ttstub_input_close(handle);
     }
 
     csi = NEW(1, CIDSysInfo);
@@ -1039,7 +1039,7 @@ CIDFont_type0_open (CIDFont *font, const char *name,
     if (!expect_type1_font) {
         sfnt_close(sfont);
         if (handle)
-	    ttstub_input_close(handle);
+            ttstub_input_close(handle);
     }
 
     return 0;

--- a/tectonic/dpx-cidtype0.h
+++ b/tectonic/dpx-cidtype0.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cidtype2.c
+++ b/tectonic/dpx-cidtype2.c
@@ -542,7 +542,7 @@ CIDFont_type2_dofont (CIDFont *font)
     if (!handle) {
         handle = dpx_open_dfont_file(font->ident);
         if (!handle)
-	    _tt_abort("Could not open TTF/dfont file: %s", font->ident);
+            _tt_abort("Could not open TTF/dfont file: %s", font->ident);
         sfont = dfont_open(handle, font->options->index);
     } else {
         sfont = sfnt_open(handle);
@@ -956,7 +956,7 @@ CIDFont_type2_open (CIDFont *font, const char *name,
     }
 
     if (!sfont) {
-	ttstub_input_close(handle);
+        ttstub_input_close(handle);
         return -1;
     }
 

--- a/tectonic/dpx-cidtype2.h
+++ b/tectonic/dpx-cidtype2.h
@@ -28,7 +28,7 @@ extern void CIDFont_type2_set_verbose (void);
 extern void CIDFont_type2_set_flags   (int flags);
 
 extern int  CIDFont_type2_open    (CIDFont *font, const char *name,
-				   CIDSysInfo *cmap_csi, cid_opt *opt);
+                                   CIDSysInfo *cmap_csi, cid_opt *opt);
 extern void CIDFont_type2_dofont  (CIDFont *font);
 
 #endif /* _CIDTYPE2_H_ */

--- a/tectonic/dpx-cidtype2.h
+++ b/tectonic/dpx-cidtype2.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cmap.h
+++ b/tectonic/dpx-cmap.h
@@ -79,32 +79,32 @@ extern void   CMap_set_CIDSysInfo (CMap *cmap, const CIDSysInfo *csi);
 
 /* charName not supported */
 extern int   CMap_add_bfchar  (CMap *cmap,
-			       const unsigned char *src, int srcdim,
-			       const unsigned char *dest, int destdim);
+                               const unsigned char *src, int srcdim,
+                               const unsigned char *dest, int destdim);
 extern int   CMap_add_cidchar (CMap *cmap,
-			       const unsigned char *src, int srcdim, CID dest);
+                               const unsigned char *src, int srcdim, CID dest);
 extern int   CMap_add_bfrange (CMap *cmap,
-			       const unsigned char *srclo, const unsigned char *srchi, int srcdim,
-			       const unsigned char *dest, int destdim);
+                               const unsigned char *srclo, const unsigned char *srchi, int srcdim,
+                               const unsigned char *dest, int destdim);
 extern int   CMap_add_cidrange(CMap *cmap,
-			       const unsigned char *srclo, const unsigned char *hi, int srcdim,
-			       CID base);
+                               const unsigned char *srclo, const unsigned char *hi, int srcdim,
+                               CID base);
 
 extern int CMap_add_notdefchar  (CMap *cmap, const unsigned char *src, int srcdim, CID dst);
 extern int CMap_add_notdefrange (CMap *cmap,
-				 const unsigned char *srclo, const unsigned char *srchi, int srcdim,
-				 CID dst);
+                                 const unsigned char *srclo, const unsigned char *srchi, int srcdim,
+                                 CID dst);
 
 extern int  CMap_add_codespacerange (CMap *cmap,
-				     const unsigned char *codelo, const unsigned char *codehi, int dim);
+                                     const unsigned char *codelo, const unsigned char *codehi, int dim);
 
 extern void CMap_decode_char (CMap *cmap,
-			      const unsigned char **inbuf, int *inbytesleft,
-			      unsigned char **outbuf, int *outbytesleft);
+                              const unsigned char **inbuf, int *inbytesleft,
+                              unsigned char **outbuf, int *outbytesleft);
 
 extern int  CMap_decode (CMap *cmap,
-			 const unsigned char **inbuf,  int *inbytesleft,
-			 unsigned char **outbuf, int *outbytesleft);
+                         const unsigned char **inbuf,  int *inbytesleft,
+                         unsigned char **outbuf, int *outbytesleft);
 
 extern int  CMap_reverse_decode(CMap *cmap, CID cid);
 

--- a/tectonic/dpx-cmap_p.h
+++ b/tectonic/dpx-cmap_p.h
@@ -69,9 +69,9 @@ typedef struct mapData {
 struct CMap {
   char  *name;
   int    type;     /* CMapType: 1 for usual CMaps,
-		    *           2 for ToUnicode CMaps,
-		    *           0 for IDENTITY is also defined for convenience.
-		    */
+                    *           2 for ToUnicode CMaps,
+                    *           0 for IDENTITY is also defined for convenience.
+                    */
   int    wmode;    /* WMode: 0 for Horizontal, 1 for Vertical. */
   CIDSysInfo *CSI; /* CIDSystemInfo */
 

--- a/tectonic/dpx-cmap_write.c
+++ b/tectonic/dpx-cmap_write.c
@@ -55,8 +55,8 @@ struct sbuf {
 };
 
 static int write_map (mapDef *mtab, int count,
-		      unsigned char *codestr, int depth,
-		      struct sbuf *wbuf, pdf_obj *stream);
+                      unsigned char *codestr, int depth,
+                      struct sbuf *wbuf, pdf_obj *stream);
 #if 0
 /* Not completed yet */
 
@@ -66,10 +66,10 @@ static int write_map (mapDef *mtab, int count,
  * cid-to-code mapping.
  */
 static int add_inverse_map (CMap *icmap, mapDef *mtab,
-			    unsigned char *codestr, int depth,
-			    unsigned char *used_slot);
+                            unsigned char *codestr, int depth,
+                            unsigned char *used_slot);
 static int add_map         (CMap *cmap,  mapDef *mtab,
-			    unsigned char *codestr, int depth);
+                            unsigned char *codestr, int depth);
 static CMap *invert_cmap  (CMap *cmap, unsigned char *used_slot);
 static CMap *flatten_cmap (CMap *cmap);
 #endif /* 0 */
@@ -83,14 +83,14 @@ block_count (mapDef *mtab, int c)
   c += 1;
   for (; c < 256; c++) {
     if (LOOKUP_CONTINUE(mtab[c].flag) ||
-	!MAP_DEFINED(mtab[c].flag)     ||
-	(MAP_TYPE(mtab[c].flag) != MAP_IS_CID &&
-	 MAP_TYPE(mtab[c].flag) != MAP_IS_CODE) ||
-	mtab[c-1].len != mtab[c].len)
+        !MAP_DEFINED(mtab[c].flag)     ||
+        (MAP_TYPE(mtab[c].flag) != MAP_IS_CID &&
+         MAP_TYPE(mtab[c].flag) != MAP_IS_CODE) ||
+        mtab[c-1].len != mtab[c].len)
       break;
     else if (!memcmp(mtab[c-1].code, mtab[c].code, n) &&
-	     mtab[c-1].code[n] < 255 &&
-	     mtab[c-1].code[n] + 1 == mtab[c].code[n])
+             mtab[c-1].code[n] < 255 &&
+             mtab[c-1].code[n] + 1 == mtab[c].code[n])
       count++;
     else {
       break;
@@ -116,8 +116,8 @@ sputx (unsigned char c, char **s, char *end)
 
 static int
 write_map (mapDef *mtab, int count,
-	   unsigned char *codestr, int depth,
-	   struct sbuf *wbuf, pdf_obj *stream)
+           unsigned char *codestr, int depth,
+           struct sbuf *wbuf, pdf_obj *stream)
 {
   int     c, i, block_length;
   mapDef *mtab1;
@@ -133,56 +133,56 @@ write_map (mapDef *mtab, int count,
     if (LOOKUP_CONTINUE(mtab[c].flag)) {
       mtab1 = mtab[c].next;
       count = write_map(mtab1, count,
-			codestr, depth + 1, wbuf, stream);
+                        codestr, depth + 1, wbuf, stream);
     } else {
       if (MAP_DEFINED(mtab[c].flag)) {
-	switch (MAP_TYPE(mtab[c].flag)) {
-	case MAP_IS_CID: case MAP_IS_CODE:
-	  block_length = block_count(mtab, c);
-	  if (block_length >= BLOCK_LEN_MIN) {
-	    blocks[num_blocks].start = c;
-	    blocks[num_blocks].count = block_length;
-	    num_blocks++;
-	    c += block_length;
-	  } else {
-	    *(wbuf->curptr)++ = '<';
-	    for (i = 0; i <= depth; i++)
-	      sputx(codestr[i], &(wbuf->curptr), wbuf->limptr);
-	    *(wbuf->curptr)++ = '>';
-	    *(wbuf->curptr)++ = ' ';
-	    *(wbuf->curptr)++ = '<';
-	    for (i = 0; i < mtab[c].len; i++)
-	      sputx(mtab[c].code[i], &(wbuf->curptr), wbuf->limptr);
-	    *(wbuf->curptr)++ = '>';
-	    *(wbuf->curptr)++ = '\n';
-	    count++;
-	  }
-	  break;
-	case MAP_IS_NAME:
-	  _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
-	  break;
-	case MAP_IS_NOTDEF:
-	  break;
-	default:
-	  _tt_abort("%s: Unknown mapping type: %d",
-		CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
-	}
+        switch (MAP_TYPE(mtab[c].flag)) {
+        case MAP_IS_CID: case MAP_IS_CODE:
+          block_length = block_count(mtab, c);
+          if (block_length >= BLOCK_LEN_MIN) {
+            blocks[num_blocks].start = c;
+            blocks[num_blocks].count = block_length;
+            num_blocks++;
+            c += block_length;
+          } else {
+            *(wbuf->curptr)++ = '<';
+            for (i = 0; i <= depth; i++)
+              sputx(codestr[i], &(wbuf->curptr), wbuf->limptr);
+            *(wbuf->curptr)++ = '>';
+            *(wbuf->curptr)++ = ' ';
+            *(wbuf->curptr)++ = '<';
+            for (i = 0; i < mtab[c].len; i++)
+              sputx(mtab[c].code[i], &(wbuf->curptr), wbuf->limptr);
+            *(wbuf->curptr)++ = '>';
+            *(wbuf->curptr)++ = '\n';
+            count++;
+          }
+          break;
+        case MAP_IS_NAME:
+          _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
+          break;
+        case MAP_IS_NOTDEF:
+          break;
+        default:
+          _tt_abort("%s: Unknown mapping type: %d",
+                CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
+        }
       }
     }
 
     /* Flush if necessary */
     if (count >= 100 ||
-	wbuf->curptr >= wbuf->limptr ) {
+        wbuf->curptr >= wbuf->limptr ) {
       char fmt_buf[32];
       if (count > 100)
-	_tt_abort("Unexpected error....: %d", count);
+        _tt_abort("Unexpected error....: %d", count);
       sprintf(fmt_buf, "%d beginbfchar\n", count);
       pdf_add_stream(stream, fmt_buf,  strlen(fmt_buf));
       pdf_add_stream(stream,
-		     wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
+                     wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
       wbuf->curptr = wbuf->buf;
       pdf_add_stream(stream,
-		     "endbfchar\n", strlen("endbfchar\n"));
+                     "endbfchar\n", strlen("endbfchar\n"));
       count = 0;
     }
   }
@@ -194,10 +194,10 @@ write_map (mapDef *mtab, int count,
       sprintf(fmt_buf, "%d beginbfchar\n", count);
       pdf_add_stream(stream, fmt_buf,  strlen(fmt_buf));
       pdf_add_stream(stream,
-		     wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
+                     wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
       wbuf->curptr = wbuf->buf;
       pdf_add_stream(stream,
-		     "endbfchar\n", strlen("endbfchar\n"));
+                     "endbfchar\n", strlen("endbfchar\n"));
       count = 0;
     }
     sprintf(fmt_buf, "%d beginbfrange\n", num_blocks);
@@ -208,27 +208,27 @@ write_map (mapDef *mtab, int count,
       c = blocks[i].start;
       *(wbuf->curptr)++ = '<';
       for (j = 0; j < depth; j++)
-	sputx(codestr[j], &(wbuf->curptr), wbuf->limptr);
+        sputx(codestr[j], &(wbuf->curptr), wbuf->limptr);
       sputx((unsigned char)c, &(wbuf->curptr), wbuf->limptr);
       *(wbuf->curptr)++ = '>';
       *(wbuf->curptr)++ = ' ';
       *(wbuf->curptr)++ = '<';
       for (j = 0; j < depth; j++)
-	sputx(codestr[j], &(wbuf->curptr), wbuf->limptr);
+        sputx(codestr[j], &(wbuf->curptr), wbuf->limptr);
       sputx((unsigned char)(c + blocks[i].count), &(wbuf->curptr), wbuf->limptr);
       *(wbuf->curptr)++ = '>';
       *(wbuf->curptr)++ = ' ';
       *(wbuf->curptr)++ = '<';
       for (j = 0; j < mtab[c].len; j++)
-	sputx(mtab[c].code[j], &(wbuf->curptr), wbuf->limptr);
+        sputx(mtab[c].code[j], &(wbuf->curptr), wbuf->limptr);
       *(wbuf->curptr)++ = '>';
       *(wbuf->curptr)++ = '\n';
     }
     pdf_add_stream(stream,
-		   wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
+                   wbuf->buf, (int) (wbuf->curptr - wbuf->buf));
     wbuf->curptr = wbuf->buf;
     pdf_add_stream(stream,
-		   "endbfrange\n", strlen("endbfrange\n"));
+                   "endbfrange\n", strlen("endbfrange\n"));
   }
 
   return count;
@@ -280,27 +280,27 @@ CMap_create_stream (CMap *cmap)
 
     csi_dict = pdf_new_dict();
     pdf_add_dict(csi_dict,
-		 pdf_new_name("Registry"),
-		 pdf_new_string(csi->registry, strlen(csi->registry)));
+                 pdf_new_name("Registry"),
+                 pdf_new_string(csi->registry, strlen(csi->registry)));
     pdf_add_dict(csi_dict,
-		 pdf_new_name("Ordering"),
-		 pdf_new_string(csi->ordering, strlen(csi->ordering)));
+                 pdf_new_name("Ordering"),
+                 pdf_new_string(csi->ordering, strlen(csi->ordering)));
     pdf_add_dict(csi_dict,
-		 pdf_new_name("Supplement"),
-		 pdf_new_number(csi->supplement));
+                 pdf_new_name("Supplement"),
+                 pdf_new_number(csi->supplement));
 
     pdf_add_dict(stream_dict,
-		 pdf_new_name("Type"),
-		 pdf_new_name("CMap"));
+                 pdf_new_name("Type"),
+                 pdf_new_name("CMap"));
     pdf_add_dict(stream_dict,
-		 pdf_new_name("CMapName"),
-		 pdf_new_name(cmap->name));
+                 pdf_new_name("CMapName"),
+                 pdf_new_name(cmap->name));
     pdf_add_dict(stream_dict,
-		 pdf_new_name("CIDSystemInfo"), csi_dict);
+                 pdf_new_name("CIDSystemInfo"), csi_dict);
     if (cmap->wmode != 0)
       pdf_add_dict(stream_dict,
-		   pdf_new_name("WMode"),
-		   pdf_new_number(cmap->wmode));
+                   pdf_new_name("WMode"),
+                   pdf_new_number(cmap->wmode));
   }
 
   /* TODO:
@@ -310,13 +310,13 @@ CMap_create_stream (CMap *cmap)
     _tt_abort("UseCMap found (not supported yet)...");
     if (CMap_is_Identity(cmap->useCMap)) { /* not sure */
       if (CMap_get_wmode(cmap) == 1) {
-	pdf_add_dict(stream_dict,
-		     pdf_new_name("UseCMap"),
-		     pdf_new_name("Identity-V"));
+        pdf_add_dict(stream_dict,
+                     pdf_new_name("UseCMap"),
+                     pdf_new_name("Identity-V"));
       } else {
-    	pdf_add_dict(stream_dict,
-		     pdf_new_name("UseCMap"),
-		     pdf_new_name("Identity-H"));
+        pdf_add_dict(stream_dict,
+                     pdf_new_name("UseCMap"),
+                     pdf_new_name("Identity-H"));
       }
     } else {
       int      res_id;
@@ -324,19 +324,19 @@ CMap_create_stream (CMap *cmap)
 
       res_id = pdf_findresource("CMap", CMap_get_name(cmap->useCMap));
       if (res_id >= 0) {
-	ucmap_ref = pdf_get_resource_reference(res_id);
+        ucmap_ref = pdf_get_resource_reference(res_id);
       } else {
-	pdf_obj *ucmap_obj;
+        pdf_obj *ucmap_obj;
 
-	ucmap_obj = CMap_create_stream(cmap->useCMap);
-	if (!ucmap_obj) {
-	  _tt_abort("Uh ah. I cannot continue...");
-	}
+        ucmap_obj = CMap_create_stream(cmap->useCMap);
+        if (!ucmap_obj) {
+          _tt_abort("Uh ah. I cannot continue...");
+        }
 
-	res_id = pdf_defineresource("CMap",
-				    CMap_get_name(cmap->useCMap),
-				    ucmap_obj, PDF_RES_FLUSH_IMMEDIATE);
-	ucmap_ref = pdf_get_resource_reference(res_id);
+        res_id = pdf_defineresource("CMap",
+                                    CMap_get_name(cmap->useCMap),
+                                    ucmap_obj, PDF_RES_FLUSH_IMMEDIATE);
+        ucmap_ref = pdf_get_resource_reference(res_id);
       }
       pdf_add_dict(stream_dict, pdf_new_name("UseCMap"), ucmap_ref);
     }
@@ -366,14 +366,14 @@ CMap_create_stream (CMap *cmap)
   /Supplement %d\n\
 >> def\n"
   wbuf.curptr += sprintf(wbuf.curptr, CMAP_CSI_FMT,
-			 csi->registry, csi->ordering, csi->supplement);
+                         csi->registry, csi->ordering, csi->supplement);
   pdf_add_stream(stream, wbuf.buf, (int)(wbuf.curptr - wbuf.buf));
   wbuf.curptr = wbuf.buf;
 
   /* codespacerange */
   ranges = cmap->codespace.ranges;
   wbuf.curptr += sprintf(wbuf.curptr,
-			 "%d begincodespacerange\n", cmap->codespace.num);
+                         "%d begincodespacerange\n", cmap->codespace.num);
   for (i = 0; i < cmap->codespace.num; i++) {
     *(wbuf.curptr)++ = '<';
     for (j = 0; j < ranges[i].dim; j++) {
@@ -391,22 +391,22 @@ CMap_create_stream (CMap *cmap)
   pdf_add_stream(stream, wbuf.buf, (int)(wbuf.curptr - wbuf.buf));
   wbuf.curptr = wbuf.buf;
   pdf_add_stream(stream,
-		 "endcodespacerange\n", strlen("endcodespacerange\n"));
+                 "endcodespacerange\n", strlen("endcodespacerange\n"));
 
   /* CMap body */
   if (cmap->mapTbl) {
     count = write_map(cmap->mapTbl,
-		      0, codestr, 0, &wbuf, stream); /* Top node */
+                      0, codestr, 0, &wbuf, stream); /* Top node */
     if (count > 0) { /* Flush */
       char fmt_buf[32];
       if (count > 100)
-	_tt_abort("Unexpected error....: %d", count);
+        _tt_abort("Unexpected error....: %d", count);
       sprintf(fmt_buf, "%d beginbfchar\n", count);
       pdf_add_stream(stream, fmt_buf,  strlen(fmt_buf));
       pdf_add_stream(stream,
-		     wbuf.buf, (int) (wbuf.curptr - wbuf.buf));
+                     wbuf.buf, (int) (wbuf.curptr - wbuf.buf));
       pdf_add_stream(stream,
-		     "endbfchar\n", strlen("endbfchar\n"));
+                     "endbfchar\n", strlen("endbfchar\n"));
       count = 0;
       wbuf.curptr = wbuf.buf;
     }
@@ -425,8 +425,8 @@ CMap_create_stream (CMap *cmap)
 
 static int
 add_inverse_map (CMap *icmap, mapDef *mtab,
-		 unsigned char *codestr, int depth,
-		 unsigned char *used_slot)
+                 unsigned char *codestr, int depth,
+                 unsigned char *used_slot)
 {
   CID     cid;
   int     c;
@@ -439,33 +439,33 @@ add_inverse_map (CMap *icmap, mapDef *mtab,
       add_inverse_map(icmap, mtab1, codestr, depth + 1, used_slot);
     } else {
       if (MAP_DEFINED(mtab[c].flag)) {
-	switch (MAP_TYPE(mtab[c].flag)) {
-	  /* We should restrict it to to-CID mapping.
-	   * However...
-	   */
-	case MAP_IS_CID: case MAP_IS_CODE:
-	  if (mtab[c].len == 2) {
-	    cid = (mtab[c].code[0] << 8)|mtab[c].code[1];
+        switch (MAP_TYPE(mtab[c].flag)) {
+          /* We should restrict it to to-CID mapping.
+           * However...
+           */
+        case MAP_IS_CID: case MAP_IS_CODE:
+          if (mtab[c].len == 2) {
+            cid = (mtab[c].code[0] << 8)|mtab[c].code[1];
 #ifndef is_used_char2
 #define is_used_char2(b,c) (((b)[(c)/8]) & (1 << (7-((c)%8))))
 #endif
-	    if (!used_slot ||
-		is_used_char2(used_slot, cid)) {
-	      CMap_add_bfchar(icmap,
-			      mtab[c].code, mtab[c].len,
-			      codestr, depth + 1);
-	    }
-	  }
-	  break;
-	case MAP_IS_NAME:
-	  _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
-	  break;
-	case MAP_IS_NOTDEF:
-	  break;
-	default:
-	  _tt_abort("%s: Unknown mapping type: %d",
-		CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
-	}
+            if (!used_slot ||
+                is_used_char2(used_slot, cid)) {
+              CMap_add_bfchar(icmap,
+                              mtab[c].code, mtab[c].len,
+                              codestr, depth + 1);
+            }
+          }
+          break;
+        case MAP_IS_NAME:
+          _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
+          break;
+        case MAP_IS_NOTDEF:
+          break;
+        default:
+          _tt_abort("%s: Unknown mapping type: %d",
+                CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
+        }
       }
     }
   }
@@ -475,7 +475,7 @@ add_inverse_map (CMap *icmap, mapDef *mtab,
 
 static int
 add_map (CMap *cmap, mapDef *mtab,
-	 unsigned char *codestr, int depth)
+         unsigned char *codestr, int depth)
 {
   int     c;
   mapDef *mtab1;
@@ -487,21 +487,21 @@ add_map (CMap *cmap, mapDef *mtab,
       add_map(cmap, mtab1, codestr, depth + 1);
     } else {
       if (MAP_DEFINED(mtab[c].flag)) {
-	switch (MAP_TYPE(mtab[c].flag)) {
-	case MAP_IS_CID: case MAP_IS_CODE:
-	  CMap_add_bfchar(cmap,
-			  codestr, depth + 1,
-			  mtab[c].code, mtab[c].len);
-	  break;
-	case MAP_IS_NAME:
-	  _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
-	  break;
-	case MAP_IS_NOTDEF:
-	  break;
-	default:
-	  _tt_abort("%s: Unknown mapping type: %d",
-		CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
-	}
+        switch (MAP_TYPE(mtab[c].flag)) {
+        case MAP_IS_CID: case MAP_IS_CODE:
+          CMap_add_bfchar(cmap,
+                          codestr, depth + 1,
+                          mtab[c].code, mtab[c].len);
+          break;
+        case MAP_IS_NAME:
+          _tt_abort("%s: Unexpected error...", CMAP_DEBUG_STR);
+          break;
+        case MAP_IS_NOTDEF:
+          break;
+        default:
+          _tt_abort("%s: Unknown mapping type: %d",
+                CMAP_DEBUG_STR, MAP_TYPE(mtab[c].flag));
+        }
       }
     }
   }
@@ -529,7 +529,7 @@ invert_cmap (CMap *cmap, unsigned char *used_slot)
     codestr = NEW(cmap->profile.maxBytesIn, unsigned char);
     memset(codestr, 0, cmap->profile.maxBytesIn);
     add_inverse_map(icmap, cmap->mapTbl,
-		    codestr, 0, used_slot); /* top node */
+                    codestr, 0, used_slot); /* top node */
     free(codestr);
   }
 
@@ -577,8 +577,8 @@ flatten_cmap (CMap *cmap)
 
 pdf_obj *
 CMap_ToCode_stream (CMap *cmap, const char *cmap_name,
-		    CIDSysInfo *csi, int cmap_type,
-		    unsigned char *used_slot, int flags)
+                    CIDSysInfo *csi, int cmap_type,
+                    unsigned char *used_slot, int flags)
 {
   pdf_obj *stream = NULL;
   CMap    *icmap;

--- a/tectonic/dpx-cmap_write.h
+++ b/tectonic/dpx-cmap_write.h
@@ -29,8 +29,8 @@ extern pdf_obj *CMap_create_stream (CMap *cmap);
 #if 0
 /* Not completed yet */
 extern pdf_obj *CMap_ToCode_stream (CMap *cmap, const char *cmap_name,
-				    CIDSysInfo *csi, int cmap_type,
-				    unsigned char *used_slot, int flags);
+                                    CIDSysInfo *csi, int cmap_type,
+                                    unsigned char *used_slot, int flags);
 #endif /* 0 */
 
 #endif /*  _CMAP_WRITE_H_ */

--- a/tectonic/dpx-cs_type2.c
+++ b/tectonic/dpx-cs_type2.c
@@ -283,8 +283,8 @@ do_operator1 (card8 **dest, card8 *limit, card8 **data, card8 *endptr)
   case cs_cntrmask:
     if (phase < 2) {
       if (phase == 0 && (stack_top % 2)) {
-	have_width = 1;
-	width = arg_stack[0];
+        have_width = 1;
+        width = arg_stack[0];
       }
       num_stems += stack_top/2;
     }
@@ -528,10 +528,10 @@ do_operator2 (card8 **dest, card8 *limit, card8 **data, card8 *endptr)
     {
       int idx = (int)arg_stack[stack_top-1];
       if (idx < 0) {
-	arg_stack[stack_top-1] = arg_stack[stack_top-2];
+        arg_stack[stack_top-1] = arg_stack[stack_top-2];
       } else {
-	NEED(stack_top, idx+2);
-	arg_stack[stack_top-1] = arg_stack[stack_top-idx-2];
+        NEED(stack_top, idx+2);
+        arg_stack[stack_top-1] = arg_stack[stack_top-idx-2];
       }
     }
     break;
@@ -543,27 +543,27 @@ do_operator2 (card8 **dest, card8 *limit, card8 **data, card8 *endptr)
       N = (int)arg_stack[--stack_top];
       NEED(stack_top, N);
       if (J > 0) {
-	J = J % N;
-	while (J-- > 0) {
-	  double save = arg_stack[stack_top-1];
-	  int i = stack_top - 1;
-	  while (i > stack_top-N) {
-	    arg_stack[i] = arg_stack[i-1];
-	    i--;
-	  }
-	  arg_stack[i] = save;
-	}
+        J = J % N;
+        while (J-- > 0) {
+          double save = arg_stack[stack_top-1];
+          int i = stack_top - 1;
+          while (i > stack_top-N) {
+            arg_stack[i] = arg_stack[i-1];
+            i--;
+          }
+          arg_stack[i] = save;
+        }
       } else {
-	J = (-J) % N;
-	while (J-- > 0) {
-	  double save = arg_stack[stack_top-N];
-	  int i = stack_top - N;
-	  while (i < stack_top-1) {
-	    arg_stack[i] = arg_stack[i+1];
-	    i++;
-	  }
-	  arg_stack[i] = save;
-	}
+        J = (-J) % N;
+        while (J-- > 0) {
+          double save = arg_stack[stack_top-N];
+          int i = stack_top - N;
+          while (i < stack_top-1) {
+            arg_stack[i] = arg_stack[i+1];
+            i++;
+          }
+          arg_stack[i] = save;
+        }
       }
     }
     break;
@@ -696,8 +696,8 @@ get_subr (card8 **subr, int *len, cff_index *subr_idx, int id)
 
 static void
 do_charstring (card8 **dest, card8 *limit,
-	       card8 **data, card8 *endptr,
-	       cff_index *gsubr_idx, cff_index *subr_idx)
+               card8 **data, card8 *endptr,
+               cff_index *gsubr_idx, cff_index *subr_idx)
 {
   card8 b0 = 0, *subr;
   int   len;
@@ -715,27 +715,27 @@ do_charstring (card8 **dest, card8 *limit,
       status = CS_SUBR_RETURN;
     } else if (b0 == cs_callgsubr) {
       if (stack_top < 1) {
-	status = CS_STACK_ERROR;
+        status = CS_STACK_ERROR;
       } else {
-	stack_top--;
-	get_subr(&subr, &len, gsubr_idx, (int) arg_stack[stack_top]);
-	if (*dest + len > limit)
-	  _tt_abort("%s: Possible buffer overflow.", CS_TYPE2_DEBUG_STR);
-	do_charstring(dest, limit, &subr, subr + len,
-		      gsubr_idx, subr_idx);
-	*data += 1;
+        stack_top--;
+        get_subr(&subr, &len, gsubr_idx, (int) arg_stack[stack_top]);
+        if (*dest + len > limit)
+          _tt_abort("%s: Possible buffer overflow.", CS_TYPE2_DEBUG_STR);
+        do_charstring(dest, limit, &subr, subr + len,
+                      gsubr_idx, subr_idx);
+        *data += 1;
       }
     } else if (b0 == cs_callsubr) {
       if (stack_top < 1) {
-	status = CS_STACK_ERROR;
+        status = CS_STACK_ERROR;
       } else {
-	stack_top--;
-	get_subr(&subr, &len, subr_idx, (int) arg_stack[stack_top]);
-	if (limit < *dest + len)
-	  _tt_abort("%s: Possible buffer overflow.", CS_TYPE2_DEBUG_STR);
-	do_charstring(dest, limit, &subr, subr + len,
-		      gsubr_idx, subr_idx);
-	*data += 1;
+        stack_top--;
+        get_subr(&subr, &len, subr_idx, (int) arg_stack[stack_top]);
+        if (limit < *dest + len)
+          _tt_abort("%s: Possible buffer overflow.", CS_TYPE2_DEBUG_STR);
+        do_charstring(dest, limit, &subr, subr + len,
+                      gsubr_idx, subr_idx);
+        *data += 1;
       }
     } else if (b0 == cs_escape) {
       do_operator2(dest, limit, data, endptr);
@@ -754,7 +754,7 @@ do_charstring (card8 **dest, card8 *limit,
     dpx_warning("%s: Garbage after endchar.", CS_TYPE2_DEBUG_STR);
   } else if (status < CS_PARSE_OK) { /* error */
     _tt_abort("%s: Parsing charstring failed: (status=%d, stack=%d)",
-	  CS_TYPE2_DEBUG_STR, status, stack_top);
+          CS_TYPE2_DEBUG_STR, status, stack_top);
   }
 
   nest--;
@@ -777,9 +777,9 @@ cs_parse_init (void)
  */
 int
 cs_copy_charstring (card8 *dst, int dstlen,
-		    card8 *src, int srclen,
-		    cff_index *gsubr, cff_index *subr,
-		    double default_width, double nominal_width, cs_ginfo *ginfo)
+                    card8 *src, int srclen,
+                    cff_index *gsubr, cff_index *subr,
+                    double default_width, double nominal_width, cs_ginfo *ginfo)
 {
   card8 *save = dst;
 

--- a/tectonic/dpx-cs_type2.c
+++ b/tectonic/dpx-cs_type2.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -170,7 +170,7 @@ static double trn_array[CS_TRANS_ARRAY_MAX];
 /*      RESERVED      19 */
 #define cs_put        20
 #define cs_get        21
-#define cs_ifelse     22 
+#define cs_ifelse     22
 #define cs_random     23
 #define cs_mul        24
 /*      RESERVED      25 */

--- a/tectonic/dpx-cs_type2.h
+++ b/tectonic/dpx-cs_type2.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-cs_type2.h
+++ b/tectonic/dpx-cs_type2.h
@@ -36,8 +36,8 @@ typedef struct {
 } cs_ginfo;
 
 extern int cs_copy_charstring (card8 *dest, int destlen,
-			       card8 *src, int srclen,
-			       cff_index *gsubr, cff_index *subr,
-			       double default_width, double nominal_width, cs_ginfo *ginfo);
+                               card8 *src, int srclen,
+                               cff_index *gsubr, cff_index *subr,
+                               double default_width, double nominal_width, cs_ginfo *ginfo);
 
 #endif /* _CS_TYPE2_H_ */

--- a/tectonic/dpx-dpxconf.c
+++ b/tectonic/dpx-dpxconf.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -82,7 +82,7 @@ paperinfo (const char *ppformat)
       break;
     ppinfo = papernext(ppinfo);
   }
-  
+
   return ((ppinfo && papername(ppinfo)) ? ppinfo : NULL);
 }
 
@@ -98,7 +98,7 @@ dumppaperinfo (void)
     wd = paperpswidth (ppinfo);
     ht = paperpsheight(ppinfo);
     fprintf(stdout, "%s: %.2f %.2f (%.2fmm %.2fmm)\n",
-            papername(ppinfo), wd, ht, 25.4 * wd / 72.0, 25.4 * ht / 72.0); 
+            papername(ppinfo), wd, ht, 25.4 * wd / 72.0, 25.4 * ht / 72.0);
     ppinfo = papernext(ppinfo);
-  }  
+  }
 }

--- a/tectonic/dpx-dpxconf.h
+++ b/tectonic/dpx-dpxconf.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-dpxcrypt.c
+++ b/tectonic/dpx-dpxcrypt.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2003-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -30,7 +30,7 @@
 static void _gcry_burn_stack (int bytes)
 {
   char buf[64];
-    
+
   memset(buf, 0, sizeof buf);
   bytes -= sizeof buf;
   if (bytes > 0) _gcry_burn_stack(bytes);
@@ -63,8 +63,8 @@ static void _gcry_burn_stack (int bytes)
  *
  * According to the definition of MD5 in RFC 1321 from April 1992.
  * NOTE: This is *not* the same file as the one from glibc.
- * Written by Ulrich Drepper <drepper@gnu.ai.mit.edu>, 1995. 
- * heavily modified for GnuPG by Werner Koch <wk@gnupg.org> 
+ * Written by Ulrich Drepper <drepper@gnu.ai.mit.edu>, 1995.
+ * heavily modified for GnuPG by Werner Koch <wk@gnupg.org>
  */
 
 void MD5_init (MD5_CONTEXT *ctx)
@@ -1128,8 +1128,8 @@ SHA512_final (unsigned char *outbuf, SHA512_CONTEXT *hd)
  *
  * According to the definition of MD5 in RFC 1321 from April 1992.
  * NOTE: This is *not* the same file as the one from glibc.
- * Written by Ulrich Drepper <drepper@gnu.ai.mit.edu>, 1995. 
- * heavily modified for GnuPG by Werner Koch <wk@gnupg.org> 
+ * Written by Ulrich Drepper <drepper@gnu.ai.mit.edu>, 1995.
+ * heavily modified for GnuPG by Werner Koch <wk@gnupg.org>
  */
 
 static void do_encrypt_stream (ARC4_CONTEXT *ctx, unsigned char *outbuf, const unsigned char *inbuf, unsigned int len)
@@ -1147,7 +1147,7 @@ static void do_encrypt_stream (ARC4_CONTEXT *ctx, unsigned char *outbuf, const u
     t = sbox[i]; sbox[i] = sbox[j]; sbox[j] = t;
     *outbuf++ = *inbuf++ ^ sbox[(sbox[i] + sbox[j]) & 255];
   }
-  
+
   ctx->idx_i = i;
   ctx->idx_j = j;
 }
@@ -1172,7 +1172,7 @@ static void do_arcfour_setkey (ARC4_CONTEXT *ctx, const unsigned char *key, unsi
     t = ctx->sbox[i];
     ctx->sbox[i] = ctx->sbox[j];
     ctx->sbox[j] = t;
-  } 
+  }
   memset(karr, 0, 256);
 }
 

--- a/tectonic/dpx-dpxcrypt.c
+++ b/tectonic/dpx-dpxcrypt.c
@@ -279,7 +279,7 @@ void MD5_final (unsigned char *outbuf, MD5_CONTEXT *hd)
   p = outbuf; /* p = hd->buf; */
 #ifdef WORDS_BIGENDIAN
 #define X(a) do { *p++ = hd->a; *p++ = hd->a >> 8; \
-	          *p++ = hd->a >> 16; *p++ = hd->a >> 24; } while (0)
+                  *p++ = hd->a >> 16; *p++ = hd->a >> 24; } while (0)
 #else /* little endian */
 #define X(a) do { *(uint32_t *)p = (*hd).a ; p += sizeof(uint32_t); } while (0)
 #endif

--- a/tectonic/dpx-dpxcrypt.h
+++ b/tectonic/dpx-dpxcrypt.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2003-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-dpxfile.c
+++ b/tectonic/dpx-dpxfile.c
@@ -78,7 +78,7 @@ check_stream_is_truetype (rust_input_handle_t handle)
     ttstub_input_seek (handle, 0, SEEK_SET);
 
     if (n != 4)
-	return 0;
+        return 0;
 
     if (!memcmp(_sbuf, "true", 4) || !memcmp(_sbuf, "\0\1\0\0", 4)) /* This doesn't help... */
         return 1;
@@ -101,7 +101,7 @@ check_stream_is_opentype (rust_input_handle_t handle)
     ttstub_input_seek (handle, 0, SEEK_SET);
 
     if (n != 4)
-	return 0;
+        return 0;
 
     if (!memcmp(_sbuf, "OTTO", 4))
         return 1;
@@ -121,7 +121,7 @@ check_stream_is_type1 (rust_input_handle_t handle)
     ttstub_input_seek (handle, 0, SEEK_SET);
 
     if (n != 21)
-	return 0;
+        return 0;
 
     if (p[0] != (char) 0x80 || p[1] < 0 || p[1] > 3)
         return 0;
@@ -130,10 +130,10 @@ check_stream_is_type1 (rust_input_handle_t handle)
         return 1;
 
     if (!memcmp(p + 6, "%!PS", 4)) {
-	/* This was #if-0'd out:
-	 * p[20] = '\0'; p += 6;
-	 * dpx_warning("Ambiguous PostScript resource type: %s", (char *) p);
-	 */
+        /* This was #if-0'd out:
+         * p[20] = '\0'; p += 6;
+         * dpx_warning("Ambiguous PostScript resource type: %s", (char *) p);
+         */
         return 1;
     }
 
@@ -246,7 +246,7 @@ dpx_open_file (const char *filename, dpx_res_type type)
         fqpn = dpx_find__app__xyz(filename, "", 1);
         break;
     default:
-	_tt_abort("XXX unhandled dpx_open_file(%s, %d)", filename, type);
+        _tt_abort("XXX unhandled dpx_open_file(%s, %d)", filename, type);
     }
     if (fqpn) {
         fp = fopen(fqpn, FOPEN_RBIN_MODE);
@@ -329,11 +329,11 @@ dpx_open_type1_file (const char *filename)
 
     handle = ttstub_input_open (filename, kpse_type1_format, 0);
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     if (!check_stream_is_type1 (handle)) {
-	ttstub_input_close (handle);
-	return NULL;
+        ttstub_input_close (handle);
+        return NULL;
     }
 
     return handle;
@@ -347,11 +347,11 @@ dpx_open_truetype_file (const char *filename)
 
     handle = ttstub_input_open (filename, kpse_truetype_format, 0);
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     if (!check_stream_is_truetype (handle)) {
-	ttstub_input_close (handle);
-	return NULL;
+        ttstub_input_close (handle);
+        return NULL;
     }
 
     return handle;
@@ -369,11 +369,11 @@ dpx_open_opentype_file (const char *filename)
     free (q);
 
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     if (!check_stream_is_opentype (handle)) {
-	ttstub_input_close (handle);
-	return NULL;
+        ttstub_input_close (handle);
+        return NULL;
     }
 
     return handle;
@@ -388,24 +388,24 @@ dpx_open_dfont_file (const char *filename)
     int len = strlen(filename);
 
     if (len > 6 && strncmp(filename + len - 6, ".dfont", 6)) {
-	/* I've double-checked that we're accurately representing the original
-	 * code -- the above strncmp() is *not* missing a logical negation.
-	 */
-	q = NEW(len + 6, char);
-	strcpy(q, filename);
-	strcat(q, "/rsrc");
+        /* I've double-checked that we're accurately representing the original
+         * code -- the above strncmp() is *not* missing a logical negation.
+         */
+        q = NEW(len + 6, char);
+        strcpy(q, filename);
+        strcat(q, "/rsrc");
     } else {
-	q = xstrdup (filename);
+        q = xstrdup (filename);
     }
 
     handle = ttstub_input_open (q, kpse_truetype_format, 0);
     free (q);
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     if (!check_stream_is_dfont (handle)) {
-	ttstub_input_close (handle);
-	return NULL;
+        ttstub_input_close (handle);
+        return NULL;
     }
 
     return handle;

--- a/tectonic/dpx-dpxfile.h
+++ b/tectonic/dpx-dpxfile.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-dpxfile.h
+++ b/tectonic/dpx-dpxfile.h
@@ -62,6 +62,6 @@ extern int   keep_cache;
 /* Tectonic-enabled I/O alternatives */
 
 extern rust_input_handle_t dpx_tt_open (const char *filename, const char *suffix,
-					kpse_file_format_type format);
+                                        kpse_file_format_type format);
 
 #endif /* _DPXFILE_H_ */

--- a/tectonic/dpx-dpxutil.c
+++ b/tectonic/dpx-dpxutil.c
@@ -82,11 +82,11 @@ ht_clear_table (struct ht_table *ht)
     hent = ht->table[i];
     while (hent) {
       if (hent->value && ht->hval_free_fn) {
-	ht->hval_free_fn(hent->value);
+        ht->hval_free_fn(hent->value);
       }
       hent->value  = NULL;
       if (hent->key) {
-	free(hent->key);
+        free(hent->key);
       }
       hent->key = NULL;
       next = hent->next;
@@ -131,7 +131,7 @@ ht_lookup_table (struct ht_table *ht, const void *key, int keylen)
   hent = ht->table[hkey];
   while (hent) {
     if (hent->keylen == keylen &&
-	!memcmp(hent->key, key, keylen)) {
+        !memcmp(hent->key, key, keylen)) {
       return hent->value;
     }
     hent = hent->next;
@@ -142,7 +142,7 @@ ht_lookup_table (struct ht_table *ht, const void *key, int keylen)
 
 int
 ht_remove_table (struct ht_table *ht,
-		 const void *key, int keylen)
+                 const void *key, int keylen)
 /* returns 1 if the element was found and removed and 0 otherwise */
 {
   struct ht_entry *hent, *prev;
@@ -155,7 +155,7 @@ ht_remove_table (struct ht_table *ht,
   prev = NULL;
   while (hent) {
     if (hent->keylen == keylen &&
-	!memcmp(hent->key, key, keylen)) {
+        !memcmp(hent->key, key, keylen)) {
       break;
     }
     prev = hent;
@@ -185,7 +185,7 @@ ht_remove_table (struct ht_table *ht,
 /* replace... */
 void
 ht_insert_table (struct ht_table *ht,
-		 const void *key, int keylen, void *value)
+                 const void *key, int keylen, void *value)
 {
   struct ht_entry *hent, *prev;
   unsigned int     hkey;
@@ -197,7 +197,7 @@ ht_insert_table (struct ht_table *ht,
   prev = NULL;
   while (hent) {
     if (hent->keylen == keylen &&
-	!memcmp(hent->key, key, keylen)) {
+        !memcmp(hent->key, key, keylen)) {
       break;
     }
     prev = hent;
@@ -205,7 +205,7 @@ ht_insert_table (struct ht_table *ht,
   }
   if (hent) {
       if (hent->value && ht->hval_free_fn)
-	ht->hval_free_fn(hent->value);
+        ht->hval_free_fn(hent->value);
       hent->value  = value;
   } else {
     hent = NEW(1, struct ht_entry);
@@ -225,7 +225,7 @@ ht_insert_table (struct ht_table *ht,
 
 void
 ht_append_table (struct ht_table *ht,
-		 const void *key, int keylen, void *value)
+                 const void *key, int keylen, void *value)
 {
   struct ht_entry *hent, *last;
   unsigned int hkey;

--- a/tectonic/dpx-dpxutil.c
+++ b/tectonic/dpx-dpxutil.c
@@ -225,7 +225,7 @@ ht_insert_table (struct ht_table *ht,
 
 void
 ht_append_table (struct ht_table *ht,
-		 const void *key, int keylen, void *value) 
+		 const void *key, int keylen, void *value)
 {
   struct ht_entry *hent, *last;
   unsigned int hkey;

--- a/tectonic/dpx-dpxutil.h
+++ b/tectonic/dpx-dpxutil.h
@@ -32,13 +32,13 @@
 
 #ifndef is_space
 #define is_space(c) ((c) == ' '  || (c) == '\t' || (c) == '\f' || \
-		     (c) == '\r' || (c) == '\n' || (c) == '\0')
+                     (c) == '\r' || (c) == '\n' || (c) == '\0')
 #endif
 #ifndef is_delim
 #define is_delim(c) ((c) == '(' || (c) == ')' || \
                      (c) == '/' || \
                      (c) == '<' || (c) == '>' || \
-		     (c) == '[' || (c) == ']' || \
+                     (c) == '[' || (c) == ']' || \
                      (c) == '{' || (c) == '}' || \
                      (c) == '%')
 #endif
@@ -72,11 +72,11 @@ extern int   ht_table_size   (struct ht_table *ht);
 extern void *ht_lookup_table (struct ht_table *ht,
                               const void *key, int keylen);
 extern void  ht_append_table (struct ht_table *ht,
-			      const void *key, int keylen, void *value) ;
+                              const void *key, int keylen, void *value) ;
 extern int   ht_remove_table (struct ht_table *ht,
-			      const void *key, int keylen);
+                              const void *key, int keylen);
 extern void  ht_insert_table (struct ht_table *ht,
-			      const void *key, int keylen, void *value);
+                              const void *key, int keylen, void *value);
 
 struct ht_iter {
   int    index;

--- a/tectonic/dpx-dvi.c
+++ b/tectonic/dpx-dvi.c
@@ -355,7 +355,7 @@ find_post (void)
 
     /* Scan backwards through PADDING */
     do {
-	ttstub_input_seek (dvi_handle, --current, SEEK_SET);
+        ttstub_input_seek (dvi_handle, --current, SEEK_SET);
     } while ((ch = ttstub_input_getc(dvi_handle)) == PADDING && current > 0);
 
     /* file_position now points to last non padding character or
@@ -423,7 +423,7 @@ get_page_info (int32_t post_location)
     page_loc[num_pages-1] = tt_get_unsigned_quad(dvi_handle);
     range_check_loc(page_loc[num_pages-1] + 41);
     for (i = num_pages - 2; i >= 0; i--) {
-	ttstub_input_seek (dvi_handle, page_loc[i+1] + 41, SEEK_SET);
+        ttstub_input_seek (dvi_handle, page_loc[i+1] + 41, SEEK_SET);
         page_loc[i] = tt_get_unsigned_quad(dvi_handle);
         range_check_loc(page_loc[num_pages-1] + 41);
     }
@@ -1980,11 +1980,11 @@ dvi_init (char *dvi_filename, double mag)
     int32_t post_location;
 
     if (!dvi_filename)
-	_tt_abort("filename must be specified");
+        _tt_abort("filename must be specified");
 
     dvi_handle = ttstub_input_open (dvi_filename, kpse_program_binary_format, 0);
     if (dvi_handle == NULL)
-	_tt_abort("cannot open \"%s\"", dvi_filename);
+        _tt_abort("cannot open \"%s\"", dvi_filename);
 
     /* DVI files are most easily read backwards by searching for post_post and
      * then post opcode.

--- a/tectonic/dpx-dvi.h
+++ b/tectonic/dpx-dvi.h
@@ -2,26 +2,26 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
 
 #ifndef _DVI_H_
-#define _DVI_H_	
+#define _DVI_H_
 
 #include <tectonic/dpx-error.h>
 #include <tectonic/dpx-numbers.h>

--- a/tectonic/dpx-dvi.h
+++ b/tectonic/dpx-dvi.h
@@ -71,7 +71,7 @@ extern void dvi_dirchg(unsigned char dir);
 
 extern void  dvi_do_page  (double paper_height, double x_offset, double y_offset);
 extern void  dvi_scan_specials (int page_no,
-				double *width, double *height,
+                                double *width, double *height,
                                 double *x_offset, double *y_offset, int *landscape,
                                 int *majorversion, int *minorversion,
                                 int *do_enc, int *keybits, int32_t *perm,

--- a/tectonic/dpx-dvicodes.h
+++ b/tectonic/dpx-dvicodes.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -40,7 +40,7 @@
 #define PUT3   135 /* Like SET3 */
 #define PUT4   136 /* Like SET4 */
 #define PUT_RULE 137 /* Like SET_RULE */
-#define NOP    138 
+#define NOP    138
 #define BOP    139 /* Followed by 10 four byte count registers (signed?).  Last parameter points to */
                    /* previous BOP (backward linked, first BOP has -1).  BOP clears stack and resets current point. */
 #define EOP    140
@@ -84,7 +84,7 @@
 #define FNT4       238 /* Four byte operator (Knuth says signed, but what would be the point? */
 #define XXX1       239 /* Special.  Operand is one byte length.  Special follows immediately */
 #define XXX2       240 /* Two byte operand */
-#define XXX3       241 /* Three byte operand */ 
+#define XXX3       241 /* Three byte operand */
 #define XXX4       242 /* Four byte operand (Knuth says TeX uses only XXX1 and XXX4 */
 #define FNT_DEF1   243 /* One byte font number, four byte checksum, four byte magnified size (DVI units),
                           four byte designed size, single byte directory length, single byte name length,
@@ -108,7 +108,7 @@
                               four byte denominator
                               four byte mag
                               four byte maximum height (signed?)
-                              four byte maximum width 
+                              four byte maximum width
                               two byte max stack depth required to process file
                               two byte number of pages */
 #define POST_POST  249  /* End of postamble

--- a/tectonic/dpx-dvipdfmx.c
+++ b/tectonic/dpx-dvipdfmx.c
@@ -395,7 +395,7 @@ do_args (int argc, char *argv[], const char *source, int unsafe)
       break;
 
     case 133: /* --kpathsea-debug */
-	/*kpathsea_debug = atoi(optarg);*/
+        /*kpathsea_debug = atoi(optarg);*/
       break;
 
     case 'D':
@@ -588,10 +588,10 @@ read_config_special (const char **start, const char *end)
     if (*start < end) {
       argc += 1;
       if (**start == '"') {
-	argv[2] = parse_c_string (start, end);
+        argv[2] = parse_c_string (start, end);
       }
       else
-	argv[2] = parse_ident (start, end);
+        argv[2] = parse_ident (start, end);
     }
   }
   do_args (argc, argv, argv0, 1); /* Set to unsafe */

--- a/tectonic/dpx-dvipdfmx.h
+++ b/tectonic/dpx-dvipdfmx.h
@@ -2,7 +2,7 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho, Matthias Franz, and Shunsaku Hirata,
     the DVIPDFMx project team.
-    
+
     Copyright (c) 2006 SIL. (xdvipdfmx extensions for XeTeX support)
 
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
@@ -11,12 +11,12 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-epdf.c
+++ b/tectonic/dpx-epdf.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -85,14 +85,14 @@ static int  concat_stream    (pdf_obj *dst, pdf_obj *src);
  * include any extra bleed area needed to accommodate the physical
  * limitations of cutting, folding, and trimming equipment. The actual printed
  * page may include printing marks that fall outside the bleed box.
- * The default value is the page's crop box. 
+ * The default value is the page's crop box.
  *
  * TrimBox rectangle (Optional; PDF 1.3)
  *
  * The trim box (PDF 1.3) defines the intended dimensions of the finished page
  * after trimming. It may be smaller than the media box, to allow for
  * production-related content such as printing instructions, cut marks, or
- * color bars. The default value is the pageâ€™s crop box. 
+ * color bars. The default value is the pageâ€™s crop box.
  *
  * ArtBox rectangle (Optional; PDF 1.3)
  *
@@ -200,7 +200,7 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
 
     while (1) {
       int kids_length, i;
- 
+
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "MediaBox")))) {
 	if (bbox)
 	  pdf_release_obj(bbox);
@@ -278,7 +278,7 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
 
 	page_idx -= count;
       }
-      
+
       pdf_release_obj(kids);
 
       if (i == kids_length) {
@@ -316,7 +316,7 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
     pdf_release_obj(rotate);
     rotate = NULL;
   }
-  
+
   if (ret_bbox != NULL)
     *ret_bbox = bbox;
   if (ret_resources != NULL)
@@ -455,7 +455,7 @@ pdf_include_page (pdf_ximage        *ximage,
       content_new = pdf_new_stream(0);
       /* TODO: better don't include anything if the page is empty */
     } else if (PDF_OBJ_STREAMTYPE(contents)) {
-      /* 
+      /*
        * We must import the stream because its dictionary
        * may contain indirect references.
        */
@@ -621,7 +621,7 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
   pdf_tmatrix M;
   double stack[6];
   pdf_file *pf;
-  
+
   pf = pdf_open(NULL, image_file);
   if (!pf)
     return -1;

--- a/tectonic/dpx-epdf.c
+++ b/tectonic/dpx-epdf.c
@@ -115,7 +115,7 @@ rect_equal (pdf_obj *rect1, pdf_obj *rect2)
     return 0;
   for (i = 0; i < 4; i++) {
     if (pdf_number_value(pdf_get_array(rect1, i)) !=
-	pdf_number_value(pdf_get_array(rect2, i)))
+        pdf_number_value(pdf_get_array(rect2, i)))
       return 0;
   }
 
@@ -151,7 +151,7 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
       dpx_warning("Can't read document catalog.");
       pdf_release_obj(trailer);
       if (catalog)
-	pdf_release_obj(catalog);
+        pdf_release_obj(catalog);
       return NULL;
     }
     pdf_release_obj(trailer);
@@ -179,9 +179,9 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
     int count = pdf_number_value(pdf_lookup_dict(page_tree, "Count"));
     page_idx = page_no + (page_no >= 0 ? -1 : count);
     if (page_idx < 0 || page_idx >= count) {
-	dpx_warning("Page %ld does not exist.", page_no);
-	pdf_release_obj(page_tree);
-	return NULL;
+        dpx_warning("Page %ld does not exist.", page_no);
+        pdf_release_obj(page_tree);
+        return NULL;
       }
     page_no = page_idx+1;
   }
@@ -202,96 +202,96 @@ pdf_get_page_obj (pdf_file *pf, int page_no,
       int kids_length, i;
 
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "MediaBox")))) {
-	if (bbox)
-	  pdf_release_obj(bbox);
-	bbox = tmp;
+        if (bbox)
+          pdf_release_obj(bbox);
+        bbox = tmp;
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "BleedBox")))) {
         if (!rect_equal(tmp, bbox)) {
-	  if (bbox)
-	    pdf_release_obj(bbox);
-	  bbox = tmp;
+          if (bbox)
+            pdf_release_obj(bbox);
+          bbox = tmp;
         } else {
           pdf_release_obj(tmp);
       }
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "TrimBox")))) {
         if (!rect_equal(tmp, bbox)) {
-	  if (bbox)
-	    pdf_release_obj(bbox);
-	  bbox = tmp;
+          if (bbox)
+            pdf_release_obj(bbox);
+          bbox = tmp;
         } else {
           pdf_release_obj(tmp);
       }
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "ArtBox")))) {
         if (!rect_equal(tmp, bbox)) {
-	  if (bbox)
-	    pdf_release_obj(bbox);
-	  bbox = tmp;
+          if (bbox)
+            pdf_release_obj(bbox);
+          bbox = tmp;
         } else {
           pdf_release_obj(tmp);
       }
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "CropBox")))) {
-	if (crop_box)
-	  pdf_release_obj(crop_box);
-	crop_box = tmp;
+        if (crop_box)
+          pdf_release_obj(crop_box);
+        crop_box = tmp;
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "Rotate")))) {
-	if (rotate)
-	  pdf_release_obj(rotate);
-	rotate = tmp;
+        if (rotate)
+          pdf_release_obj(rotate);
+        rotate = tmp;
       }
       if ((tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "Resources")))) {
 #if 0
-	pdf_merge_dict(tmp, resources);
+        pdf_merge_dict(tmp, resources);
 #endif
-	if (resources)
-	  pdf_release_obj(resources);
-	resources = tmp;
+        if (resources)
+          pdf_release_obj(resources);
+        resources = tmp;
       }
 
       kids_ref = pdf_lookup_dict(page_tree, "Kids");
       if (!kids_ref)
-	break;
+        break;
       kids = pdf_deref_obj(kids_ref);
       kids_length = pdf_array_length(kids);
 
       for (i = 0; i < kids_length; i++) {
-	int count;
+        int count;
 
-	pdf_release_obj(page_tree);
-	page_tree = pdf_deref_obj(pdf_get_array(kids, i));
+        pdf_release_obj(page_tree);
+        page_tree = pdf_deref_obj(pdf_get_array(kids, i));
 
-	tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "Count"));
-	if (tmp) {
-	  /* Pages object */
-	  count = pdf_number_value(tmp);
-	  pdf_release_obj(tmp);
+        tmp = pdf_deref_obj(pdf_lookup_dict(page_tree, "Count"));
+        if (tmp) {
+          /* Pages object */
+          count = pdf_number_value(tmp);
+          pdf_release_obj(tmp);
         } else {
-	  /* Page object */
-	  count = 1;
+          /* Page object */
+          count = 1;
         }
-	if (page_idx < count)
-	  break;
+        if (page_idx < count)
+          break;
 
-	page_idx -= count;
+        page_idx -= count;
       }
 
       pdf_release_obj(kids);
 
       if (i == kids_length) {
-	dpx_warning("Page %ld not found! Broken PDF file?", page_no);
-	if (bbox)
-	  pdf_release_obj(bbox);
-	if (crop_box)
-	  pdf_release_obj(crop_box);
-	if (rotate)
-	  pdf_release_obj(rotate);
-	pdf_release_obj(resources);
-	pdf_release_obj(page_tree);
-	return NULL;
+        dpx_warning("Page %ld not found! Broken PDF file?", page_no);
+        if (bbox)
+          pdf_release_obj(bbox);
+        if (crop_box)
+          pdf_release_obj(crop_box);
+        if (rotate)
+          pdf_release_obj(rotate);
+        pdf_release_obj(resources);
+        pdf_release_obj(page_tree);
+        return NULL;
       }
     }
     if (crop_box) {
@@ -349,21 +349,21 @@ pdf_get_page_content (pdf_obj* page)
     for (;;) {
       content_seg = pdf_deref_obj(pdf_get_array(contents, idx));
       if (!content_seg)
-	break;
+        break;
       else if (PDF_OBJ_NULLTYPE(content_seg)) {
-	/* Silently ignore. */
+        /* Silently ignore. */
       }  else if (!PDF_OBJ_STREAMTYPE(content_seg)) {
-	dpx_warning("Page content not a stream object. Broken PDF file?");
+        dpx_warning("Page content not a stream object. Broken PDF file?");
         pdf_release_obj(content_seg);
-	pdf_release_obj(content_new);
+        pdf_release_obj(content_new);
         pdf_release_obj(contents);
-	return NULL;
+        return NULL;
       } else if (pdf_concat_stream(content_new, content_seg) < 0) {
-	dpx_warning("Could not handle content stream with multiple segments.");
+        dpx_warning("Could not handle content stream with multiple segments.");
         pdf_release_obj(content_seg);
-	pdf_release_obj(content_new);
+        pdf_release_obj(content_new);
         pdf_release_obj(contents);
-	return NULL;
+        return NULL;
       }
       pdf_release_obj(content_seg);
       idx++;
@@ -394,7 +394,7 @@ pdf_get_page_content (pdf_obj* page)
 /* ximage here is the result. DONT USE IT FOR PASSING OPTIONS! */
 int
 pdf_include_page (pdf_ximage        *ximage,
-		  rust_input_handle_t handle,
+                  rust_input_handle_t handle,
                   const char        *ident,
                   load_options       options)
 {
@@ -430,7 +430,7 @@ pdf_include_page (pdf_ximage        *ximage,
     pdf_release_obj(markinfo);
     if (!PDF_OBJ_BOOLEANTYPE(tmp)) {
       if (tmp)
-	pdf_release_obj(tmp);
+        pdf_release_obj(tmp);
       goto error;
     } else if (pdf_boolean_value(tmp)) {
       dpx_warning("PDF file is tagged... Ignoring tags.");
@@ -467,14 +467,14 @@ pdf_include_page (pdf_ximage        *ximage,
       int idx, len = pdf_array_length(contents);
       content_new = pdf_new_stream(STREAM_COMPRESS);
       for (idx = 0; idx < len; idx++) {
-	pdf_obj *content_seg = pdf_deref_obj(pdf_get_array(contents, idx));
-	if (!PDF_OBJ_STREAMTYPE(content_seg) ||
-	    pdf_concat_stream(content_new, content_seg) < 0) {
-	  pdf_release_obj(content_seg);
-	  pdf_release_obj(content_new);
-	  goto error;
-	}
-	pdf_release_obj(content_seg);
+        pdf_obj *content_seg = pdf_deref_obj(pdf_get_array(contents, idx));
+        if (!PDF_OBJ_STREAMTYPE(content_seg) ||
+            pdf_concat_stream(content_new, content_seg) < 0) {
+          pdf_release_obj(content_seg);
+          pdf_release_obj(content_new);
+          goto error;
+        }
+        pdf_release_obj(content_seg);
       }
     } else {
       goto error;
@@ -660,13 +660,13 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
       if (*clip_path == 'q')
         depth++;
       if (*clip_path == 'Q')
-	depth--;
+        depth--;
       parse_ident(&clip_path, end_path);
       continue;
     } else if (*clip_path == '-'
-	    || *clip_path == '+'
-	    || *clip_path == '.'
-	    || isdigit((unsigned char)*clip_path)) {
+            || *clip_path == '+'
+            || *clip_path == '.'
+            || isdigit((unsigned char)*clip_path)) {
       stack[++top] = strtod(clip_path, &temp);
       clip_path = temp;
     } else if (*clip_path == '[') {
@@ -675,29 +675,29 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
       stack[++top] = 0;
     } else if (*clip_path == '/') {
       if  (strncmp("/DeviceGray",	clip_path, 11) == 0
-	|| strncmp("/Indexed",		clip_path, 8)  == 0
-	|| strncmp("/CalGray",		clip_path, 8)  == 0) {
-	color_dimen = 1;
-	continue;
+        || strncmp("/Indexed",		clip_path, 8)  == 0
+        || strncmp("/CalGray",		clip_path, 8)  == 0) {
+        color_dimen = 1;
+        continue;
       }
       else if  (strncmp("/DeviceRGB",	clip_path, 10) == 0
-	|| strncmp("/CalRGB",		clip_path, 7)  == 0
-	|| strncmp("/Lab",		clip_path, 4)  == 0) {
-	color_dimen = 3;
-	continue;
+        || strncmp("/CalRGB",		clip_path, 7)  == 0
+        || strncmp("/Lab",		clip_path, 4)  == 0) {
+        color_dimen = 3;
+        continue;
       }
       else if  (strncmp("/DeviceCMYK",	clip_path, 11) == 0) {
-	color_dimen = 4;
-	continue;
+        color_dimen = 4;
+        continue;
       }
       else {
         clip_path++;
         parse_ident(&clip_path, end_path);
-	skip_white(&clip_path, end_path);
-	token = parse_ident(&clip_path, end_path);
+        skip_white(&clip_path, end_path);
+        token = parse_ident(&clip_path, end_path);
         if (strcmp(token, "gs") == 0) {
-	  continue;
-	}
+          continue;
+        }
         return -1;
       }
     } else {
@@ -708,144 +708,144 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
       token = parse_ident(&clip_path, end_path);
       for (j = 0; j < sizeof(pdf_operators) / sizeof(pdf_operators[0]); j++)
         if (strcmp(token, pdf_operators[j].token) == 0)
-	  break;
+          break;
       if (j == sizeof(pdf_operators) / sizeof(pdf_operators[0])) {
         return -1;
       }
       switch (pdf_operators[j].opcode) {
-	case  0:
-	case -1:
-	case -2:
-	case -3:
-	case -4:
-	  /* Just pop the stack and do nothing. */
-	  top += pdf_operators[j].opcode;
-	  if (top < -1)
-	    return -1;
-	  break;
-	case OP_SETCOLOR:
-	  top -= color_dimen;
-	  if (top < -1)
-	    return -1;
-	  break;
-	case OP_CLOSEandCLIP:
-	  pdf_dev_closepath();
-	case OP_CLIP:
+        case  0:
+        case -1:
+        case -2:
+        case -3:
+        case -4:
+          /* Just pop the stack and do nothing. */
+          top += pdf_operators[j].opcode;
+          if (top < -1)
+            return -1;
+          break;
+        case OP_SETCOLOR:
+          top -= color_dimen;
+          if (top < -1)
+            return -1;
+          break;
+        case OP_CLOSEandCLIP:
+          pdf_dev_closepath();
+        case OP_CLIP:
 #if 0
-	  pdf_dev_clip();
+          pdf_dev_clip();
 #else
-	  pdf_dev_flushpath('W', PDF_FILL_RULE_NONZERO);
+          pdf_dev_flushpath('W', PDF_FILL_RULE_NONZERO);
 #endif
-	  break;
-	case OP_CONCATMATRIX:
-	  if (top < 5)
-	    return -1;
-	  T.f = stack[top--];
-	  T.e = stack[top--];
-	  T.d = stack[top--];
-	  T.c = stack[top--];
-	  T.b = stack[top--];
-	  T.a = stack[top--];
-	  pdf_concatmatrix(&M, &T);
-	  break;
-	case OP_SETCOLORSPACE:
-	  /* Do nothing. */
-	  break;
-	case OP_RECTANGLE:
-	  if (top < 3)
-	    return -1;
-	  p1.y = stack[top--];
-	  p1.x = stack[top--];
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  if (M.b == 0 && M.c == 0) {
-	    pdf_tmatrix M0;
-	    M0.a = M.a; M0.b = M.b; M0.c = M.c; M0.d = M.d;
-	    M0.e = 0; M0.f = 0;
-	    pdf_dev_transform(&p0, &M);
-	    pdf_dev_transform(&p1, &M0);
-	    pdf_dev_rectadd(p0.x, p0.y, p1.x, p1.y);
-	  } else {
-	    p2.x = p0.x + p1.x; p2.y = p0.y + p1.y;
-	    p3.x = p0.x; p3.y = p0.y + p1.y;
-	    p1.x += p0.x; p1.y = p0.y;
-	    pdf_dev_transform(&p0, &M);
-	    pdf_dev_transform(&p1, &M);
-	    pdf_dev_transform(&p2, &M);
-	    pdf_dev_transform(&p3, &M);
-	    pdf_dev_moveto(p0.x, p0.y);
-	    pdf_dev_lineto(p1.x, p1.y);
-	    pdf_dev_lineto(p2.x, p2.y);
-	    pdf_dev_lineto(p3.x, p3.y);
-	    pdf_dev_closepath();
-	  }
-	  break;
-	case OP_CURVETO:
-	  if (top < 5)
-	    return -1;
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  pdf_dev_transform(&p0, &M);
-	  p1.y = stack[top--];
-	  p1.x = stack[top--];
-	  pdf_dev_transform(&p1, &M);
-	  p2.y = stack[top--];
-	  p2.x = stack[top--];
-	  pdf_dev_transform(&p2, &M);
-	  pdf_dev_curveto(p2.x, p2.y, p1.x, p1.y, p0.x, p0.y);
-	  break;
-	case OP_CLOSEPATH:
-	  pdf_dev_closepath();
-	  break;
-	case OP_LINETO:
-	  if (top < 1)
-	    return -1;
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  pdf_dev_transform(&p0, &M);
-	  pdf_dev_lineto(p0.x, p0.y);
-	  break;
-	case OP_MOVETO:
-	  if (top < 1)
-	    return -1;
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  pdf_dev_transform(&p0, &M);
-	  pdf_dev_moveto(p0.x, p0.y);
-	  break;
-	case OP_NOOP:
-	  pdf_doc_add_page_content(" n", 2);
-	  break;
-	case OP_GSAVE:
-	  depth++;
-	  break;
-	case OP_GRESTORE:
-	  depth--;
-	  break;
-	case OP_CURVETO1:
-	  if (top < 3)
-	    return -1;
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  pdf_dev_transform(&p0, &M);
-	  p1.y = stack[top--];
-	  p1.x = stack[top--];
-	  pdf_dev_transform(&p1, &M);
-	  pdf_dev_vcurveto(p1.x, p1.y, p0.x, p0.y);
-	  break;
-	case OP_CURVETO2:
-	  if (top < 3)
-	    return -1;
-	  p0.y = stack[top--];
-	  p0.x = stack[top--];
-	  pdf_dev_transform(&p0, &M);
-	  p1.y = stack[top--];
-	  p1.x = stack[top--];
-	  pdf_dev_transform(&p1, &M);
-	  pdf_dev_ycurveto(p1.x, p1.y, p0.x, p0.y);
-	  break;
-	default:
-	  return -1;
+          break;
+        case OP_CONCATMATRIX:
+          if (top < 5)
+            return -1;
+          T.f = stack[top--];
+          T.e = stack[top--];
+          T.d = stack[top--];
+          T.c = stack[top--];
+          T.b = stack[top--];
+          T.a = stack[top--];
+          pdf_concatmatrix(&M, &T);
+          break;
+        case OP_SETCOLORSPACE:
+          /* Do nothing. */
+          break;
+        case OP_RECTANGLE:
+          if (top < 3)
+            return -1;
+          p1.y = stack[top--];
+          p1.x = stack[top--];
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          if (M.b == 0 && M.c == 0) {
+            pdf_tmatrix M0;
+            M0.a = M.a; M0.b = M.b; M0.c = M.c; M0.d = M.d;
+            M0.e = 0; M0.f = 0;
+            pdf_dev_transform(&p0, &M);
+            pdf_dev_transform(&p1, &M0);
+            pdf_dev_rectadd(p0.x, p0.y, p1.x, p1.y);
+          } else {
+            p2.x = p0.x + p1.x; p2.y = p0.y + p1.y;
+            p3.x = p0.x; p3.y = p0.y + p1.y;
+            p1.x += p0.x; p1.y = p0.y;
+            pdf_dev_transform(&p0, &M);
+            pdf_dev_transform(&p1, &M);
+            pdf_dev_transform(&p2, &M);
+            pdf_dev_transform(&p3, &M);
+            pdf_dev_moveto(p0.x, p0.y);
+            pdf_dev_lineto(p1.x, p1.y);
+            pdf_dev_lineto(p2.x, p2.y);
+            pdf_dev_lineto(p3.x, p3.y);
+            pdf_dev_closepath();
+          }
+          break;
+        case OP_CURVETO:
+          if (top < 5)
+            return -1;
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          pdf_dev_transform(&p0, &M);
+          p1.y = stack[top--];
+          p1.x = stack[top--];
+          pdf_dev_transform(&p1, &M);
+          p2.y = stack[top--];
+          p2.x = stack[top--];
+          pdf_dev_transform(&p2, &M);
+          pdf_dev_curveto(p2.x, p2.y, p1.x, p1.y, p0.x, p0.y);
+          break;
+        case OP_CLOSEPATH:
+          pdf_dev_closepath();
+          break;
+        case OP_LINETO:
+          if (top < 1)
+            return -1;
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          pdf_dev_transform(&p0, &M);
+          pdf_dev_lineto(p0.x, p0.y);
+          break;
+        case OP_MOVETO:
+          if (top < 1)
+            return -1;
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          pdf_dev_transform(&p0, &M);
+          pdf_dev_moveto(p0.x, p0.y);
+          break;
+        case OP_NOOP:
+          pdf_doc_add_page_content(" n", 2);
+          break;
+        case OP_GSAVE:
+          depth++;
+          break;
+        case OP_GRESTORE:
+          depth--;
+          break;
+        case OP_CURVETO1:
+          if (top < 3)
+            return -1;
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          pdf_dev_transform(&p0, &M);
+          p1.y = stack[top--];
+          p1.x = stack[top--];
+          pdf_dev_transform(&p1, &M);
+          pdf_dev_vcurveto(p1.x, p1.y, p0.x, p0.y);
+          break;
+        case OP_CURVETO2:
+          if (top < 3)
+            return -1;
+          p0.y = stack[top--];
+          p0.x = stack[top--];
+          pdf_dev_transform(&p0, &M);
+          p1.y = stack[top--];
+          p1.x = stack[top--];
+          pdf_dev_transform(&p1, &M);
+          pdf_dev_ycurveto(p1.x, p1.y, p0.x, p0.y);
+          break;
+        default:
+          return -1;
       }
     }
   }

--- a/tectonic/dpx-epdf.c
+++ b/tectonic/dpx-epdf.c
@@ -546,22 +546,22 @@ pdf_include_page (pdf_ximage        *ximage,
 }
 
 typedef enum {
-  OP_SETCOLOR		= 1,
-  OP_CLOSEandCLIP	= 2,
-  OP_CLIP		= 3,
-  OP_CONCATMATRIX	= 4,
-  OP_SETCOLORSPACE	= 5,
-  OP_RECTANGLE		= 6,
-  OP_CURVETO		= 7,
-  OP_CLOSEPATH		= 8,
-  OP_LINETO		= 9,
-  OP_MOVETO		= 10,
-  OP_NOOP		= 11,
-  OP_GSAVE		= 12,
-  OP_GRESTORE		= 13,
-  OP_CURVETO1		= 14,
-  OP_CURVETO2		= 15,
-  OP_UNKNOWN		= 16
+  OP_SETCOLOR          = 1,
+  OP_CLOSEandCLIP      = 2,
+  OP_CLIP              = 3,
+  OP_CONCATMATRIX      = 4,
+  OP_SETCOLORSPACE     = 5,
+  OP_RECTANGLE         = 6,
+  OP_CURVETO           = 7,
+  OP_CLOSEPATH         = 8,
+  OP_LINETO            = 9,
+  OP_MOVETO            = 10,
+  OP_NOOP              = 11,
+  OP_GSAVE             = 12,
+  OP_GRESTORE          = 13,
+  OP_CURVETO1          = 14,
+  OP_CURVETO2          = 15,
+  OP_UNKNOWN           = 16
 } pdf_opcode;
 
 static struct operator
@@ -569,45 +569,45 @@ static struct operator
   const char *token;
   int         opcode;
 } pdf_operators[] = {
-  {"SCN",	OP_SETCOLOR},
-  {"b*",	OP_CLOSEandCLIP},
-  {"B*",	OP_CLIP},
-  {"cm",	OP_CONCATMATRIX},
-  {"CS",	OP_SETCOLORSPACE},
-  {"f*",	0},
-  {"gs",	-1},
-  {"re",	OP_RECTANGLE},
-  {"rg",	-3},
-  {"RG",	-3},
-  {"sc",	OP_SETCOLOR},
-  {"SC",	OP_SETCOLOR},
-  {"W*",	OP_CLIP},
-  {"b",		OP_CLOSEandCLIP},
-  {"B",		OP_CLIP},
-  {"c",		OP_CURVETO},
-  {"d",		-2},
-  {"f",		0},
-  {"F",		0},
-  {"g",		-1},
-  {"G",		-1},
-  {"h",		OP_CLOSEPATH},
-  {"i",		-1},
-  {"j",		-1},
-  {"J",		-1},
-  {"k",		-4},
-  {"K",		-4},
-  {"l",		OP_LINETO},
-  {"m",		OP_MOVETO},
-  {"M",		-1},
-  {"n",		OP_NOOP},
-  {"q",		OP_GSAVE},
-  {"Q",		OP_GRESTORE},
-  {"s",		OP_CLOSEandCLIP},
-  {"S",		OP_CLIP},
-  {"v",		OP_CURVETO1},
-  {"w",		-1},
-  {"W",		OP_CLIP},
-  {"y",		OP_CURVETO2}
+  {"SCN",       OP_SETCOLOR},
+  {"b*",        OP_CLOSEandCLIP},
+  {"B*",        OP_CLIP},
+  {"cm",        OP_CONCATMATRIX},
+  {"CS",        OP_SETCOLORSPACE},
+  {"f*",        0},
+  {"gs",        -1},
+  {"re",        OP_RECTANGLE},
+  {"rg",        -3},
+  {"RG",        -3},
+  {"sc",        OP_SETCOLOR},
+  {"SC",        OP_SETCOLOR},
+  {"W*",        OP_CLIP},
+  {"b",         OP_CLOSEandCLIP},
+  {"B",         OP_CLIP},
+  {"c",         OP_CURVETO},
+  {"d",         -2},
+  {"f",         0},
+  {"F",         0},
+  {"g",         -1},
+  {"G",         -1},
+  {"h",         OP_CLOSEPATH},
+  {"i",         -1},
+  {"j",         -1},
+  {"J",         -1},
+  {"k",         -4},
+  {"K",         -4},
+  {"l",         OP_LINETO},
+  {"m",         OP_MOVETO},
+  {"M",         -1},
+  {"n",         OP_NOOP},
+  {"q",         OP_GSAVE},
+  {"Q",         OP_GRESTORE},
+  {"s",         OP_CLOSEandCLIP},
+  {"S",         OP_CLIP},
+  {"v",         OP_CURVETO1},
+  {"w",         -1},
+  {"W",         OP_CLIP},
+  {"y",         OP_CURVETO2}
 };
 
 
@@ -651,7 +651,7 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
   depth = 0;
 
   for (; clip_path < end_path; clip_path++) {
-    int color_dimen = 0;	/* silence uninitialized warning */
+    int color_dimen = 0; /* silence uninitialized warning */
     char *token;
     skip_white(&clip_path, end_path);
     if (clip_path == end_path)
@@ -674,19 +674,19 @@ pdf_copy_clip (FILE *image_file, int pageNo, double x_user, double y_user)
       parse_pdf_array(&clip_path, end_path, pf);
       stack[++top] = 0;
     } else if (*clip_path == '/') {
-      if  (strncmp("/DeviceGray",	clip_path, 11) == 0
-        || strncmp("/Indexed",		clip_path, 8)  == 0
-        || strncmp("/CalGray",		clip_path, 8)  == 0) {
+      if  (strncmp("/DeviceGray", clip_path, 11) == 0
+        || strncmp("/Indexed",    clip_path, 8)  == 0
+        || strncmp("/CalGray",    clip_path, 8)  == 0) {
         color_dimen = 1;
         continue;
       }
-      else if  (strncmp("/DeviceRGB",	clip_path, 10) == 0
-        || strncmp("/CalRGB",		clip_path, 7)  == 0
-        || strncmp("/Lab",		clip_path, 4)  == 0) {
+      else if  (strncmp("/DeviceRGB", clip_path, 10) == 0
+        || strncmp("/CalRGB",         clip_path, 7)  == 0
+        || strncmp("/Lab",            clip_path, 4)  == 0) {
         color_dimen = 3;
         continue;
       }
-      else if  (strncmp("/DeviceCMYK",	clip_path, 11) == 0) {
+      else if  (strncmp("/DeviceCMYK", clip_path, 11) == 0) {
         color_dimen = 4;
         continue;
       }

--- a/tectonic/dpx-epdf.h
+++ b/tectonic/dpx-epdf.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-error.c
+++ b/tectonic/dpx-error.c
@@ -52,7 +52,7 @@ _dpx_ensure_output_handle (void)
     _dpx_message_handle = ttstub_output_open_stdout();
 
     if (_dpx_message_handle == NULL)
-	_tt_abort("xdvipdfmx cannot get output logging handle?!");
+        _tt_abort("xdvipdfmx cannot get output logging handle?!");
 
     return _dpx_message_handle;
 }
@@ -69,8 +69,8 @@ _dpx_print_to_stdout (const char *fmt, va_list argp)
      * bigger than sizeof(buf). */
 
     if (n >= sizeof(_dpx_message_buf)) {
-	n = sizeof(_dpx_message_buf) - 1;
-	_dpx_message_buf[n] = '\0';
+        n = sizeof(_dpx_message_buf) - 1;
+        _dpx_message_buf[n] = '\0';
     }
 
     ttstub_output_write(_dpx_ensure_output_handle(), _dpx_message_buf, n);
@@ -84,7 +84,7 @@ dpx_message (const char *fmt, ...)
     int n;
 
     if (_dpx_quietness > 0)
-	return;
+        return;
 
     va_start(argp, fmt);
     _dpx_print_to_stdout (fmt, argp);
@@ -98,10 +98,10 @@ dpx_warning (const char *fmt, ...)
     va_list argp;
 
     if (_dpx_quietness > 1)
-	return;
+        return;
 
     if (_last_message_type == DPX_MESG_INFO)
-	ttstub_output_write(_dpx_ensure_output_handle(), "\n", 1);
+        ttstub_output_write(_dpx_ensure_output_handle(), "\n", 1);
 
     ttstub_output_write(_dpx_ensure_output_handle(), "warning: ", 9);
     va_start(argp, fmt);

--- a/tectonic/dpx-error.h
+++ b/tectonic/dpx-error.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-fontmap.c
+++ b/tectonic/dpx-fontmap.c
@@ -286,14 +286,14 @@ parse_integer_value (const char **pp, const char *endptr, int base)
             base = 10;
         }
     }
-#define ISDIGIT_WB(c,b) (				\
+#define ISDIGIT_WB(c,b) (                               \
         ((b) <= 10 && (c) >= '0' && (c) < '0' + (b)) || \
-        ((b) >  10 && (					\
-            ((c) >= '0' && (c) <= '9') ||		\
-            ((c) >= 'a' && (c) < 'a' + ((b) - 10)) ||	\
-            ((c) >= 'A' && (c) < 'A' + ((b) - 10))	\
-            )						\
-            )						\
+        ((b) >  10 && (                                 \
+            ((c) >= '0' && (c) <= '9') ||               \
+            ((c) >= 'a' && (c) < 'a' + ((b) - 10)) ||   \
+            ((c) >= 'A' && (c) < 'A' + ((b) - 10))      \
+            )                                           \
+            )                                           \
         )
     for (n = 0; p < endptr && ISDIGIT_WB(*p, base); p++, n++);
     if (n == 0)

--- a/tectonic/dpx-fontmap.c
+++ b/tectonic/dpx-fontmap.c
@@ -82,22 +82,22 @@ pdf_clear_fontmap_record (fontmap_rec *mrec)
     assert(mrec);
 
     if (mrec->map_name)
-	free(mrec->map_name);
+        free(mrec->map_name);
     if (mrec->charmap.sfd_name)
-	free(mrec->charmap.sfd_name);
+        free(mrec->charmap.sfd_name);
     if (mrec->charmap.subfont_id)
-	free(mrec->charmap.subfont_id);
+        free(mrec->charmap.subfont_id);
     if (mrec->enc_name)
-	free(mrec->enc_name);
+        free(mrec->enc_name);
     if (mrec->font_name)
-	free(mrec->font_name);
+        free(mrec->font_name);
 
     if (mrec->opt.tounicode)
-	free(mrec->opt.tounicode);
+        free(mrec->opt.tounicode);
     if (mrec->opt.otl_tags)
-	free(mrec->opt.otl_tags);
+        free(mrec->opt.otl_tags);
     if (mrec->opt.charcoll)
-	free(mrec->opt.charcoll);
+        free(mrec->opt.charcoll);
     pdf_init_fontmap_record(mrec);
 }
 
@@ -107,7 +107,7 @@ mstrdup (const char *s)
 {
     char  *r;
     if (!s)
-	return  NULL;
+        return  NULL;
     r = NEW(strlen(s) + 1, char);
     strcpy(r, s);
     return  r;
@@ -157,21 +157,21 @@ static void
 fill_in_defaults (fontmap_rec *mrec, const char *tex_name)
 {
     if (mrec->enc_name &&
-	(!strcmp(mrec->enc_name, "default") ||
-	 !strcmp(mrec->enc_name, "none"))) {
-	free(mrec->enc_name);
-	mrec->enc_name = NULL;
+        (!strcmp(mrec->enc_name, "default") ||
+         !strcmp(mrec->enc_name, "none"))) {
+        free(mrec->enc_name);
+        mrec->enc_name = NULL;
     }
     if (mrec->font_name &&
-	(!strcmp(mrec->font_name, "default") ||
-	 !strcmp(mrec->font_name, "none"))) {
-	free(mrec->font_name);
-	mrec->font_name = NULL;
+        (!strcmp(mrec->font_name, "default") ||
+         !strcmp(mrec->font_name, "none"))) {
+        free(mrec->font_name);
+        mrec->font_name = NULL;
     }
     /* We *must* fill font_name either explicitly or by default */
     if (!mrec->font_name) {
-	mrec->font_name = NEW(strlen(tex_name)+1, char);
-	strcpy(mrec->font_name, tex_name);
+        mrec->font_name = NEW(strlen(tex_name)+1, char);
+        strcpy(mrec->font_name, tex_name);
     }
 
     mrec->map_name = NEW(strlen(tex_name)+1, char);
@@ -183,19 +183,19 @@ fill_in_defaults (fontmap_rec *mrec, const char *tex_name)
      * compatibility.
      */
     if (mrec->charmap.sfd_name && mrec->enc_name &&
-	!mrec->opt.charcoll) {
-	if ((!strcmp(mrec->enc_name, "Identity-H") ||
-	     !strcmp(mrec->enc_name, "Identity-V"))
-	    &&
-	    (strstr(mrec->charmap.sfd_name, "Uni")  ||
-	     strstr(mrec->charmap.sfd_name, "UBig") ||
-	     strstr(mrec->charmap.sfd_name, "UBg")  ||
-	     strstr(mrec->charmap.sfd_name, "UGB")  ||
-	     strstr(mrec->charmap.sfd_name, "UKS")  ||
-	     strstr(mrec->charmap.sfd_name, "UJIS"))) {
-	    mrec->opt.charcoll = NEW(strlen("UCS")+1, char);
-	    strcpy(mrec->opt.charcoll, "UCS");
-	}
+        !mrec->opt.charcoll) {
+        if ((!strcmp(mrec->enc_name, "Identity-H") ||
+             !strcmp(mrec->enc_name, "Identity-V"))
+            &&
+            (strstr(mrec->charmap.sfd_name, "Uni")  ||
+             strstr(mrec->charmap.sfd_name, "UBig") ||
+             strstr(mrec->charmap.sfd_name, "UBg")  ||
+             strstr(mrec->charmap.sfd_name, "UGB")  ||
+             strstr(mrec->charmap.sfd_name, "UKS")  ||
+             strstr(mrec->charmap.sfd_name, "UJIS"))) {
+            mrec->opt.charcoll = NEW(strlen("UCS")+1, char);
+            strcpy(mrec->opt.charcoll, "UCS");
+        }
     }
 #endif /* WITHOUT_COMPAT */
 
@@ -211,11 +211,11 @@ tt_readline (char *buf, int buf_len, rust_input_handle_t handle)
 
     p = tt_mfgets(buf, buf_len, handle);
     if (!p)
-	return  NULL;
+        return  NULL;
 
     q = strchr(p, '%'); /* we don't have quoted string */
     if (q)
-	*q = '\0';
+        *q = '\0';
 
     return p;
 }
@@ -228,7 +228,7 @@ skip_blank (const char **pp, const char *endptr)
 {
     const char  *p = *pp;
     if (!p || p >= endptr)
-	return;
+        return;
     for ( ; p < endptr && ISBLANK(*p); p++);
     *pp = p;
 }
@@ -241,15 +241,15 @@ parse_string_value (const char **pp, const char *endptr)
     int    n;
 
     if (!p || p >= endptr)
-	return  NULL;
+        return  NULL;
     if (*p == '"')
-	q = parse_c_string(&p, endptr);
+        q = parse_c_string(&p, endptr);
     else {
-	for (n = 0; p < endptr && !isspace((unsigned char)*p); p++, n++);
-	if (n == 0)
-	    return  NULL;
-	q = NEW(n + 1, char);
-	memcpy(q, *pp, n); q[n] = '\0';
+        for (n = 0; p < endptr && !isspace((unsigned char)*p); p++, n++);
+        if (n == 0)
+            return  NULL;
+        q = NEW(n + 1, char);
+        memcpy(q, *pp, n); q[n] = '\0';
     }
 
     *pp = p;
@@ -267,41 +267,41 @@ parse_integer_value (const char **pp, const char *endptr, int base)
     assert( base == 0 || (base >= 2 && base <= 36) );
 
     if (!p || p >= endptr)
-	return  NULL;
+        return  NULL;
 
     if (*p == '-' || *p == '+') {
-	p++; has_sign = 1;
+        p++; has_sign = 1;
     }
     if ((base == 0 || base == 16) &&
-	p + 2 <= endptr &&
-	p[0] == '0' && p[1] == 'x') {
-	p += 2; has_prefix = 1;
+        p + 2 <= endptr &&
+        p[0] == '0' && p[1] == 'x') {
+        p += 2; has_prefix = 1;
     }
     if (base == 0) {
-	if (has_prefix)
-	    base = 16;
-	else if (p < endptr && *p == '0')
-	    base = 8;
-	else {
-	    base = 10;
-	}
+        if (has_prefix)
+            base = 16;
+        else if (p < endptr && *p == '0')
+            base = 8;
+        else {
+            base = 10;
+        }
     }
 #define ISDIGIT_WB(c,b) (				\
-	((b) <= 10 && (c) >= '0' && (c) < '0' + (b)) || \
-	((b) >  10 && (					\
-	    ((c) >= '0' && (c) <= '9') ||		\
-	    ((c) >= 'a' && (c) < 'a' + ((b) - 10)) ||	\
-	    ((c) >= 'A' && (c) < 'A' + ((b) - 10))	\
-	    )						\
-	    )						\
-	)
+        ((b) <= 10 && (c) >= '0' && (c) < '0' + (b)) || \
+        ((b) >  10 && (					\
+            ((c) >= '0' && (c) <= '9') ||		\
+            ((c) >= 'a' && (c) < 'a' + ((b) - 10)) ||	\
+            ((c) >= 'A' && (c) < 'A' + ((b) - 10))	\
+            )						\
+            )						\
+        )
     for (n = 0; p < endptr && ISDIGIT_WB(*p, base); p++, n++);
     if (n == 0)
-	return  NULL;
+        return  NULL;
     if (has_sign)
-	n += 1;
+        n += 1;
     if (has_prefix)
-	n += 2;
+        n += 2;
 
     q = NEW(n + 1, char);
     memcpy(q, *pp, n); q[n] = '\0';
@@ -332,225 +332,225 @@ fontmap_parse_mapdef_dpm (fontmap_rec *mrec,
     skip_blank(&p, endptr);
     /* encoding field */
     if (p < endptr && *p != '-') { /* May be NULL */
-	mrec->enc_name = parse_string_value(&p, endptr);
-	skip_blank(&p, endptr);
+        mrec->enc_name = parse_string_value(&p, endptr);
+        skip_blank(&p, endptr);
     }
 
     /* fontname or font filename field */
     if (p < endptr && *p != '-') { /* May be NULL */
-	mrec->font_name = parse_string_value(&p, endptr);
-	skip_blank(&p, endptr);
+        mrec->font_name = parse_string_value(&p, endptr);
+        skip_blank(&p, endptr);
     }
     if (mrec->font_name) {
-	char  *tmp;
-	/* Several options are encoded in font_name for
-	 * compatibility with dvipdfm.
-	 */
-	tmp = strip_options(mrec->font_name, &mrec->opt);
-	if (tmp) {
-	    free(mrec->font_name);
-	    mrec->font_name = tmp;
-	}
+        char  *tmp;
+        /* Several options are encoded in font_name for
+         * compatibility with dvipdfm.
+         */
+        tmp = strip_options(mrec->font_name, &mrec->opt);
+        if (tmp) {
+            free(mrec->font_name);
+            mrec->font_name = tmp;
+        }
     }
 
     skip_blank(&p, endptr);
     /* Parse any remaining arguments */
     while (p + 1 < endptr &&
-	   *p != '\r' && *p != '\n' && *p == '-') {
-	char  *q, mopt = p[1];
-	int    v;
+           *p != '\r' && *p != '\n' && *p == '-') {
+        char  *q, mopt = p[1];
+        int    v;
 
-	p += 2; skip_blank(&p, endptr);
-	switch (mopt) {
+        p += 2; skip_blank(&p, endptr);
+        switch (mopt) {
 
-	case  's': /* Slant option */
-	    q = parse_float_decimal(&p, endptr);
-	    if (!q) {
-		dpx_warning("Missing a number value for 's' option.");
-		return  -1;
-	    }
-	    mrec->opt.slant = atof(q);
-	    free(q);
-	    break;
+        case  's': /* Slant option */
+            q = parse_float_decimal(&p, endptr);
+            if (!q) {
+                dpx_warning("Missing a number value for 's' option.");
+                return  -1;
+            }
+            mrec->opt.slant = atof(q);
+            free(q);
+            break;
 
-	case  'e': /* Extend option */
-	    q = parse_float_decimal(&p, endptr);
-	    if (!q) {
-		dpx_warning("Missing a number value for 'e' option.");
-		return  -1;
-	    }
-	    mrec->opt.extend = atof(q);
-	    if (mrec->opt.extend <= 0.0) {
-		dpx_warning("Invalid value for 'e' option: %s", q);
-		return  -1;
-	    }
-	    free(q);
-	    break;
+        case  'e': /* Extend option */
+            q = parse_float_decimal(&p, endptr);
+            if (!q) {
+                dpx_warning("Missing a number value for 'e' option.");
+                return  -1;
+            }
+            mrec->opt.extend = atof(q);
+            if (mrec->opt.extend <= 0.0) {
+                dpx_warning("Invalid value for 'e' option: %s", q);
+                return  -1;
+            }
+            free(q);
+            break;
 
-	case  'b': /* Fake-bold option */
-	    q = parse_float_decimal(&p, endptr);
-	    if (!q) {
-		dpx_warning("Missing a number value for 'b' option.");
-		return  -1;
-	    }
-	    mrec->opt.bold = atof(q);
-	    if (mrec->opt.bold <= 0.0) {
-		dpx_warning("Invalid value for 'b' option: %s", q);
-		return  -1;
-	    }
-	    free(q);
-	    break;
+        case  'b': /* Fake-bold option */
+            q = parse_float_decimal(&p, endptr);
+            if (!q) {
+                dpx_warning("Missing a number value for 'b' option.");
+                return  -1;
+            }
+            mrec->opt.bold = atof(q);
+            if (mrec->opt.bold <= 0.0) {
+                dpx_warning("Invalid value for 'b' option: %s", q);
+                return  -1;
+            }
+            free(q);
+            break;
 
-	case  'r': /* Remap option; obsolete; just ignore */
-	    break;
+        case  'r': /* Remap option; obsolete; just ignore */
+            break;
 
-	case  'i':  /* TTC index */
-	    q = parse_integer_value(&p, endptr, 10);
-	    if (!q) {
-		dpx_warning("Missing TTC index number...");
-		return  -1;
-	    }
-	    mrec->opt.index = atoi(q);
-	    if (mrec->opt.index < 0) {
-		dpx_warning("Invalid TTC index number: %s", q);
-		return  -1;
-	    }
-	    free(q);
-	    break;
+        case  'i':  /* TTC index */
+            q = parse_integer_value(&p, endptr, 10);
+            if (!q) {
+                dpx_warning("Missing TTC index number...");
+                return  -1;
+            }
+            mrec->opt.index = atoi(q);
+            if (mrec->opt.index < 0) {
+                dpx_warning("Invalid TTC index number: %s", q);
+                return  -1;
+            }
+            free(q);
+            break;
 
-	case  'p': /* UCS plane: just for testing */
-	    q = parse_integer_value(&p, endptr, 0);
-	    if (!q) {
-		dpx_warning("Missing a number for 'p' option.");
-		return  -1;
-	    }
-	    v = strtol(q, NULL, 0);
-	    if (v < 0 || v > 16)
-		dpx_warning("Invalid value for option 'p': %s", q);
-	    else {
-		mrec->opt.mapc = v << 16;
-	    }
-	    free(q);
-	    break;
+        case  'p': /* UCS plane: just for testing */
+            q = parse_integer_value(&p, endptr, 0);
+            if (!q) {
+                dpx_warning("Missing a number for 'p' option.");
+                return  -1;
+            }
+            v = strtol(q, NULL, 0);
+            if (v < 0 || v > 16)
+                dpx_warning("Invalid value for option 'p': %s", q);
+            else {
+                mrec->opt.mapc = v << 16;
+            }
+            free(q);
+            break;
 
-	case  'u': /* ToUnicode */
-	    q = parse_string_value(&p, endptr);
-	    if (q)
-		mrec->opt.tounicode = q;
-	    else {
-		dpx_warning("Missing string value for option 'u'.");
-		return  -1;
-	    }
-	    break;
+        case  'u': /* ToUnicode */
+            q = parse_string_value(&p, endptr);
+            if (q)
+                mrec->opt.tounicode = q;
+            else {
+                dpx_warning("Missing string value for option 'u'.");
+                return  -1;
+            }
+            break;
 
-	case  'v': /* StemV */
-	    q = parse_integer_value(&p, endptr, 10);
-	    if (!q) {
-		dpx_warning("Missing a number for 'v' option.");
-		return  -1;
-	    }
-	    mrec->opt.stemv = strtol(q, NULL, 0);
-	    free(q);
-	    break;
+        case  'v': /* StemV */
+            q = parse_integer_value(&p, endptr, 10);
+            if (!q) {
+                dpx_warning("Missing a number for 'v' option.");
+                return  -1;
+            }
+            mrec->opt.stemv = strtol(q, NULL, 0);
+            free(q);
+            break;
 
-	    /* Omega uses both single-byte and double-byte set_char command
-	     * even for double-byte OFMs. This confuses CMap decoder.
-	     */
-	case  'm':
-	    /* Map single bytes char 0xab to double byte char 0xcdab  */
-	    if (p + 4 <= endptr &&
-		p[0] == '<' && p[3] == '>') {
-		p++;
-		q = parse_integer_value(&p, endptr, 16);
-		if (!q) {
-		    dpx_warning("Invalid value for option 'm'.");
-		    return  -1;
-		} else if (p < endptr && *p != '>') {
-		    dpx_warning("Invalid value for option 'm': %s", q);
-		    free(q);
-		    return  -1;
-		}
-		v = strtol(q, NULL, 16);
-		mrec->opt.mapc = ((v << 8) & 0x0000ff00L);
-		free(q); p++;
-	    } else if (p + 4 <= endptr &&
-		       !memcmp(p, "sfd:", strlen("sfd:"))) {
-		char  *r;
-		const char  *rr;
-		/* SFD mapping: sfd:Big5,00 */
-		p += 4; skip_blank(&p, endptr);
-		q  = parse_string_value(&p, endptr);
-		if (!q) {
-		    dpx_warning("Missing value for option 'm'.");
-		    return  -1;
-		}
-		r  = strchr(q, ',');
-		if (!r) {
-		    dpx_warning("Invalid value for option 'm': %s", q);
-		    free(q);
-		    return  -1;
-		}
-		*r = 0; rr = ++r; skip_blank(&rr, r + strlen(r));
-		if (*rr == '\0') {
-		    dpx_warning("Invalid value for option 'm': %s,", q);
-		    free(q);
-		    return  -1;
-		}
-		mrec->charmap.sfd_name   = mstrdup(q);
-		mrec->charmap.subfont_id = mstrdup(rr);
-		free(q);
-	    } else if (p + 4 < endptr &&
-		       !memcmp(p, "pad:", strlen("pad:"))) {
-		p += 4; skip_blank(&p, endptr);
-		q  = parse_integer_value(&p, endptr, 16);
-		if (!q) {
-		    dpx_warning("Invalid value for option 'm'.");
-		    return  -1;
-		} else if (p < endptr && !isspace((unsigned char)*p)) {
-		    dpx_warning("Invalid value for option 'm': %s", q);
-		    free(q);
-		    return  -1;
-		}
-		v = strtol(q, NULL, 16);
-		mrec->opt.mapc = ((v << 8) & 0x0000ff00L);
-		free(q);
-	    } else {
-		dpx_warning("Invalid value for option 'm'.");
-		return  -1;
-	    }
-	    break;
+            /* Omega uses both single-byte and double-byte set_char command
+             * even for double-byte OFMs. This confuses CMap decoder.
+             */
+        case  'm':
+            /* Map single bytes char 0xab to double byte char 0xcdab  */
+            if (p + 4 <= endptr &&
+                p[0] == '<' && p[3] == '>') {
+                p++;
+                q = parse_integer_value(&p, endptr, 16);
+                if (!q) {
+                    dpx_warning("Invalid value for option 'm'.");
+                    return  -1;
+                } else if (p < endptr && *p != '>') {
+                    dpx_warning("Invalid value for option 'm': %s", q);
+                    free(q);
+                    return  -1;
+                }
+                v = strtol(q, NULL, 16);
+                mrec->opt.mapc = ((v << 8) & 0x0000ff00L);
+                free(q); p++;
+            } else if (p + 4 <= endptr &&
+                       !memcmp(p, "sfd:", strlen("sfd:"))) {
+                char  *r;
+                const char  *rr;
+                /* SFD mapping: sfd:Big5,00 */
+                p += 4; skip_blank(&p, endptr);
+                q  = parse_string_value(&p, endptr);
+                if (!q) {
+                    dpx_warning("Missing value for option 'm'.");
+                    return  -1;
+                }
+                r  = strchr(q, ',');
+                if (!r) {
+                    dpx_warning("Invalid value for option 'm': %s", q);
+                    free(q);
+                    return  -1;
+                }
+                *r = 0; rr = ++r; skip_blank(&rr, r + strlen(r));
+                if (*rr == '\0') {
+                    dpx_warning("Invalid value for option 'm': %s,", q);
+                    free(q);
+                    return  -1;
+                }
+                mrec->charmap.sfd_name   = mstrdup(q);
+                mrec->charmap.subfont_id = mstrdup(rr);
+                free(q);
+            } else if (p + 4 < endptr &&
+                       !memcmp(p, "pad:", strlen("pad:"))) {
+                p += 4; skip_blank(&p, endptr);
+                q  = parse_integer_value(&p, endptr, 16);
+                if (!q) {
+                    dpx_warning("Invalid value for option 'm'.");
+                    return  -1;
+                } else if (p < endptr && !isspace((unsigned char)*p)) {
+                    dpx_warning("Invalid value for option 'm': %s", q);
+                    free(q);
+                    return  -1;
+                }
+                v = strtol(q, NULL, 16);
+                mrec->opt.mapc = ((v << 8) & 0x0000ff00L);
+                free(q);
+            } else {
+                dpx_warning("Invalid value for option 'm'.");
+                return  -1;
+            }
+            break;
 
-	case 'w': /* Writing mode (for unicode encoding) */
-	    if (!mrec->enc_name ||
-		strcmp(mrec->enc_name, "unicode")) {
-		dpx_warning("Fontmap option 'w' meaningless for encoding other than \"unicode\".");
-		return  -1;
-	    }
-	    q  = parse_integer_value(&p, endptr, 10);
-	    if (!q) {
-		dpx_warning("Missing wmode value...");
-		return  -1;
-	    }
-	    if (atoi(q) == 1)
-		mrec->opt.flags |= FONTMAP_OPT_VERT;
-	    else if (atoi(q) == 0)
-		mrec->opt.flags &= ~FONTMAP_OPT_VERT;
-	    else {
-		dpx_warning("Invalid value for option 'w': %s", q);
-	    }
-	    free(q);
-	    break;
+        case 'w': /* Writing mode (for unicode encoding) */
+            if (!mrec->enc_name ||
+                strcmp(mrec->enc_name, "unicode")) {
+                dpx_warning("Fontmap option 'w' meaningless for encoding other than \"unicode\".");
+                return  -1;
+            }
+            q  = parse_integer_value(&p, endptr, 10);
+            if (!q) {
+                dpx_warning("Missing wmode value...");
+                return  -1;
+            }
+            if (atoi(q) == 1)
+                mrec->opt.flags |= FONTMAP_OPT_VERT;
+            else if (atoi(q) == 0)
+                mrec->opt.flags &= ~FONTMAP_OPT_VERT;
+            else {
+                dpx_warning("Invalid value for option 'w': %s", q);
+            }
+            free(q);
+            break;
 
-	default:
-	    dpx_warning("Unrecognized font map option: '%c'", mopt);
-	    return  -1;
-	}
-	skip_blank(&p, endptr);
+        default:
+            dpx_warning("Unrecognized font map option: '%c'", mopt);
+            return  -1;
+        }
+        skip_blank(&p, endptr);
     }
 
     if (p < endptr && *p != '\r' && *p != '\n') {
-	dpx_warning("Invalid char in fontmap line: %c", *p);
-	return  -1;
+        dpx_warning("Invalid char in fontmap line: %c", *p);
+        return  -1;
     }
 
     return  0;
@@ -571,72 +571,72 @@ fontmap_parse_mapdef_dps (fontmap_rec *mrec,
     /* However, pdftex.map allows a line without PostScript name. */
 
     if (*p != '"' && *p != '<') {
-	if (p < endptr) {
-	    q = parse_string_value(&p, endptr);
-	    if (q) free(q);
-	    skip_blank(&p, endptr);
-	} else {
-	    dpx_warning("Missing a PostScript font name.");
-	    return -1;
-	}
+        if (p < endptr) {
+            q = parse_string_value(&p, endptr);
+            if (q) free(q);
+            skip_blank(&p, endptr);
+        } else {
+            dpx_warning("Missing a PostScript font name.");
+            return -1;
+        }
     }
 
     if (p >= endptr) return 0;
 
     /* Parse any remaining arguments */
     while (p < endptr && *p != '\r' && *p != '\n' && (*p == '<' || *p == '"')) {
-	switch (*p) {
-	case '<': /* encoding or fontfile field */
-	    /* If we see <[ or <<, just ignore the second char instead
-	       of doing as directed (define encoding file, fully embed); sorry.  */
-	    if (++p < endptr && (*p == '[' || *p == '<')) p++; /*skip */
-	    skip_blank(&p, endptr);
-	    if ((q = parse_string_value(&p, endptr))) {
-		int n = strlen(q);
-		if (n > 4 && strncmp(q+n-4, ".enc", 4) == 0)
-		    mrec->enc_name = q;
-		else
-		    mrec->font_name = q;
-	    }
-	    skip_blank(&p, endptr);
-	    break;
+        switch (*p) {
+        case '<': /* encoding or fontfile field */
+            /* If we see <[ or <<, just ignore the second char instead
+               of doing as directed (define encoding file, fully embed); sorry.  */
+            if (++p < endptr && (*p == '[' || *p == '<')) p++; /*skip */
+            skip_blank(&p, endptr);
+            if ((q = parse_string_value(&p, endptr))) {
+                int n = strlen(q);
+                if (n > 4 && strncmp(q+n-4, ".enc", 4) == 0)
+                    mrec->enc_name = q;
+                else
+                    mrec->font_name = q;
+            }
+            skip_blank(&p, endptr);
+            break;
 
-	case '"': /* Options */
-	    if ((q = parse_string_value(&p, endptr))) {
-		const char *r = q, *e = q+strlen(q);
-		char *s, *t;
-		skip_blank(&r, e);
-		while (r < e) {
-		    if ((s = parse_float_decimal(&r, e))) {
-			skip_blank(&r, e);
-			if ((t = parse_string_value(&r, e))) {
-			    if (strcmp(t, "SlantFont") == 0)
-				mrec->opt.slant = atof(s);
-			    else if (strcmp(t, "ExtendFont") == 0)
-				mrec->opt.extend = atof(s);
-			    free(t);
-			}
-			free(s);
-		    } else if ((s = parse_string_value(&r, e))) { /* skip */
-			free(s);
-		    }
-		    skip_blank(&r, e);
-		}
-		free(q);
-	    }
-	    skip_blank(&p, endptr);
-	    break;
+        case '"': /* Options */
+            if ((q = parse_string_value(&p, endptr))) {
+                const char *r = q, *e = q+strlen(q);
+                char *s, *t;
+                skip_blank(&r, e);
+                while (r < e) {
+                    if ((s = parse_float_decimal(&r, e))) {
+                        skip_blank(&r, e);
+                        if ((t = parse_string_value(&r, e))) {
+                            if (strcmp(t, "SlantFont") == 0)
+                                mrec->opt.slant = atof(s);
+                            else if (strcmp(t, "ExtendFont") == 0)
+                                mrec->opt.extend = atof(s);
+                            free(t);
+                        }
+                        free(s);
+                    } else if ((s = parse_string_value(&r, e))) { /* skip */
+                        free(s);
+                    }
+                    skip_blank(&r, e);
+                }
+                free(q);
+            }
+            skip_blank(&p, endptr);
+            break;
 
-	default:
-	    dpx_warning("Found an invalid entry: %s", p);
-	    return -1;
-	}
-	skip_blank(&p, endptr);
+        default:
+            dpx_warning("Found an invalid entry: %s", p);
+            return -1;
+        }
+        skip_blank(&p, endptr);
     }
 
     if (p < endptr && *p != '\r' && *p != '\n') {
-	dpx_warning("Invalid char in fontmap line: %c", *p);
-	return -1;
+        dpx_warning("Invalid char in fontmap line: %c", *p);
+        return -1;
     }
 
     return  0;
@@ -657,14 +657,14 @@ chop_sfd_name (const char *tex_name, char **sfd_name)
 
     p = strchr(tex_name, '@');
     if (!p ||
-	p[1] == '\0' || p == tex_name) {
-	return  NULL;
+        p[1] == '\0' || p == tex_name) {
+        return  NULL;
     }
     m = (int) (p - tex_name);
     p++;
     q = strchr(p, '@');
     if (!q || q == p) {
-	return NULL;
+        return NULL;
     }
     n = (int) (q - p);
     q++;
@@ -674,7 +674,7 @@ chop_sfd_name (const char *tex_name, char **sfd_name)
     memcpy(fontname, tex_name, m);
     fontname[m] = '\0';
     if (*q)
-	strcat(fontname, q);
+        strcat(fontname, q);
 
     *sfd_name = NEW(n+1, char);
     memcpy(*sfd_name, p, n);
@@ -692,21 +692,21 @@ make_subfont_name (const char *map_name, const char *sfd_name, const char *sub_i
 
     p = strchr(map_name, '@');
     if (!p || p == map_name)
-	return  NULL;
+        return  NULL;
     m = (int) (p - map_name);
     q = strchr(p + 1, '@');
     if (!q || q == p + 1)
-	return  NULL;
+        return  NULL;
     n = (int) (q - p) + 1; /* including two '@' */
     if (strlen(sfd_name) != n - 2 ||
-	memcmp(p + 1, sfd_name, n - 2))
-	return  NULL;
+        memcmp(p + 1, sfd_name, n - 2))
+        return  NULL;
     tfm_name = NEW(strlen(map_name) - n + strlen(sub_id) + 1, char);
     memcpy(tfm_name, map_name, m);
     tfm_name[m] = '\0';
     strcat(tfm_name, sub_id);
     if (q[1]) /* not ending with '@' */
-	strcat(tfm_name, q + 1);
+        strcat(tfm_name, q + 1);
 
     return  tfm_name;
 }
@@ -724,52 +724,52 @@ pdf_append_fontmap_record (const char *kp, const fontmap_rec *vp)
     char        *fnt_name, *sfd_name = NULL;
 
     if (!kp || fontmap_invalid(vp)) {
-	dpx_warning("Invalid fontmap record...");
-	return -1;
+        dpx_warning("Invalid fontmap record...");
+        return -1;
     }
 
     if (verbose > 3)
-	dpx_message("fontmap>> append key=\"%s\"...", kp);
+        dpx_message("fontmap>> append key=\"%s\"...", kp);
 
     fnt_name = chop_sfd_name(kp, &sfd_name);
     if (fnt_name && sfd_name) {
-	char  *tfm_name;
-	char **subfont_ids;
-	int    n = 0;
-	subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
-	if (!subfont_ids)
-	    return  -1;
-	while (n-- > 0) {
-	    tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
-	    if (!tfm_name)
-		continue;
-	    mrec = ht_lookup_table(fontmap, tfm_name, strlen(tfm_name));
-	    if (!mrec) {
-		mrec = NEW(1, fontmap_rec);
-		pdf_init_fontmap_record(mrec);
-		mrec->map_name = mstrdup(kp); /* link */
-		mrec->charmap.sfd_name   = mstrdup(sfd_name);
-		mrec->charmap.subfont_id = mstrdup(subfont_ids[n]);
-		ht_insert_table(fontmap, tfm_name, strlen(tfm_name), mrec);
-	    }
-	    free(tfm_name);
-	}
-	free(fnt_name);
-	free(sfd_name);
+        char  *tfm_name;
+        char **subfont_ids;
+        int    n = 0;
+        subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
+        if (!subfont_ids)
+            return  -1;
+        while (n-- > 0) {
+            tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
+            if (!tfm_name)
+                continue;
+            mrec = ht_lookup_table(fontmap, tfm_name, strlen(tfm_name));
+            if (!mrec) {
+                mrec = NEW(1, fontmap_rec);
+                pdf_init_fontmap_record(mrec);
+                mrec->map_name = mstrdup(kp); /* link */
+                mrec->charmap.sfd_name   = mstrdup(sfd_name);
+                mrec->charmap.subfont_id = mstrdup(subfont_ids[n]);
+                ht_insert_table(fontmap, tfm_name, strlen(tfm_name), mrec);
+            }
+            free(tfm_name);
+        }
+        free(fnt_name);
+        free(sfd_name);
     }
 
     mrec = ht_lookup_table(fontmap, kp, strlen(kp));
     if (!mrec) {
-	mrec = NEW(1, fontmap_rec);
-	pdf_copy_fontmap_record(mrec, vp);
-	if (mrec->map_name && !strcmp(kp, mrec->map_name)) {
-	    free(mrec->map_name);
-	    mrec->map_name = NULL;
-	}
-	ht_insert_table(fontmap, kp, strlen(kp), mrec);
+        mrec = NEW(1, fontmap_rec);
+        pdf_copy_fontmap_record(mrec, vp);
+        if (mrec->map_name && !strcmp(kp, mrec->map_name)) {
+            free(mrec->map_name);
+            mrec->map_name = NULL;
+        }
+        ht_insert_table(fontmap, kp, strlen(kp), mrec);
     }
     if (verbose > 3)
-	dpx_message("\n");
+        dpx_message("\n");
 
     return  0;
 }
@@ -780,38 +780,38 @@ pdf_remove_fontmap_record (const char *kp)
     char  *fnt_name, *sfd_name = NULL;
 
     if (!kp)
-	return  -1;
+        return  -1;
 
     if (verbose > 3)
-	dpx_message("fontmap>> remove key=\"%s\"...", kp);
+        dpx_message("fontmap>> remove key=\"%s\"...", kp);
 
     fnt_name = chop_sfd_name(kp, &sfd_name);
     if (fnt_name && sfd_name) {
-	char  *tfm_name;
-	char **subfont_ids;
-	int    n = 0;
-	subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
-	if (!subfont_ids)
-	    return  -1;
-	if (verbose > 3)
-	    dpx_message("\nfontmap>> Expand @%s@:", sfd_name);
-	while (n-- > 0) {
-	    tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
-	    if (!tfm_name)
-		continue;
-	    if (verbose > 3)
-		dpx_message(" %s", tfm_name);
-	    ht_remove_table(fontmap, tfm_name, strlen(tfm_name));
-	    free(tfm_name);
-	}
-	free(fnt_name);
-	free(sfd_name);
+        char  *tfm_name;
+        char **subfont_ids;
+        int    n = 0;
+        subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
+        if (!subfont_ids)
+            return  -1;
+        if (verbose > 3)
+            dpx_message("\nfontmap>> Expand @%s@:", sfd_name);
+        while (n-- > 0) {
+            tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
+            if (!tfm_name)
+                continue;
+            if (verbose > 3)
+                dpx_message(" %s", tfm_name);
+            ht_remove_table(fontmap, tfm_name, strlen(tfm_name));
+            free(tfm_name);
+        }
+        free(fnt_name);
+        free(sfd_name);
     }
 
     ht_remove_table(fontmap, kp, strlen(kp));
 
     if (verbose > 3)
-	dpx_message("\n");
+        dpx_message("\n");
 
     return  0;
 }
@@ -823,55 +823,55 @@ pdf_insert_fontmap_record (const char *kp, const fontmap_rec *vp)
     char        *fnt_name, *sfd_name;
 
     if (!kp || fontmap_invalid(vp)) {
-	dpx_warning("Invalid fontmap record...");
-	return NULL;
+        dpx_warning("Invalid fontmap record...");
+        return NULL;
     }
 
     if (verbose > 3)
-	dpx_message("fontmap>> insert key=\"%s\"...", kp);
+        dpx_message("fontmap>> insert key=\"%s\"...", kp);
 
     fnt_name = chop_sfd_name(kp, &sfd_name);
     if (fnt_name && sfd_name) {
-	char  *tfm_name;
-	char **subfont_ids;
-	int    n = 0;
-	subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
-	if (!subfont_ids) {
-	    free(fnt_name);
-	    free(sfd_name);
-	    dpx_warning("Could not open SFD file: %s", sfd_name);
-	    return NULL;
-	}
-	if (verbose > 3)
-	    dpx_message("\nfontmap>> Expand @%s@:", sfd_name);
-	while (n-- > 0) {
-	    tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
-	    if (!tfm_name)
-		continue;
-	    if (verbose > 3)
-		dpx_message(" %s", tfm_name);
-	    mrec = NEW(1, fontmap_rec);
-	    pdf_init_fontmap_record(mrec);
-	    mrec->map_name = mstrdup(kp); /* link to this entry */
-	    mrec->charmap.sfd_name   = mstrdup(sfd_name);
-	    mrec->charmap.subfont_id = mstrdup(subfont_ids[n]);
-	    ht_insert_table(fontmap, tfm_name, strlen(tfm_name), mrec);
-	    free(tfm_name);
-	}
-	free(fnt_name);
-	free(sfd_name);
+        char  *tfm_name;
+        char **subfont_ids;
+        int    n = 0;
+        subfont_ids = sfd_get_subfont_ids(sfd_name, &n);
+        if (!subfont_ids) {
+            free(fnt_name);
+            free(sfd_name);
+            dpx_warning("Could not open SFD file: %s", sfd_name);
+            return NULL;
+        }
+        if (verbose > 3)
+            dpx_message("\nfontmap>> Expand @%s@:", sfd_name);
+        while (n-- > 0) {
+            tfm_name = make_subfont_name(kp, sfd_name, subfont_ids[n]);
+            if (!tfm_name)
+                continue;
+            if (verbose > 3)
+                dpx_message(" %s", tfm_name);
+            mrec = NEW(1, fontmap_rec);
+            pdf_init_fontmap_record(mrec);
+            mrec->map_name = mstrdup(kp); /* link to this entry */
+            mrec->charmap.sfd_name   = mstrdup(sfd_name);
+            mrec->charmap.subfont_id = mstrdup(subfont_ids[n]);
+            ht_insert_table(fontmap, tfm_name, strlen(tfm_name), mrec);
+            free(tfm_name);
+        }
+        free(fnt_name);
+        free(sfd_name);
     }
 
     mrec = NEW(1, fontmap_rec);
     pdf_copy_fontmap_record(mrec, vp);
     if (mrec->map_name && !strcmp(kp, mrec->map_name)) {
-	free(mrec->map_name);
-	mrec->map_name = NULL;
+        free(mrec->map_name);
+        mrec->map_name = NULL;
     }
     ht_insert_table(fontmap, kp, strlen(kp), mrec);
 
     if (verbose > 3)
-	dpx_message("\n");
+        dpx_message("\n");
 
     return mrec;
 }
@@ -891,34 +891,34 @@ pdf_read_fontmap_line (fontmap_rec *mrec, const char *mline, int mline_len, int 
 
     skip_blank(&p, endptr);
     if (p >= endptr)
-	return -1;
+        return -1;
 
     q = parse_string_value(&p, endptr);
     if (!q)
-	return -1;
+        return -1;
 
     if (format > 0) /* DVIPDFM format */
-	error = fontmap_parse_mapdef_dpm(mrec, p, endptr);
+        error = fontmap_parse_mapdef_dpm(mrec, p, endptr);
     else /* DVIPS/pdfTeX format */
-	error = fontmap_parse_mapdef_dps(mrec, p, endptr);
+        error = fontmap_parse_mapdef_dps(mrec, p, endptr);
     if (!error) {
-	char  *fnt_name, *sfd_name = NULL;
-	fnt_name = chop_sfd_name(q, &sfd_name);
-	if (fnt_name && sfd_name) {
-	    if (!mrec->font_name) {
-		/* In the case of subfonts, the base name (before the character '@')
-		 * will be used as a font_name by default.
-		 * Otherwise tex_name will be used as a font_name by default.
-		 */
-		mrec->font_name = fnt_name;
-	    } else {
-		free(fnt_name);
-	    }
-	    if (mrec->charmap.sfd_name)
-		free(mrec->charmap.sfd_name);
-	    mrec->charmap.sfd_name = sfd_name ;
-	}
-	fill_in_defaults(mrec, q);
+        char  *fnt_name, *sfd_name = NULL;
+        fnt_name = chop_sfd_name(q, &sfd_name);
+        if (fnt_name && sfd_name) {
+            if (!mrec->font_name) {
+                /* In the case of subfonts, the base name (before the character '@')
+                 * will be used as a font_name by default.
+                 * Otherwise tex_name will be used as a font_name by default.
+                 */
+                mrec->font_name = fnt_name;
+            } else {
+                free(fnt_name);
+            }
+            if (mrec->charmap.sfd_name)
+                free(mrec->charmap.sfd_name);
+            mrec->charmap.sfd_name = sfd_name ;
+        }
+        fill_in_defaults(mrec, q);
     }
     free(q);
 
@@ -940,7 +940,7 @@ is_pdfm_mapline (const char *mline) /* NULL terminated. */
     const char *p, *endptr;
 
     if (strchr(mline, '"') || strchr(mline, '<'))
-	return -1; /* DVIPS/pdfTeX format */
+        return -1; /* DVIPS/pdfTeX format */
 
     p      = mline;
     endptr = p + strlen(mline);
@@ -948,10 +948,10 @@ is_pdfm_mapline (const char *mline) /* NULL terminated. */
     skip_blank(&p, endptr);
 
     while (p < endptr) {
-	/* Break if '-' preceeded by blanks is found. (DVIPDFM format) */
-	if (*p == '-') return 1;
-	for (n++; p < endptr && !ISBLANK(*p); p++);
-	skip_blank(&p, endptr);
+        /* Break if '-' preceeded by blanks is found. (DVIPDFM format) */
+        if (*p == '-') return 1;
+        for (n++; p < endptr && !ISBLANK(*p); p++);
+        skip_blank(&p, endptr);
     }
 
     /* Two entries: TFM_NAME PS_NAME only (DVIPS format)
@@ -973,66 +973,66 @@ pdf_load_fontmap_file (const char *filename, int mode)
     assert(fontmap);
 
     if (verbose)
-	dpx_message("<FONTMAP:");
+        dpx_message("<FONTMAP:");
 
     handle = dpx_tt_open(filename, ".map", kpse_fontmap_format);
     if (handle == NULL) {
-	dpx_warning("Couldn't open font map file \"%s\".", filename);
-	return  -1;
+        dpx_warning("Couldn't open font map file \"%s\".", filename);
+        return  -1;
     }
 
     while (!error && (p = tt_readline(work_buffer, WORK_BUFFER_SIZE, handle)) != NULL) {
-	int m;
+        int m;
 
-	lpos++;
-	llen  = strlen(work_buffer);
-	endptr = p + llen;
+        lpos++;
+        llen  = strlen(work_buffer);
+        endptr = p + llen;
 
-	skip_blank(&p, endptr);
-	if (p == endptr)
-	    continue;
+        skip_blank(&p, endptr);
+        if (p == endptr)
+            continue;
 
-	m = is_pdfm_mapline(p);
+        m = is_pdfm_mapline(p);
 
-	if (format * m < 0) { /* mismatch */
-	    dpx_warning("Found a mismatched fontmap line %d from %s.", lpos, filename);
-	    dpx_warning("-- Ignore the current input buffer: %s", p);
-	    continue;
-	} else
-	    format += m;
+        if (format * m < 0) { /* mismatch */
+            dpx_warning("Found a mismatched fontmap line %d from %s.", lpos, filename);
+            dpx_warning("-- Ignore the current input buffer: %s", p);
+            continue;
+        } else
+            format += m;
 
-	mrec  = NEW(1, fontmap_rec);
-	pdf_init_fontmap_record(mrec);
+        mrec  = NEW(1, fontmap_rec);
+        pdf_init_fontmap_record(mrec);
 
-	/* format > 0: DVIPDFM, format <= 0: DVIPS/pdfTeX */
-	error = pdf_read_fontmap_line(mrec, p, llen, format);
-	if (error) {
-	    dpx_warning("Invalid map record in fontmap line %d from %s.", lpos, filename);
-	    dpx_warning("-- Ignore the current input buffer: %s", p);
-	    pdf_clear_fontmap_record(mrec);
-	    free(mrec);
-	    continue;
-	} else {
-	    switch (mode) {
-	    case FONTMAP_RMODE_REPLACE:
-		pdf_insert_fontmap_record(mrec->map_name, mrec);
-		break;
-	    case FONTMAP_RMODE_APPEND:
-		pdf_append_fontmap_record(mrec->map_name, mrec);
-		break;
-	    case FONTMAP_RMODE_REMOVE:
-		pdf_remove_fontmap_record(mrec->map_name);
-		break;
-	    }
-	}
-	pdf_clear_fontmap_record(mrec);
-	free(mrec);
+        /* format > 0: DVIPDFM, format <= 0: DVIPS/pdfTeX */
+        error = pdf_read_fontmap_line(mrec, p, llen, format);
+        if (error) {
+            dpx_warning("Invalid map record in fontmap line %d from %s.", lpos, filename);
+            dpx_warning("-- Ignore the current input buffer: %s", p);
+            pdf_clear_fontmap_record(mrec);
+            free(mrec);
+            continue;
+        } else {
+            switch (mode) {
+            case FONTMAP_RMODE_REPLACE:
+                pdf_insert_fontmap_record(mrec->map_name, mrec);
+                break;
+            case FONTMAP_RMODE_APPEND:
+                pdf_append_fontmap_record(mrec->map_name, mrec);
+                break;
+            case FONTMAP_RMODE_REMOVE:
+                pdf_remove_fontmap_record(mrec->map_name);
+                break;
+            }
+        }
+        pdf_clear_fontmap_record(mrec);
+        free(mrec);
     }
 
     ttstub_input_close(handle);
 
     if (verbose)
-	dpx_message(">");
+        dpx_message(">");
 
     return error;
 }
@@ -1052,7 +1052,7 @@ pdf_insert_native_fontmap_record (const char *path, uint32_t index,
     sprintf(fontmap_key, "%s/%d/%c/%d/%d/%d", path, index, layout_dir == 0 ? 'H' : 'V', extend, slant, embolden);
 
     if (verbose)
-	dpx_message("<NATIVE-FONTMAP:%s", fontmap_key);
+        dpx_message("<NATIVE-FONTMAP:%s", fontmap_key);
 
     mrec  = NEW(1, fontmap_rec);
     pdf_init_fontmap_record(mrec);
@@ -1062,7 +1062,7 @@ pdf_insert_native_fontmap_record (const char *path, uint32_t index,
     mrec->font_name = mstrdup(path);
     mrec->opt.index = index;
     if (layout_dir != 0)
-	mrec->opt.flags |= FONTMAP_OPT_VERT;
+        mrec->opt.flags |= FONTMAP_OPT_VERT;
 
     fill_in_defaults(mrec, fontmap_key);
 
@@ -1075,7 +1075,7 @@ pdf_insert_native_fontmap_record (const char *path, uint32_t index,
     free(mrec);
 
     if (verbose)
-	dpx_message(">");
+        dpx_message(">");
 
     return ret;
 }
@@ -1099,20 +1099,20 @@ test_subfont (const char *tfm_name, const char *map_name, const char *sfd_name)
     /* until first occurence of '@' */
     for ( ; *p && *q && *p == *q && *p != '@'; p++, q++);
     if (*p != '@')
-	return  0;
+        return  0;
     p++;
     /* compare sfd_name (should be always true here) */
     if (strlen(p) <= strlen(sfd_name) ||
-	memcmp(p, sfd_name, strlen(sfd_name)) ||
-	p[strlen(sfd_name)] != '@')
-	return  0;
+        memcmp(p, sfd_name, strlen(sfd_name)) ||
+        p[strlen(sfd_name)] != '@')
+        return  0;
     /* check tfm_name follows second '@' */
     p += strlen(sfd_name) + 1;
     if (*p) {
-	char  *r = (char *) tfm_name;
-	r += strlen(tfm_name) - strlen(p);
-	if (strcmp(r, p))
-	    return  0;
+        char  *r = (char *) tfm_name;
+        r += strlen(tfm_name) - strlen(p);
+        if (strcmp(r, p))
+            return  0;
     }
     /* Now 'p' is located at next to SFD name terminator
      * (second '@') in map_name and 'q' is at first char
@@ -1120,16 +1120,16 @@ test_subfont (const char *tfm_name, const char *map_name, const char *sfd_name)
      */
     n  = strlen(q) - strlen(p); /* length of subfont_id string */
     if (n <= 0)
-	return  0;
+        return  0;
     /* check if n-length substring 'q' is valid as subfont ID */
     ids = sfd_get_subfont_ids(sfd_name, &m);
     if (!ids)
-	return  0;
+        return  0;
     while (!r && m-- > 0) {
-	if (strlen(ids[m]) == n &&
-	    !memcmp(q, ids[m], n)) {
-	    r = 1;
-	}
+        if (strlen(ids[m]) == n &&
+            !memcmp(q, ids[m], n)) {
+            r = 1;
+        }
     }
 
     return  r;
@@ -1143,7 +1143,7 @@ pdf_lookup_fontmap_record (const char *tfm_name)
     fontmap_rec *mrec = NULL;
 
     if (fontmap && tfm_name)
-	mrec = ht_lookup_table(fontmap, tfm_name, strlen(tfm_name));
+        mrec = ht_lookup_table(fontmap, tfm_name, strlen(tfm_name));
 
     return  mrec;
 }
@@ -1160,8 +1160,8 @@ void
 pdf_close_fontmaps (void)
 {
     if (fontmap) {
-	ht_clear_table(fontmap);
-	free(fontmap);
+        ht_clear_table(fontmap);
+        free(fontmap);
     }
     fontmap = NULL;
 
@@ -1192,7 +1192,7 @@ substr (const char **str, char stop)
 
     endptr = strchr(*str, stop);
     if (!endptr || endptr == *str)
-	return NULL;
+        return NULL;
     sstr = NEW(endptr-(*str)+1, char);
     memcpy(sstr, *str, endptr-(*str));
     sstr[endptr-(*str)] = '\0';
@@ -1222,60 +1222,60 @@ strip_options (const char *map_name, fontmap_opt *opt)
     opt->flags     = 0;
 
     if (*p == ':' && isdigit((unsigned char)*(p+1))) {
-	opt->index = (int) strtoul(p+1, &next, 10);
-	if (*next == ':')
-	    p = next + 1;
-	else {
-	    opt->index = 0;
-	}
+        opt->index = (int) strtoul(p+1, &next, 10);
+        if (*next == ':')
+            p = next + 1;
+        else {
+            opt->index = 0;
+        }
     }
     if (*p == '!') { /* no-embedding */
-	if (*(++p) == '\0')
-	    _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	opt->flags |= FONTMAP_OPT_NOEMBED;
+        if (*(++p) == '\0')
+            _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+        opt->flags |= FONTMAP_OPT_NOEMBED;
     }
 
     if ((next = strchr(p, CID_MAPREC_CSI_DELIM)) != NULL) {
-	if (next == p)
-	    _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	font_name = substr(&p, CID_MAPREC_CSI_DELIM);
-	have_csi  = 1;
+        if (next == p)
+            _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+        font_name = substr(&p, CID_MAPREC_CSI_DELIM);
+        have_csi  = 1;
     } else if ((next = strchr(p, ',')) != NULL) {
-	if (next == p)
-	    _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	font_name = substr(&p, ',');
-	have_style = 1;
+        if (next == p)
+            _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+        font_name = substr(&p, ',');
+        have_style = 1;
     } else {
-	font_name = NEW(strlen(p)+1, char);
-	strcpy(font_name, p);
+        font_name = NEW(strlen(p)+1, char);
+        strcpy(font_name, p);
     }
 
     if (have_csi) {
-	if ((next = strchr(p, ',')) != NULL) {
-	    opt->charcoll = substr(&p, ',');
-	    have_style = 1;
-	} else if (p[0] == '\0') {
-	    _tt_abort("Invalid map record: %s.", map_name);
-	} else {
-	    opt->charcoll = NEW(strlen(p)+1, char);
-	    strcpy(opt->charcoll, p);
-	}
+        if ((next = strchr(p, ',')) != NULL) {
+            opt->charcoll = substr(&p, ',');
+            have_style = 1;
+        } else if (p[0] == '\0') {
+            _tt_abort("Invalid map record: %s.", map_name);
+        } else {
+            opt->charcoll = NEW(strlen(p)+1, char);
+            strcpy(opt->charcoll, p);
+        }
     }
 
     if (have_style) {
-	if (!strncmp(p, "BoldItalic", 10)) {
-	    if (*(p+10))
-		_tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	    opt->style = FONTMAP_STYLE_BOLDITALIC;
-	} else if (!strncmp(p, "Bold", 4)) {
-	    if (*(p+4))
-		_tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	    opt->style = FONTMAP_STYLE_BOLD;
-	} else if (!strncmp(p, "Italic", 6)) {
-	    if (*(p+6))
-		_tt_abort("Invalid map record: %s (--> %s)", map_name, p);
-	    opt->style = FONTMAP_STYLE_ITALIC;
-	}
+        if (!strncmp(p, "BoldItalic", 10)) {
+            if (*(p+10))
+                _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+            opt->style = FONTMAP_STYLE_BOLDITALIC;
+        } else if (!strncmp(p, "Bold", 4)) {
+            if (*(p+4))
+                _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+            opt->style = FONTMAP_STYLE_BOLD;
+        } else if (!strncmp(p, "Italic", 6)) {
+            if (*(p+6))
+                _tt_abort("Invalid map record: %s (--> %s)", map_name, p);
+            opt->style = FONTMAP_STYLE_ITALIC;
+        }
     }
 
     return font_name;
@@ -1288,61 +1288,61 @@ dump_fontmap_rec (const char *key, const fontmap_rec *mrec)
     fontmap_opt *opt = (fontmap_opt *) &mrec->opt;
 
     if (mrec->map_name)
-	fprintf(stdout, "  <!-- subfont");
+        fprintf(stdout, "  <!-- subfont");
     else
-	fprintf(stdout, "  <insert");
+        fprintf(stdout, "  <insert");
     fprintf(stdout, " id=\"%s\"", key);
     if (mrec->map_name)
-	fprintf(stdout, " map-name=\"%s\"", mrec->map_name);
+        fprintf(stdout, " map-name=\"%s\"", mrec->map_name);
     if (mrec->enc_name)
-	fprintf(stdout, " enc-name=\"%s\"",  mrec->enc_name);
+        fprintf(stdout, " enc-name=\"%s\"",  mrec->enc_name);
     if (mrec->font_name)
-	fprintf(stdout, " font-name=\"%s\"", mrec->font_name);
+        fprintf(stdout, " font-name=\"%s\"", mrec->font_name);
     if (mrec->charmap.sfd_name && mrec->charmap.subfont_id) {
-	fprintf(stdout, " charmap=\"sfd:%s,%s\"",
-		mrec->charmap.sfd_name, mrec->charmap.subfont_id);
+        fprintf(stdout, " charmap=\"sfd:%s,%s\"",
+                mrec->charmap.sfd_name, mrec->charmap.subfont_id);
     }
     if (opt->slant != 0.0)
-	fprintf(stdout, " font-slant=\"%g\"", opt->slant);
+        fprintf(stdout, " font-slant=\"%g\"", opt->slant);
     if (opt->extend != 1.0)
-	fprintf(stdout, " font-extend=\"%g\"", opt->extend);
+        fprintf(stdout, " font-extend=\"%g\"", opt->extend);
     if (opt->charcoll)
-	fprintf(stdout, " glyph-order=\"%s\"", opt->charcoll);
+        fprintf(stdout, " glyph-order=\"%s\"", opt->charcoll);
     if (opt->tounicode)
-	fprintf(stdout, " tounicode=\"%s\"", opt->tounicode);
+        fprintf(stdout, " tounicode=\"%s\"", opt->tounicode);
     if (opt->index != 0)
-	fprintf(stdout, " ttc-index=\"%d\"", opt->index);
+        fprintf(stdout, " ttc-index=\"%d\"", opt->index);
     if (opt->flags & FONTMAP_OPT_NOEMBED)
-	fprintf(stdout, " embedding=\"no\"");
+        fprintf(stdout, " embedding=\"no\"");
     if (opt->mapc >= 0) {
-	fprintf(stdout, " charmap=\"pad:");
-	if (opt->mapc > 0xffff)
-	    fprintf(stdout, "%02x %02x", (opt->mapc >> 16) & 0xff, (opt->mapc >> 8) & 0xff);
-	else
-	    fprintf(stdout, "%02x", (opt->mapc >> 8) & 0xff);
-	fprintf(stdout, "\"");
+        fprintf(stdout, " charmap=\"pad:");
+        if (opt->mapc > 0xffff)
+            fprintf(stdout, "%02x %02x", (opt->mapc >> 16) & 0xff, (opt->mapc >> 8) & 0xff);
+        else
+            fprintf(stdout, "%02x", (opt->mapc >> 8) & 0xff);
+        fprintf(stdout, "\"");
     }
     if (opt->flags & FONTMAP_OPT_VERT)
-	fprintf(stdout, " writing-mode=\"vertical\"");
+        fprintf(stdout, " writing-mode=\"vertical\"");
     if (opt->style != FONTMAP_STYLE_NONE) {
-	fprintf(stdout, " font-style=\"");
-	switch (opt->style) {
-	case FONTMAP_STYLE_BOLD:
-	    fprintf(stdout, "bold");
-	    break;
-	case FONTMAP_STYLE_ITALIC:
-	    fprintf(stdout, "italic");
-	    break;
-	case FONTMAP_STYLE_BOLDITALIC:
-	    fprintf(stdout, "bolditalic");
-	    break;
-	}
-	fprintf(stdout, "\"");
+        fprintf(stdout, " font-style=\"");
+        switch (opt->style) {
+        case FONTMAP_STYLE_BOLD:
+            fprintf(stdout, "bold");
+            break;
+        case FONTMAP_STYLE_ITALIC:
+            fprintf(stdout, "italic");
+            break;
+        case FONTMAP_STYLE_BOLDITALIC:
+            fprintf(stdout, "bolditalic");
+            break;
+        }
+        fprintf(stdout, "\"");
     }
     if (mrec->map_name)
-	fprintf(stdout, " / -->\n");
+        fprintf(stdout, " / -->\n");
     else
-	fprintf(stdout, " />\n");
+        fprintf(stdout, " />\n");
 }
 
 void
@@ -1354,20 +1354,20 @@ dump_fontmaps (void)
     int            kl;
 
     if (!fontmap)
-	return;
+        return;
 
     fprintf(stdout, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     fprintf(stdout, "<!DOCTYPE fontmap SYSTEM \"fontmap.dtd\">\n");
     fprintf(stdout, "<fontmap id=\"%s\">\n", "foo");
     if (ht_set_iter(fontmap, &iter) == 0) {
-	do {
-	    kp   = ht_iter_getkey(&iter, &kl);
-	    mrec = ht_iter_getval(&iter);
-	    if (kl > 127)
-		continue;
-	    memcpy(key, kp, kl); key[kl] = 0;
-	    dump_fontmap_rec(key, mrec);
-	} while (!ht_iter_next(&iter));
+        do {
+            kp   = ht_iter_getkey(&iter, &kl);
+            mrec = ht_iter_getval(&iter);
+            if (kl > 127)
+                continue;
+            memcpy(key, kp, kl); key[kl] = 0;
+            dump_fontmap_rec(key, mrec);
+        } while (!ht_iter_next(&iter));
     }
     ht_clear_iter(&iter);
     fprintf(stdout, "</fontmap>\n");
@@ -1390,45 +1390,45 @@ test_fontmap_main (int argc, char *argv[])
     char  *key = NULL;
 
     for (;;) {
-	int  c, optidx = 0;
-	static struct option long_options[] = {
-	    {"lookup", 1, 0, 'l'},
-	    {"help",   0, 0, 'h'},
-	    {0, 0, 0, 0}
-	};
-	c = getopt_long(argc, argv, "l:h", long_options, &optidx);
-	if (c == -1)
-	    break;
+        int  c, optidx = 0;
+        static struct option long_options[] = {
+            {"lookup", 1, 0, 'l'},
+            {"help",   0, 0, 'h'},
+            {0, 0, 0, 0}
+        };
+        c = getopt_long(argc, argv, "l:h", long_options, &optidx);
+        if (c == -1)
+            break;
 
-	switch (c) {
-	case  'l':
-	    key = optarg;
-	    break;
-	case  'h':
-	    test_fontmap_help();
-	    return  0;
-	    break;
-	default:
-	    test_fontmap_help();
-	    return  -1;
-	    break;
-	}
+        switch (c) {
+        case  'l':
+            key = optarg;
+            break;
+        case  'h':
+            test_fontmap_help();
+            return  0;
+            break;
+        default:
+            test_fontmap_help();
+            return  -1;
+            break;
+        }
     }
 
     pdf_init_fontmaps();
     for (i = optind; i < argc; i++)
-	pdf_load_fontmap_file(argv[i], FONTMAP_RMODE_REPLACE);
+        pdf_load_fontmap_file(argv[i], FONTMAP_RMODE_REPLACE);
 
     if (key == NULL)
-	dump_fontmaps();
+        dump_fontmaps();
     else {
-	fontmap_rec *mrec;
-	mrec = pdf_lookup_fontmap_record(key);
-	if (mrec)
-	    dump_fontmap_rec(key, mrec);
-	else {
-	    dpx_warning("Fontmap entry \"%s\" not found.", key);
-	}
+        fontmap_rec *mrec;
+        mrec = pdf_lookup_fontmap_record(key);
+        if (mrec)
+            dump_fontmap_rec(key, mrec);
+        else {
+            dpx_warning("Fontmap entry \"%s\" not found.", key);
+        }
     }
     pdf_close_fontmaps();
 

--- a/tectonic/dpx-fontmap.h
+++ b/tectonic/dpx-fontmap.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-jp2image.c
+++ b/tectonic/dpx-jp2image.c
@@ -212,9 +212,9 @@ scan_cdef (ximage_info *info, int *smask, FILE *fp, unsigned int size)
       opacity_channels++;
     }
   }
- 
+
   if (opacity_channels == 1)
-    *smask = have_type0 ? 1 : 0; 
+    *smask = have_type0 ? 1 : 0;
   else if (opacity_channels > 1) {
     dpx_warning("JPEG2000: Unsupported transparency type. (ignored)");
   }

--- a/tectonic/dpx-jp2image.h
+++ b/tectonic/dpx-jp2image.h
@@ -29,7 +29,7 @@
 extern int check_for_jp2     (FILE *fp);
 extern int jp2_include_image (pdf_ximage *ximage, FILE *fp);
 extern int jp2_get_bbox (FILE *fp, int *width, int *height,
-			double *xdensity, double *ydensity);
+                        double *xdensity, double *ydensity);
 
 #endif /* _JP2IMAGE_H_ */
 

--- a/tectonic/dpx-jpegimage.c
+++ b/tectonic/dpx-jpegimage.c
@@ -616,10 +616,10 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
 
     buffer = malloc (length);
     if (buffer == NULL)
-	_tt_abort("malloc of %d bytes failed", (int) length);
+        _tt_abort("malloc of %d bytes failed", (int) length);
 
     if (ttstub_input_read (handle, buffer, length) != length)
-	goto err;
+        goto err;
 
     p = buffer;
     endptr = buffer + length;
@@ -628,7 +628,7 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
         ++p;
 
     if (p + 8 >= endptr)
-	goto err;
+        goto err;
 
     tiff_header = p;
 
@@ -637,16 +637,16 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
     else if (*p == 'I' && *(p+1) == 'I')
         bigendian = JPEG_EXIF_LITTLEENDIAN;
     else {
-	dpx_warning("JPEG: Invalid value in Exif TIFF header.");
-	goto err;
+        dpx_warning("JPEG: Invalid value in Exif TIFF header.");
+        goto err;
     }
 
     p += 2;
 
     i = read_exif_bytes (&p, 2, bigendian);
     if (i != 42) {
-	dpx_warning("JPEG: Invalid value in Exif TIFF header.");
-	goto err;
+        dpx_warning("JPEG: Invalid value in Exif TIFF header.");
+        goto err;
     }
 
     i = read_exif_bytes (&p, 4, bigendian);
@@ -684,7 +684,7 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
             break;
         case JPEG_EXIF_TYPE_ASCII:
         default:
-	    value = 0;
+            value = 0;
             p += 4;
             break;
         }
@@ -713,8 +713,8 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
     /* Do not overwrite if already specified in JFIF */
 
     if (info->xdpi < 0.1 && info->ydpi < 0.1) {
-	info->xdpi = xres * res_unit;
-	info->ydpi = yres * res_unit;
+        info->xdpi = xres * res_unit;
+        info->ydpi = yres * res_unit;
     }
 
 err:
@@ -868,13 +868,13 @@ JPEG_copy_stream (struct JPEG_info *j_info, pdf_obj *stream, rust_input_handle_t
     }
 
     {
-	size_t total_size = ttstub_input_get_size(handle);
-	size_t pos = ttstub_input_seek(handle, 0, SEEK_CUR);
+        size_t total_size = ttstub_input_get_size(handle);
+        size_t pos = ttstub_input_seek(handle, 0, SEEK_CUR);
 
-	while ((length = ttstub_input_read(handle, work_buffer, MIN(WORK_BUFFER_SIZE, total_size - pos))) > 0) {
-	    pdf_add_stream(stream, work_buffer, length);
-	    pos += length;
-	}
+        while ((length = ttstub_input_read(handle, work_buffer, MIN(WORK_BUFFER_SIZE, total_size - pos))) > 0) {
+            pdf_add_stream(stream, work_buffer, length);
+            pos += length;
+        }
     }
 
     return (found_SOFn ? 0 : -1);

--- a/tectonic/dpx-jpegimage.h
+++ b/tectonic/dpx-jpegimage.h
@@ -30,7 +30,7 @@
 extern int check_for_jpeg     (rust_input_handle_t handle);
 extern int jpeg_include_image (pdf_ximage *ximage, rust_input_handle_t handle);
 extern int jpeg_get_bbox (rust_input_handle_t handle, int *width, int *height,
-			  double *xdensity, double *ydensity);
+                          double *xdensity, double *ydensity);
 
 #endif /* _JPEGIMAGE_H_ */
 

--- a/tectonic/dpx-mem.c
+++ b/tectonic/dpx-mem.c
@@ -2,25 +2,25 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
 
-#include <stdio.h>	
+#include <stdio.h>
 #include <stdlib.h>
 
 #include <tectonic/dpx-system.h>

--- a/tectonic/dpx-mem.h
+++ b/tectonic/dpx-mem.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-mfileio.h
+++ b/tectonic/dpx-mfileio.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-mpost.c
+++ b/tectonic/dpx-mpost.c
@@ -222,23 +222,23 @@ mps_scan_bbox (const char **pp, const char *endptr, pdf_rect *bbox)
   /* Scan for bounding box record */
   while (*pp < endptr && **pp == '%') {
     if (*pp + 14 < endptr &&
-	!strncmp(*pp, "%%BoundingBox:", 14)) {
+        !strncmp(*pp, "%%BoundingBox:", 14)) {
 
       *pp += 14;
 
       for (i = 0; i < 4; i++) {
-	skip_white(pp, endptr);
-	number = parse_number(pp, endptr);
-	if (!number) {
-	  break;
-	}
-	values[i] = atof(number);
-	free(number);
+        skip_white(pp, endptr);
+        number = parse_number(pp, endptr);
+        if (!number) {
+          break;
+        }
+        values[i] = atof(number);
+        free(number);
       }
       if (i < 4) {
-	return -1;
+        return -1;
       } else {
-	/* The new xetex.def and dvipdfmx.def require bbox->llx = bbox->lly = 0.  */
+        /* The new xetex.def and dvipdfmx.def require bbox->llx = bbox->lly = 0.  */
         if (translate_origin) {
           bbox->llx = 0;
           bbox->lly = 0;
@@ -432,7 +432,7 @@ static struct operators
   {"setcmykcolor", SETCMYKCOLOR},
 
   {"currentpoint", CURRENTPOINT}, /* This is here for rotate support
-				     in graphics package-not MP support */
+                                     in graphics package-not MP support */
   {"dtransform",   DTRANSFORM},
   {"idtransform",  IDTRANSFORM},
 
@@ -594,8 +594,8 @@ cvr_array (pdf_obj *array, double *values, int count)
     while (count-- > 0) {
       tmp = pdf_get_array(array, count);
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
-	dpx_warning("mpost: Not a number!");
-	break;
+        dpx_warning("mpost: Not a number!");
+        break;
       }
       values[count] = pdf_number_value(tmp);
     }
@@ -643,25 +643,25 @@ do_findfont (void)
   if (!font_name)
     return 1;
   else if (PDF_OBJ_STRINGTYPE(font_name) ||
-	   PDF_OBJ_NAMETYPE(font_name)) {
+           PDF_OBJ_NAMETYPE(font_name)) {
     /* Do not check the existence...
      * The reason for this is that we cannot locate PK font without
      * font scale.
      */
     font_dict = pdf_new_dict();
     pdf_add_dict(font_dict,
-		 pdf_new_name("Type"), pdf_new_name("Font"));
+                 pdf_new_name("Type"), pdf_new_name("Font"));
     if (PDF_OBJ_STRINGTYPE(font_name)) {
       pdf_add_dict(font_dict,
-		   pdf_new_name("FontName"),
-		   pdf_new_name(pdf_string_value(font_name)));
+                   pdf_new_name("FontName"),
+                   pdf_new_name(pdf_string_value(font_name)));
       pdf_release_obj(font_name);
     } else {
       pdf_add_dict(font_dict,
-		   pdf_new_name("FontName"), font_name);
+                   pdf_new_name("FontName"), font_name);
     }
     pdf_add_dict(font_dict,
-		 pdf_new_name("FontScale"), pdf_new_number(1.0));
+                 pdf_new_name("FontScale"), pdf_new_number(1.0));
 
     if (top_stack < PS_STACK_SIZE) {
       stack[top_stack++] = font_dict;
@@ -749,14 +749,14 @@ do_currentfont (void)
   } else {
     font_dict = pdf_new_dict();
     pdf_add_dict(font_dict,
-		 pdf_new_name("Type"),
-		 pdf_new_name("Font"));
+                 pdf_new_name("Type"),
+                 pdf_new_name("Font"));
     pdf_add_dict(font_dict,
-		 pdf_new_name("FontName"),
-		 pdf_new_name(font->font_name));
+                 pdf_new_name("FontName"),
+                 pdf_new_name(font->font_name));
     pdf_add_dict(font_dict,
-		 pdf_new_name("FontScale"),
-		 pdf_new_number(font->pt_size));
+                 pdf_new_name("FontScale"),
+                 pdf_new_number(font->pt_size));
     if (top_stack < PS_STACK_SIZE) {
       stack[top_stack++] = font_dict;
     } else {
@@ -819,16 +819,16 @@ do_show (void)
       ustr[2*i  ] = uch >> 8;
       ustr[2*i+1] = uch & 0xff;
       if (font->tfm_id >= 0) {
-	text_width += tfm_get_width(font->tfm_id, strptr[i]);
+        text_width += tfm_get_width(font->tfm_id, strptr[i]);
       }
     }
     text_width *= font->pt_size;
 
     pdf_dev_set_string((spt_t)(cp.x * dev_unit_dviunit()),
-		       (spt_t)(cp.y * dev_unit_dviunit()),
-		       ustr, length * 2,
-		       (spt_t)(text_width*dev_unit_dviunit()),
-		       font->font_id, 0);
+                       (spt_t)(cp.y * dev_unit_dviunit()),
+                       ustr, length * 2,
+                       (spt_t)(text_width*dev_unit_dviunit()),
+                       font->font_id, 0);
     free(ustr);
   } else {
 #define FWBASE ((double) (1<<20))
@@ -837,10 +837,10 @@ do_show (void)
       text_width *= font->pt_size;
     }
     pdf_dev_set_string((spt_t)(cp.x * dev_unit_dviunit()),
-		       (spt_t)(cp.y * dev_unit_dviunit()),
-		       strptr, length,
-		       (spt_t)(text_width*dev_unit_dviunit()),
-		       font->font_id, 0);
+                       (spt_t)(cp.y * dev_unit_dviunit()),
+                       strptr, length,
+                       (spt_t)(text_width*dev_unit_dviunit()),
+                       font->font_id, 0);
   }
 
   if (pdf_dev_get_font_wmode(font->font_id)) {
@@ -899,7 +899,7 @@ do_texfig_operator (int opcode, double x_user, double y_user)
 
       sprintf(resname, "__tf%d__", count);
       xobj_id = pdf_doc_begin_grabbing(resname,
-				       fig_p.bbox.llx, fig_p.bbox.ury, &fig_p.bbox);
+                                       fig_p.bbox.llx, fig_p.bbox.ury, &fig_p.bbox);
 
       in_tfig = 1;
       count++;
@@ -1042,15 +1042,15 @@ do_operator (const char *token, double x_user, double y_user)
     error = pop_get_numbers(values, 6);
     if (!error)
       error = pdf_dev_curveto(values[0], values[1],
-			      values[2], values[3],
-			      values[4], values[5]);
+                              values[2], values[3],
+                              values[4], values[5]);
     break;
   case RCURVETO:
     error = pop_get_numbers(values, 6);
     if (!error)
       error = pdf_dev_rcurveto(values[0], values[1],
-			       values[2], values[3],
-			       values[4], values[5]);
+                               values[2], values[3],
+                               values[4], values[5]);
     break;
   case CLOSEPATH:
     error = pdf_dev_closepath();
@@ -1059,15 +1059,15 @@ do_operator (const char *token, double x_user, double y_user)
     error = pop_get_numbers(values, 5);
     if (!error)
       error = pdf_dev_arc(values[0], values[1],
-			  values[2], /* rad */
-			  values[3], values[4]);
+                          values[2], /* rad */
+                          values[3], values[4]);
     break;
   case ARCN:
     error = pop_get_numbers(values, 5);
     if (!error)
       error = pdf_dev_arcn(values[0], values[1],
-			   values[2], /* rad */
-			   values[3], values[4]);
+                           values[2], /* rad */
+                           values[3], values[4]);
     break;
 
   case NEWPATH:
@@ -1106,9 +1106,9 @@ do_operator (const char *token, double x_user, double y_user)
       dpx_warning("Missing array before \"concat\".");
     else {
       pdf_setmatrix(&matrix,
-		    values[0], values[1],
-		    values[2], values[3],
-		    values[4], values[5]);
+                    values[0], values[1],
+                    values[2], values[3],
+                    values[4], values[5]);
       error = pdf_dev_concat(&matrix);
     }
     break;
@@ -1117,11 +1117,11 @@ do_operator (const char *token, double x_user, double y_user)
     if (!error) {
       switch (mp_cmode) {
       default:
-	pdf_setmatrix(&matrix,
-		      values[0], 0.0,
-		      0.0      , values[1],
-		      0.0      , 0.0);
-	break;
+        pdf_setmatrix(&matrix,
+                      values[0], 0.0,
+                      0.0      , values[1],
+                      0.0      , 0.0);
+        break;
       }
 
       error = pdf_dev_concat(&matrix);
@@ -1136,17 +1136,17 @@ do_operator (const char *token, double x_user, double y_user)
       switch (mp_cmode) {
       case MP_CMODE_DVIPSK:
       case MP_CMODE_MPOST: /* Really? */
-	pdf_setmatrix(&matrix,
-		      cos(values[0]), -sin(values[0]),
-		      sin(values[0]),  cos(values[0]),
-		      0.0,             0.0);
-	break;
+        pdf_setmatrix(&matrix,
+                      cos(values[0]), -sin(values[0]),
+                      sin(values[0]),  cos(values[0]),
+                      0.0,             0.0);
+        break;
       default:
-	pdf_setmatrix(&matrix,
-		      cos(values[0]) , sin(values[0]),
-		      -sin(values[0]), cos(values[0]),
-		      0.0,             0.0);
-	break;
+        pdf_setmatrix(&matrix,
+                      cos(values[0]) , sin(values[0]),
+                      -sin(values[0]), cos(values[0]),
+                      0.0,             0.0);
+        break;
       }
       error = pdf_dev_concat(&matrix);
     }
@@ -1155,9 +1155,9 @@ do_operator (const char *token, double x_user, double y_user)
     error = pop_get_numbers(values, 2);
     if (!error) {
       pdf_setmatrix(&matrix,
-		    1.0,       0.0,
-		    0.0,       1.0,
-		    values[0], values[1]);
+                    1.0,       0.0,
+                    0.0,       1.0,
+                    values[0], values[1]);
       error = pdf_dev_concat(&matrix);
     }
     break;
@@ -1173,30 +1173,30 @@ do_operator (const char *token, double x_user, double y_user)
       offset  = values[0];
       pattern = POP_STACK();
       if (!PDF_OBJ_ARRAYTYPE(pattern)) {
-	if (pattern)
-	  pdf_release_obj(pattern);
-	error = 1;
-	break;
+        if (pattern)
+          pdf_release_obj(pattern);
+        error = 1;
+        break;
       }
       num_dashes = pdf_array_length(pattern);
       if (num_dashes > PDF_DASH_SIZE_MAX) {
-	dpx_warning("Too many dashes...");
-	pdf_release_obj(pattern);
-	error = 1;
-	break;
+        dpx_warning("Too many dashes...");
+        pdf_release_obj(pattern);
+        error = 1;
+        break;
       }
       for (i = 0;
-	   i < num_dashes && !error ; i++) {
-	dash = pdf_get_array(pattern, i);
-	if (!PDF_OBJ_NUMBERTYPE(dash))
-	  error = 1;
-	else {
-	  dash_values[i] = pdf_number_value(dash);
-	}
+           i < num_dashes && !error ; i++) {
+        dash = pdf_get_array(pattern, i);
+        if (!PDF_OBJ_NUMBERTYPE(dash))
+          error = 1;
+        else {
+          dash_values[i] = pdf_number_value(dash);
+        }
       }
       pdf_release_obj(pattern);
       if (!error) {
-	error = pdf_dev_setdash(num_dashes, dash_values, offset);
+        error = pdf_dev_setdash(num_dashes, dash_values, offset);
       }
     }
     break;
@@ -1226,8 +1226,8 @@ do_operator (const char *token, double x_user, double y_user)
     /* Not handled properly */
     if (!error) {
       pdf_color_cmykcolor(&color,
-			  values[0], values[1],
-			  values[2], values[3]);
+                          values[0], values[1],
+                          values[2], values[3]);
       pdf_dev_set_strokingcolor(&color);
       pdf_dev_set_nonstrokingcolor(&color);
     }
@@ -1245,7 +1245,7 @@ do_operator (const char *token, double x_user, double y_user)
     error = pop_get_numbers(values, 3);
     if (!error) {
       pdf_color_rgbcolor(&color,
-			 values[0], values[1], values[2]);
+                         values[0], values[1], values[2]);
       pdf_dev_set_strokingcolor(&color);
       pdf_dev_set_nonstrokingcolor(&color);
     }
@@ -1268,35 +1268,35 @@ do_operator (const char *token, double x_user, double y_user)
 
       tmp = POP_STACK();
       if (PDF_OBJ_ARRAYTYPE(tmp)) {
-	error = cvr_array(tmp, values, 6); /* This does pdf_release_obj() */
-	tmp   = NULL;
-	if (error)
-	  break;
-	pdf_setmatrix(&matrix,
-		      values[0], values[1],
-		      values[2], values[3],
-		      values[4], values[5]);
-	tmp = POP_STACK();
-	has_matrix = 1;
+        error = cvr_array(tmp, values, 6); /* This does pdf_release_obj() */
+        tmp   = NULL;
+        if (error)
+          break;
+        pdf_setmatrix(&matrix,
+                      values[0], values[1],
+                      values[2], values[3],
+                      values[4], values[5]);
+        tmp = POP_STACK();
+        has_matrix = 1;
       }
 
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
-	error = 1;
-	break;
+        error = 1;
+        break;
       }
       cp.y = pdf_number_value(tmp);
       pdf_release_obj(tmp);
 
       tmp = POP_STACK();
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
-	error = 1;
-	break;
+        error = 1;
+        break;
       }
       cp.x = pdf_number_value(tmp);
       pdf_release_obj(tmp);
 
       if (!has_matrix) {
-	ps_dev_CTM(&matrix); /* Here, we need real PostScript CTM */
+        ps_dev_CTM(&matrix); /* Here, we need real PostScript CTM */
       }
       pdf_dev_dtransform(&cp, &matrix);
       PUSH(pdf_new_number(cp.x));
@@ -1310,35 +1310,35 @@ do_operator (const char *token, double x_user, double y_user)
 
       tmp = POP_STACK();
       if (PDF_OBJ_ARRAYTYPE(tmp)) {
-	error = cvr_array(tmp, values, 6); /* This does pdf_release_obj() */
-	tmp   = NULL;
-	if (error)
-	  break;
-	pdf_setmatrix(&matrix,
-		      values[0], values[1],
-		      values[2], values[3],
-		      values[4], values[5]);
-	tmp = POP_STACK();
-	has_matrix = 1;
+        error = cvr_array(tmp, values, 6); /* This does pdf_release_obj() */
+        tmp   = NULL;
+        if (error)
+          break;
+        pdf_setmatrix(&matrix,
+                      values[0], values[1],
+                      values[2], values[3],
+                      values[4], values[5]);
+        tmp = POP_STACK();
+        has_matrix = 1;
       }
 
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
-	error = 1;
-	break;
+        error = 1;
+        break;
       }
       cp.y = pdf_number_value(tmp);
       pdf_release_obj(tmp);
 
       tmp = POP_STACK();
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
-	error = 1;
-	break;
+        error = 1;
+        break;
       }
       cp.x = pdf_number_value(tmp);
       pdf_release_obj(tmp);
 
       if (!has_matrix) {
-	ps_dev_CTM(&matrix); /* Here, we need real PostScript CTM */
+        ps_dev_CTM(&matrix); /* Here, we need real PostScript CTM */
       }
       pdf_dev_idtransform(&cp, &matrix);
       PUSH(pdf_new_number(cp.x));
@@ -1421,45 +1421,45 @@ mp_parse_body (const char **start, const char *end, double x_user, double y_user
   skip_white(start, end);
   while (*start < end && !error) {
     if (isdigit((unsigned char)**start) ||
-	(*start < end - 1 &&
-	 (**start == '+' || **start == '-' || **start == '.' ))) {
+        (*start < end - 1 &&
+         (**start == '+' || **start == '-' || **start == '.' ))) {
       double value;
       char  *next;
 
       value = strtod(*start, &next);
       if (next < end && !strchr("<([{/%", *next) && !isspace((unsigned char)*next)) {
-	dpx_warning("Unkown PostScript operator.");
-	dump(*start, next);
-	error = 1;
+        dpx_warning("Unkown PostScript operator.");
+        dump(*start, next);
+        error = 1;
       } else {
-	PUSH(pdf_new_number(value));
-	*start = next;
+        PUSH(pdf_new_number(value));
+        *start = next;
       }
       /*
        * PDF parser can't handle PS operator inside arrays.
        * This shouldn't use parse_pdf_array().
        */
     } else if (**start == '[' &&
-	       (obj = parse_pdf_array(start, end, NULL))) {
+               (obj = parse_pdf_array(start, end, NULL))) {
       PUSH(obj);
       /* This cannot handle ASCII85 string. */
     } else if (*start < end - 1 &&
-	       (**start == '<' && *(*start+1) == '<') &&
-	       (obj = parse_pdf_dict(start, end, NULL))) {
+               (**start == '<' && *(*start+1) == '<') &&
+               (obj = parse_pdf_dict(start, end, NULL))) {
       PUSH(obj);
     } else if ((**start == '(' || **start == '<') &&
-	       (obj = parse_pdf_string (start, end))) {
+               (obj = parse_pdf_string (start, end))) {
       PUSH(obj);
     } else if (**start == '/' &&
-	       (obj = parse_pdf_name(start, end))) {
+               (obj = parse_pdf_name(start, end))) {
       PUSH(obj);
     } else {
       token = parse_ident(start, end);
       if (!token)
-	error = 1;
+        error = 1;
       else {
-	error = do_operator(token, x_user, y_user);
-	free(token);
+        error = do_operator(token, x_user, y_user);
+        free(token);
       }
     }
     skip_white(start, end);
@@ -1483,7 +1483,7 @@ mps_stack_depth (void)
 
 int
 mps_exec_inline (const char **p, const char *endptr,
-		 double x_user, double y_user)
+                 double x_user, double y_user)
 {
   int  error;
   int  dirmode, autorotate;

--- a/tectonic/dpx-mpost.c
+++ b/tectonic/dpx-mpost.c
@@ -309,75 +309,75 @@ skip_prolog (const char **start, const char *end)
 #undef DEF
 #undef PUSH
 
-#define ADD          	1
-#define SUB		2
-#define MUL		3
-#define DIV		4
-#define NEG    	        5
-#define TRUNCATE	6
+#define ADD            1
+#define SUB            2
+#define MUL            3
+#define DIV            4
+#define NEG            5
+#define TRUNCATE       6
 
-#define CLEAR		10
-#define EXCH		11
-#define POP		12
+#define CLEAR          10
+#define EXCH           11
+#define POP            12
 
-#define NEWPATH		31
-#define CLOSEPATH    	32
-#define MOVETO		33
-#define RMOVETO         34
-#define CURVETO   	35
-#define RCURVETO        36
-#define LINETO		37
-#define RLINETO		38
-#define ARC             39
-#define ARCN            40
+#define NEWPATH        31
+#define CLOSEPATH      32
+#define MOVETO         33
+#define RMOVETO        34
+#define CURVETO        35
+#define RCURVETO       36
+#define LINETO         37
+#define RLINETO        38
+#define ARC            39
+#define ARCN           40
 
-#define FILL		41
-#define STROKE		42
-#define SHOW		43
+#define FILL           41
+#define STROKE         42
+#define SHOW           43
 
-#define CLIP         	44
-#define EOCLIP         	45
+#define CLIP           44
+#define EOCLIP         45
 
-#define SHOWPAGE	49
+#define SHOWPAGE       49
 
-#define GSAVE		50
-#define GRESTORE	51
+#define GSAVE          50
+#define GRESTORE       51
 
-#define CONCAT       	52
-#define SCALE		53
-#define TRANSLATE	54
-#define ROTATE          55
+#define CONCAT         52
+#define SCALE          53
+#define TRANSLATE      54
+#define ROTATE         55
 
-#define SETLINEWIDTH	60
-#define SETDASH		61
-#define SETLINECAP 	62
-#define SETLINEJOIN	63
-#define SETMITERLIMIT	64
+#define SETLINEWIDTH   60
+#define SETDASH        61
+#define SETLINECAP     62
+#define SETLINEJOIN    63
+#define SETMITERLIMIT  64
 
-#define SETGRAY		70
-#define SETRGBCOLOR	71
-#define SETCMYKCOLOR	72
+#define SETGRAY        70
+#define SETRGBCOLOR    71
+#define SETCMYKCOLOR   72
 
-#define CURRENTPOINT    80
-#define IDTRANSFORM	81
-#define DTRANSFORM	82
+#define CURRENTPOINT   80
+#define IDTRANSFORM    81
+#define DTRANSFORM     82
 
-#define FINDFONT        201
-#define SCALEFONT       202
-#define SETFONT         203
-#define CURRENTFONT     204
+#define FINDFONT       201
+#define SCALEFONT      202
+#define SETFONT        203
+#define CURRENTFONT    204
 
-#define STRINGWIDTH     210
+#define STRINGWIDTH    210
 
-#define DEF             999
+#define DEF            999
 
-#define FSHOW		1001
-#define STEXFIG         1002
-#define ETEXFIG         1003
-#define HLW             1004
-#define VLW             1005
-#define RD              1006
-#define B               1007
+#define FSHOW          1001
+#define STEXFIG        1002
+#define ETEXFIG        1003
+#define HLW            1004
+#define VLW            1005
+#define RD             1006
+#define B              1007
 
 static struct operators
 {

--- a/tectonic/dpx-mpost.c
+++ b/tectonic/dpx-mpost.c
@@ -379,7 +379,7 @@ skip_prolog (const char **start, const char *end)
 #define RD              1006
 #define B               1007
 
-static struct operators 
+static struct operators
 {
   const char *token;
   int         opcode;
@@ -388,7 +388,7 @@ static struct operators
   {"mul",          MUL},
   {"div",          DIV},
   {"neg",          NEG},
-  {"sub",          SUB},  
+  {"sub",          SUB},
   {"truncate",     TRUNCATE},
 
   {"clear",        CLEAR},
@@ -410,7 +410,7 @@ static struct operators
   {"arc",          ARC},
   {"arcn",         ARCN},
 
-  {"stroke",       STROKE},  
+  {"stroke",       STROKE},
   {"fill",         FILL},
   {"show",         SHOW},
   {"showpage",     SHOWPAGE},
@@ -900,7 +900,7 @@ do_texfig_operator (int opcode, double x_user, double y_user)
       sprintf(resname, "__tf%d__", count);
       xobj_id = pdf_doc_begin_grabbing(resname,
 				       fig_p.bbox.llx, fig_p.bbox.ury, &fig_p.bbox);
-      
+
       in_tfig = 1;
       count++;
     }
@@ -969,7 +969,7 @@ do_operator (const char *token, double x_user, double y_user)
   opcode = get_opcode(token);
 
   switch (opcode) {
-    
+
     /*
      * Arithmetic operators
      */
@@ -1006,7 +1006,7 @@ do_operator (const char *token, double x_user, double y_user)
 
     /* Stack operation */
   case CLEAR:
-    error = do_clear(); 
+    error = do_clear();
     break;
   case POP:
     tmp = POP_STACK();
@@ -1014,7 +1014,7 @@ do_operator (const char *token, double x_user, double y_user)
       pdf_release_obj(tmp);
     break;
   case EXCH:
-    error = do_exch();  
+    error = do_exch();
     break;
 
     /* Path construction */
@@ -1069,7 +1069,7 @@ do_operator (const char *token, double x_user, double y_user)
 			   values[2], /* rad */
 			   values[3], values[4]);
     break;
-    
+
   case NEWPATH:
     pdf_dev_newpath();
     break;
@@ -1279,7 +1279,7 @@ do_operator (const char *token, double x_user, double y_user)
 	tmp = POP_STACK();
 	has_matrix = 1;
       }
-      
+
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
 	error = 1;
 	break;
@@ -1321,7 +1321,7 @@ do_operator (const char *token, double x_user, double y_user)
 	tmp = POP_STACK();
 	has_matrix = 1;
       }
-      
+
       if (!PDF_OBJ_NUMBERTYPE(tmp)) {
 	error = 1;
 	break;

--- a/tectonic/dpx-mpost.h
+++ b/tectonic/dpx-mpost.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-mpost.h
+++ b/tectonic/dpx-mpost.h
@@ -30,7 +30,7 @@
 extern int  mps_scan_bbox    (const char **pp, const char *endptr, pdf_rect *bbox);
 
 extern int  mps_exec_inline  (const char **buffer, const char *endptr,
-			      double x_user, double y_user);
+                              double x_user, double y_user);
 extern int  mps_stack_depth  (void);
 
 extern void mps_eop_cleanup  (void);

--- a/tectonic/dpx-numbers.c
+++ b/tectonic/dpx-numbers.c
@@ -173,7 +173,7 @@ void
 tt_skip_bytes (unsigned int n, rust_input_handle_t handle)
 {
     while (n-- > 0)
-	tt_get_unsigned_byte(handle);
+        tt_get_unsigned_byte(handle);
 }
 
 
@@ -183,7 +183,7 @@ tt_get_unsigned_byte (rust_input_handle_t handle)
     int ch;
 
     if ((ch = ttstub_input_getc (handle)) < 0)
-	_tt_abort("File ended prematurely\n");
+        _tt_abort("File ended prematurely\n");
 
     return (unsigned char) ch;
 }
@@ -196,7 +196,7 @@ tt_get_signed_byte (rust_input_handle_t handle)
 
     byte = tt_get_unsigned_byte(handle);
     if (byte >= 0x80)
-	byte -= 0x100;
+        byte -= 0x100;
 
     return (signed char) byte;
 }
@@ -227,7 +227,7 @@ tt_get_unsigned_quad(rust_input_handle_t handle)
     uint32_t quad = 0;
 
     for (i = 0; i < 4; i++)
-	quad = (quad << 8) | tt_get_unsigned_byte(handle);
+        quad = (quad << 8) | tt_get_unsigned_byte(handle);
 
     return quad;
 }
@@ -240,7 +240,7 @@ tt_get_signed_quad(rust_input_handle_t handle)
     int32_t quad = tt_get_signed_byte(handle);
 
     for (i = 0; i < 3; i++)
-	quad = (quad << 8) | tt_get_unsigned_byte(handle);
+        quad = (quad << 8) | tt_get_unsigned_byte(handle);
 
     return quad;
 }
@@ -253,18 +253,18 @@ tt_get_unsigned_num (rust_input_handle_t handle, unsigned char num)
 
     switch (num) {
     case 3:
-	if (val > 0x7F)
+        if (val > 0x7F)
             val -= 0x100;
-	val = (val << 8) | tt_get_unsigned_byte (handle);
-	/* fall through */
+        val = (val << 8) | tt_get_unsigned_byte (handle);
+        /* fall through */
     case 2:
-	val = (val << 8) | tt_get_unsigned_byte (handle);
-	/* fall through */
+        val = (val << 8) | tt_get_unsigned_byte (handle);
+        /* fall through */
     case 1:
-	val = (val << 8) | tt_get_unsigned_byte (handle);
-	/* fall through */
+        val = (val << 8) | tt_get_unsigned_byte (handle);
+        /* fall through */
     default:
-	break;
+        break;
     }
 
     return val;
@@ -277,7 +277,7 @@ tt_get_positive_quad (rust_input_handle_t handle, const char *type, const char *
     int32_t val = tt_get_signed_quad (handle);
 
     if (val < 0)
-	_tt_abort("Bad %s: negative %s: %d", type, name, val);
+        _tt_abort("Bad %s: negative %s: %d", type, name, val);
 
     return (uint32_t) val;
 }

--- a/tectonic/dpx-numbers.h
+++ b/tectonic/dpx-numbers.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -94,7 +94,7 @@ extern int32_t sqxfw (int32_t sq, fixword fw);
 #  define M_PI (4.0*atan(1.0))
 #endif
 
-#define ROUND(n,acc) (floor(((double)n)/(acc)+0.5)*(acc)) 
+#define ROUND(n,acc) (floor(((double)n)/(acc)+0.5)*(acc))
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  define __C99__

--- a/tectonic/dpx-otl_conf.c
+++ b/tectonic/dpx-otl_conf.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -485,7 +485,7 @@ otl_read_conf (const char *conf_name)
     p    += len;
     size -= len;
   }
-  
+
   pp     = wbuf;
   gclass = pdf_new_dict();
   rule   = parse_block(gclass, &pp, endptr);

--- a/tectonic/dpx-otl_conf.c
+++ b/tectonic/dpx-otl_conf.c
@@ -66,49 +66,49 @@ parse_uc_coverage (pdf_obj *gclass, const char **pp, const char *endptr)
       break;
     case '@':
       {
-	pdf_obj *cvalues;
-	int      i, size;
+        pdf_obj *cvalues;
+        int      i, size;
 
-	(*pp)++;
-	glyphclass = parse_c_ident(pp, endptr);
-	cvalues = pdf_lookup_dict(gclass, glyphclass);
-	if (!cvalues)
-	  _tt_abort("%s not defined...", glyphclass);
-	size    = pdf_array_length(cvalues);
-	for (i = 0; i < size; i++) {
-	  pdf_add_array(coverage,
-			pdf_link_obj(pdf_get_array(cvalues, i)));
-	}
+        (*pp)++;
+        glyphclass = parse_c_ident(pp, endptr);
+        cvalues = pdf_lookup_dict(gclass, glyphclass);
+        if (!cvalues)
+          _tt_abort("%s not defined...", glyphclass);
+        size    = pdf_array_length(cvalues);
+        for (i = 0; i < size; i++) {
+          pdf_add_array(coverage,
+                        pdf_link_obj(pdf_get_array(cvalues, i)));
+        }
       }
       break;
     default:
       glyphname  = parse_c_ident(pp, endptr);
       if (!glyphname)
-	_tt_abort("Invalid Unicode character specified.");
+        _tt_abort("Invalid Unicode character specified.");
 
       skip_white(pp, endptr);
       if (*pp + 1 < endptr && **pp == '-') {
-	value = pdf_new_array();
+        value = pdf_new_array();
 
-	if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
-	  _tt_abort("Invalid Unicode char: %s", glyphname);
-	pdf_add_array(value, pdf_new_number(ucv));
-	free(glyphname);
+        if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
+          _tt_abort("Invalid Unicode char: %s", glyphname);
+        pdf_add_array(value, pdf_new_number(ucv));
+        free(glyphname);
 
-	(*pp)++; skip_white(pp, endptr);
-	glyphname = parse_c_ident(pp, endptr);
-	if (!glyphname)
-	  _tt_abort("Invalid Unicode char: %s", glyphname);
-	if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
-	  _tt_abort("Invalid Unicode char: %s", glyphname);
-	pdf_add_array(value, pdf_new_number(ucv));
-	free(glyphname);
+        (*pp)++; skip_white(pp, endptr);
+        glyphname = parse_c_ident(pp, endptr);
+        if (!glyphname)
+          _tt_abort("Invalid Unicode char: %s", glyphname);
+        if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
+          _tt_abort("Invalid Unicode char: %s", glyphname);
+        pdf_add_array(value, pdf_new_number(ucv));
+        free(glyphname);
 
       } else {
-	if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
-	  _tt_abort("Invalid Unicode char: %s", glyphname);
-	value = pdf_new_number(ucv);
-	free(glyphname);
+        if (agl_get_unicodes(glyphname, &ucv, 1) != 1)
+          _tt_abort("Invalid Unicode char: %s", glyphname);
+        value = pdf_new_number(ucv);
+        free(glyphname);
       }
       pdf_add_array(coverage, value);
       break;
@@ -123,7 +123,7 @@ static pdf_obj *parse_block (pdf_obj *gclass, const char **pp, const char *endpt
 
 static void
 add_rule (pdf_obj *rule, pdf_obj *gclass,
-	  char *first, char *second, char *suffix)
+          char *first, char *second, char *suffix)
 {
   pdf_obj *glyph1, *glyph2;
 #define MAX_UNICODES 16
@@ -146,7 +146,7 @@ add_rule (pdf_obj *rule, pdf_obj *gclass,
     n_unicodes = agl_get_unicodes(first, unicodes, MAX_UNICODES);
     if (n_unicodes < 1) {
       dpx_warning("Failed to convert glyph \"%s\" to Unicode sequence.",
-	   first);
+           first);
       return;
     }
     glyph1 = pdf_new_array();
@@ -159,11 +159,11 @@ add_rule (pdf_obj *rule, pdf_obj *gclass,
       pdf_add_array(glyph1, pdf_new_number(unicodes[i]));
 
       if (verbose > VERBOSE_LEVEL_MIN) {
-	if (unicodes[i] < 0x10000) {
-	  dpx_message(" U+%04X", unicodes[i]);
-	} else {
-	  dpx_message(" U+%06X", unicodes[i]);
-	}
+        if (unicodes[i] < 0x10000) {
+          dpx_message(" U+%04X", unicodes[i]);
+        } else {
+          dpx_message(" U+%06X", unicodes[i]);
+        }
       }
     }
 
@@ -188,15 +188,15 @@ add_rule (pdf_obj *rule, pdf_obj *gclass,
     n_unicodes = agl_get_unicodes(second, unicodes, 16);
     if (n_unicodes < 1) {
       dpx_warning("Failed to convert glyph \"%s\" to Unicode sequence.",
-	   second);
+           second);
       return;
     }
 
     if (verbose > VERBOSE_LEVEL_MIN) {
       if (suffix)
-	dpx_message("otl_conf>> Input glyph sequence: %s.%s ->", second, suffix);
+        dpx_message("otl_conf>> Input glyph sequence: %s.%s ->", second, suffix);
       else
-	dpx_message("otl_conf>> Input glyph sequence: %s ->", second);
+        dpx_message("otl_conf>> Input glyph sequence: %s ->", second);
     }
 
     glyph2 = pdf_new_array();
@@ -204,11 +204,11 @@ add_rule (pdf_obj *rule, pdf_obj *gclass,
       pdf_add_array(glyph2, pdf_new_number(unicodes[i]));
 
       if (verbose > VERBOSE_LEVEL_MIN) {
-	if (unicodes[i] < 0x10000) {
-	  dpx_message(" U+%04X", unicodes[i]);
-	} else {
-	  dpx_message(" U+%06X", unicodes[i]);
-	}
+        if (unicodes[i] < 0x10000) {
+          dpx_message(" U+%04X", unicodes[i]);
+        } else {
+          dpx_message(" U+%06X", unicodes[i]);
+        }
       }
     }
     if (verbose > VERBOSE_LEVEL_MIN) {
@@ -248,11 +248,11 @@ parse_substrule (pdf_obj *gclass, const char **pp, const char *endptr)
 
     if (**pp == '#') {
       while (*pp < endptr) {
-	if (**pp == '\r' || **pp == '\n') {
-	  (*pp)++;
-	  break;
-	}
-	(*pp)++;
+        if (**pp == '\r' || **pp == '\n') {
+          (*pp)++;
+          break;
+        }
+        (*pp)++;
       }
       continue;
     } else if (**pp == ';') {
@@ -272,25 +272,25 @@ parse_substrule (pdf_obj *gclass, const char **pp, const char *endptr)
 
       first = parse_c_ident(pp, endptr);
       if (!first)
-	_tt_abort("Syntax error (1)");
+        _tt_abort("Syntax error (1)");
 
       skip_white(pp, endptr);
       tmp = parse_c_ident(pp, endptr);
       if (strcmp(tmp, "by") && strcmp(tmp, "to"))
-	_tt_abort("Syntax error (2): %s", *pp);
+        _tt_abort("Syntax error (2): %s", *pp);
 
       skip_white(pp, endptr);
       second = parse_c_ident(pp, endptr); /* allows @ */
       if (!second)
-	_tt_abort("Syntax error (3)");
+        _tt_abort("Syntax error (3)");
 
       /* (assign|substitute) tag dst src */
       pdf_add_array(substrule, pdf_new_name(token));
       if (*pp + 1 < endptr && **pp == '.') {
-	(*pp)++;
-	suffix = parse_c_ident(pp, endptr);
+        (*pp)++;
+        suffix = parse_c_ident(pp, endptr);
       } else {
-	suffix = NULL;
+        suffix = NULL;
       }
       add_rule(substrule, gclass, first, second, suffix);
 
@@ -298,7 +298,7 @@ parse_substrule (pdf_obj *gclass, const char **pp, const char *endptr)
       free(tmp);
       free(second);
       if (suffix)
-	free(suffix);
+        free(suffix);
     } else {
       _tt_abort("Unkown command %s.", token);
     }
@@ -332,11 +332,11 @@ parse_block (pdf_obj *gclass, const char **pp, const char *endptr)
       break;
     if (**pp == '#') {
       while (*pp < endptr) {
-	if (**pp == '\r' || **pp == '\n') {
-	  (*pp)++;
-	  break;
-	}
-	(*pp)++;
+        if (**pp == '\r' || **pp == '\n') {
+          (*pp)++;
+          break;
+        }
+        (*pp)++;
       }
       continue;
     } else if (**pp == ';') {
@@ -350,47 +350,47 @@ parse_block (pdf_obj *gclass, const char **pp, const char *endptr)
       break;
 
     if (!strcmp(token, "script") ||
-	!strcmp(token, "language")) {
+        !strcmp(token, "language")) {
       int  i, len;
 
       skip_white(pp, endptr);
       len = 0;
       while (*pp + len < endptr && *(*pp + len) != ';') {
-	len++;
+        len++;
       }
       if (len > 0) {
-	tmp = NEW(len+1, char);
-	memset(tmp, 0, len+1);
-	for (i = 0; i < len; i++) {
-	  if (!isspace((unsigned char)**pp))
-	    tmp[i] = **pp;
-	  (*pp)++;
-	}
-	pdf_add_dict(rule,
-		     pdf_new_name(token),
-		     pdf_new_string(tmp, strlen(tmp)));
+        tmp = NEW(len+1, char);
+        memset(tmp, 0, len+1);
+        for (i = 0; i < len; i++) {
+          if (!isspace((unsigned char)**pp))
+            tmp[i] = **pp;
+          (*pp)++;
+        }
+        pdf_add_dict(rule,
+                     pdf_new_name(token),
+                     pdf_new_string(tmp, strlen(tmp)));
 
-	if (verbose > VERBOSE_LEVEL_MIN) {
-	  dpx_message("otl_conf>> Current %s set to \"%s\"\n", token, tmp);
-	}
+        if (verbose > VERBOSE_LEVEL_MIN) {
+          dpx_message("otl_conf>> Current %s set to \"%s\"\n", token, tmp);
+        }
 
-	free(tmp);
+        free(tmp);
       }
     } else if (!strcmp(token, "option")) {
       pdf_obj *opt_dict, *opt_rule;
 
       opt_dict = pdf_lookup_dict(rule, "option");
       if (!opt_dict) {
-	opt_dict = pdf_new_dict();
-	pdf_add_dict(rule,
-		     pdf_new_name("option"), opt_dict);
+        opt_dict = pdf_new_dict();
+        pdf_add_dict(rule,
+                     pdf_new_name("option"), opt_dict);
       }
 
       skip_white(pp, endptr);
       tmp = parse_c_ident(pp, endptr);
 
       if (verbose > VERBOSE_LEVEL_MIN) {
-	dpx_message("otl_conf>> Reading option \"%s\"\n", tmp);
+        dpx_message("otl_conf>> Reading option \"%s\"\n", tmp);
       }
 
       skip_white(pp, endptr);
@@ -399,23 +399,23 @@ parse_block (pdf_obj *gclass, const char **pp, const char *endptr)
 
       free(tmp);
     } else if (!strcmp(token, "prefered") ||
-	       !strcmp(token, "required") ||
-	       !strcmp(token, "optional")) {
+               !strcmp(token, "required") ||
+               !strcmp(token, "optional")) {
       pdf_obj *subst, *rule_block;
 
       if (verbose > VERBOSE_LEVEL_MIN) {
-	dpx_message("otl_conf>> Reading block (%s)\n", token);
+        dpx_message("otl_conf>> Reading block (%s)\n", token);
       }
 
       skip_white(pp, endptr);
       if (*pp >= endptr || **pp != '{')
-	_tt_abort("Syntax error (1)");
+        _tt_abort("Syntax error (1)");
 
       rule_block = parse_substrule(gclass, pp, endptr);
       subst = pdf_lookup_dict(rule, "rule");
       if (!subst) {
-	subst = pdf_new_array();
-	pdf_add_dict(rule, pdf_new_name("rule"), subst);
+        subst = pdf_new_array();
+        pdf_add_dict(rule, pdf_new_name("rule"), subst);
       }
       pdf_add_array(subst, pdf_new_number(token[0]));
       pdf_add_array(subst, rule_block);
@@ -427,15 +427,15 @@ parse_block (pdf_obj *gclass, const char **pp, const char *endptr)
       skip_white(pp, endptr);
 
       if (verbose > VERBOSE_LEVEL_MIN) {
-	dpx_message("otl_conf>> Glyph class \"%s\"\n", token);
+        dpx_message("otl_conf>> Glyph class \"%s\"\n", token);
       }
 
       coverage = parse_uc_coverage(gclass, pp, endptr);
       if (!coverage)
-	_tt_abort("No valid Unicode characters...");
+        _tt_abort("No valid Unicode characters...");
 
       pdf_add_dict(gclass,
-		   pdf_new_name(&token[1]), coverage);
+                   pdf_new_name(&token[1]), coverage);
     }
     free(token);
     skip_white(pp, endptr);
@@ -472,7 +472,7 @@ otl_read_conf (const char *conf_name)
   if (verbose > VERBOSE_LEVEL_MIN) {
     dpx_message("\n");
     dpx_message("otl_conf>> Layout config. \"%s\" found: file=\"%s\" (%ld bytes)\n",
-	 conf_name, filename, size);
+         conf_name, filename, size);
   }
   free(filename);
   if (size < 1)
@@ -518,44 +518,44 @@ otl_find_conf (const char *conf_name)
     rule = otl_read_conf(conf_name);
     if (rule) {
       pdf_add_dict(otl_confs,
-		   pdf_new_name(conf_name), rule);
+                   pdf_new_name(conf_name), rule);
       script   = pdf_lookup_dict(rule, "script");
       language = pdf_lookup_dict(rule, "language");
       options  = pdf_lookup_dict(rule, "option");
       if (!script) {
-	script = pdf_new_string("*", 1);
-	pdf_add_dict(rule,
-		     pdf_new_name("script"),
-		     script);
-	dpx_warning("Script unspecified in \"%s\"...", conf_name);
+        script = pdf_new_string("*", 1);
+        pdf_add_dict(rule,
+                     pdf_new_name("script"),
+                     script);
+        dpx_warning("Script unspecified in \"%s\"...", conf_name);
       }
       if (!language) {
-	language = pdf_new_string("dflt", 4);
-	pdf_add_dict(rule,
-		     pdf_new_name("language"),
-		     language);
-	dpx_warning("Language unspecified in \"%s\"...", conf_name);
+        language = pdf_new_string("dflt", 4);
+        pdf_add_dict(rule,
+                     pdf_new_name("language"),
+                     language);
+        dpx_warning("Language unspecified in \"%s\"...", conf_name);
       }
 
       if (options) {
-	pdf_obj *optkeys, *opt, *key;
-	int      i, num_opts;
+        pdf_obj *optkeys, *opt, *key;
+        int      i, num_opts;
 
-	optkeys  = pdf_dict_keys(options);
-	num_opts = pdf_array_length(optkeys);
-	for (i = 0; i < num_opts; i++) {
-	  key = pdf_get_array(optkeys, i);
-	  opt = pdf_lookup_dict(options, pdf_name_value(key));
-	  if (!pdf_lookup_dict(opt, "script"))
-	    pdf_add_dict(opt,
-			 pdf_new_name("script"),
-			 pdf_link_obj(script));
-	  if (!pdf_lookup_dict(opt, "language"))
-	    pdf_add_dict(opt,
-			 pdf_new_name("language"),
-			 pdf_link_obj(language));
-	}
-	pdf_release_obj(optkeys);
+        optkeys  = pdf_dict_keys(options);
+        num_opts = pdf_array_length(optkeys);
+        for (i = 0; i < num_opts; i++) {
+          key = pdf_get_array(optkeys, i);
+          opt = pdf_lookup_dict(options, pdf_name_value(key));
+          if (!pdf_lookup_dict(opt, "script"))
+            pdf_add_dict(opt,
+                         pdf_new_name("script"),
+                         pdf_link_obj(script));
+          if (!pdf_lookup_dict(opt, "language"))
+            pdf_add_dict(opt,
+                         pdf_new_name("language"),
+                         pdf_link_obj(language));
+        }
+        pdf_release_obj(optkeys);
       }
 
     }

--- a/tectonic/dpx-otl_conf.h
+++ b/tectonic/dpx-otl_conf.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-otl_opt.c
+++ b/tectonic/dpx-otl_opt.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -108,7 +108,7 @@ static struct bt_node *
 parse_expr (const char **pp, const char *endptr)
 {
   struct bt_node *root, *curr;
-  
+
   if (*pp >= endptr)
     return NULL;
 

--- a/tectonic/dpx-otl_opt.c
+++ b/tectonic/dpx-otl_opt.c
@@ -51,21 +51,21 @@ match_expr (struct bt_node *expr, const char *key)
   if (expr) {
     if (!expr->left && !expr->right) {
       for (i = 0; i < 4; i++) {
-	if (expr->data[i] != '?' &&
-	    expr->data[i] != key[i]) {
-	  retval = 0;
-	  break;
-	}
+        if (expr->data[i] != '?' &&
+            expr->data[i] != key[i]) {
+          retval = 0;
+          break;
+        }
       }
     } else {
       if (expr->left) {
-	retval  = match_expr(expr->left, key);
+        retval  = match_expr(expr->left, key);
       }
       if (expr->right) {
-	if (retval && (expr->flag & FLAG_AND)) /* and */
-	  retval &= match_expr(expr->right, key);
-	else if (!retval && !(expr->flag & FLAG_AND)) /* or */
-	  retval  = match_expr(expr->right, key);
+        if (retval && (expr->flag & FLAG_AND)) /* and */
+          retval &= match_expr(expr->right, key);
+        else if (!retval && !(expr->flag & FLAG_AND)) /* or */
+          retval  = match_expr(expr->right, key);
       }
     }
     if (expr->flag & FLAG_NOT) /* not */
@@ -290,7 +290,7 @@ check_uc_coverage (struct uc_coverage *coverage)
       dpx_warning("Overlapping Unicode range found:");
       dpx_warning("[%x-%x], [%x-%x] ==> [%x-%x]",
            r1->start, r1->end, r2->start, r2->end,
-	   MIN(r1->start, r2->start), MAX(r1->end, r2->end));
+           MIN(r1->start, r2->start), MAX(r1->end, r2->end));
       r2->start = MIN(r1->start, r2->start);
       r2->end   = MAX(r1->end  , r2->end  );
       if (i < coverage->count - 1) {

--- a/tectonic/dpx-otl_opt.h
+++ b/tectonic/dpx-otl_opt.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfcolor.c
+++ b/tectonic/dpx-pdfcolor.c
@@ -83,7 +83,7 @@ pdf_color_rgbcolor (pdf_color *color, double r, double g, double b)
 
 int
 pdf_color_cmykcolor (pdf_color *color,
-		     double c, double m, double y, double k)
+                     double c, double m, double y, double k)
 {
   assert(color);
 
@@ -401,18 +401,18 @@ pdf_dev_preserve_color (void)
 /***************************** COLOR SPACE *****************************/
 
 static int pdf_colorspace_defineresource (const char *ident,
-					  int   subtype,
-					  void *cdata, pdf_obj *resource);
+                                          int   subtype,
+                                          void *cdata, pdf_obj *resource);
 
 static int pdf_colorspace_findresource   (const char *ident,
-					  int   subtype, const void *cdata);
+                                          int   subtype, const void *cdata);
 
 #if 0
 struct calgray_cdata
 {
   double white_point[3]; /* required, second component must
-			  * be equal to 1.0
-			  */
+                          * be equal to 1.0
+                          */
   double black_point[3]; /* optional, default: [0 0 0] */
   double gamma;          /* optional, default: 1.0     */
 };
@@ -420,13 +420,13 @@ struct calgray_cdata
 struct calrgb_cdata
 {
   double white_point[3]; /* required, second component must
-			  * be equal to 1.0
-			  */
+                          * be equal to 1.0
+                          */
   double black_point[3]; /* optional, default: [0 0 0] */
   double gamma[3];       /* optional, default: [1 1 1] */
   double matrix[9];      /* optional, default: identity
-			  * [1 0 0 0 1 0 0 0 1]
-			  */
+                          * [1 0 0 0 1 0 0 0 1]
+                          */
 };
 
 static void
@@ -442,7 +442,7 @@ release_calrgb (void *cdata)
 
 static int
 compare_calrgb (const char *ident1, const void *cdata1,
-		const char *ident2, const void *cdata2)
+                const char *ident2, const void *cdata2)
 {
   struct calrgb_cdata *calrgb1;
   struct calrgb_cdata *calrgb2;
@@ -649,9 +649,9 @@ typedef struct
   iccXYZNumber  illuminant;
   iccSig        creator;
   unsigned char ID[16]; /* MD5 checksum with Rendering intent,
-			 * Header attrs, Profile ID fields are
-			 * set to zeros.
-			 */
+                         * Header attrs, Profile ID fields are
+                         * set to zeros.
+                         */
   /* 28 bytes reserved - must be set to zeros */
 } iccHeader;
 
@@ -700,8 +700,8 @@ struct iccbased_cdata
 
   unsigned char  checksum[16]; /* 16 bytes MD5 Checksum   */
   int            colorspace;   /* input colorspace:
-				*   RGB, Gray, CMYK, (Lab?)
-				*/
+                                *   RGB, Gray, CMYK, (Lab?)
+                                */
   int            alternate;    /* alternate colorspace (id), unused */
 };
 
@@ -755,7 +755,7 @@ get_num_components_iccbased (const struct iccbased_cdata *cdata)
 
 static int
 compare_iccbased (const char *ident1, const struct iccbased_cdata *cdata1,
-		  const char *ident2, const struct iccbased_cdata *cdata2)
+                  const char *ident2, const struct iccbased_cdata *cdata2)
 {
   if (cdata1 && cdata2) {
 
@@ -763,7 +763,7 @@ compare_iccbased (const char *ident1, const struct iccbased_cdata *cdata1,
     assert(check_sig(cdata2, 'i', 'c', 'c', 'b'));
 
     if (memcmp(cdata1->checksum, nullbytes16, 16) &&
-	memcmp(cdata2->checksum, nullbytes16, 16)) {
+        memcmp(cdata2->checksum, nullbytes16, 16)) {
       return memcmp(cdata1->checksum, cdata2->checksum, 16);
     }
     if (cdata1->colorspace != cdata2->colorspace) {
@@ -858,13 +858,13 @@ iccp_get_rendering_intent (const void *profile, int proflen)
 
 static int
 iccp_unpack_header (iccHeader *icch,
-		    const void *profile, int proflen, int check_size)
+                    const void *profile, int proflen, int check_size)
 {
   const unsigned char *p, *endptr;
 
   if (check_size) {
     if (!profile || proflen < 128 ||
-	proflen % 4 != 0) {
+        proflen % 4 != 0) {
       dpx_warning("Profile size: %ld", proflen);
       return -1;
     }
@@ -897,7 +897,7 @@ iccp_unpack_header (iccHeader *icch,
   icch->acsp = str2iccSig(p); /* acsp */
   if (icch->acsp != str2iccSig("acsp")) {
     dpx_warning("Invalid ICC profile: not \"acsp\" - %c%c%c%c ",
-	 p[0], p[1], p[2], p[3]);
+         p[0], p[1], p[2], p[3]);
     return -1;
   }
   p += 4;
@@ -928,7 +928,7 @@ iccp_unpack_header (iccHeader *icch,
   for (; p < endptr; p++) {
     if (*p != '\0') {
       dpx_warning("Reserved pad not zero: %02x (at offset %d in ICC profile header.)",
-	   *p, 128 - ((int) (endptr - p)));
+           *p, 128 - ((int) (endptr - p)));
       return -1;
     }
   }
@@ -1006,10 +1006,10 @@ print_iccp_header (iccHeader *icch, unsigned char *checksum)
   for (i = 0; i < 12; i += 2) {
     if (i == 0)
       dpx_message("%04u",
-	   sget_unsigned_pair((unsigned char *) icch->creationDate));
+           sget_unsigned_pair((unsigned char *) icch->creationDate));
     else {
       dpx_message(":%02u",
-	   sget_unsigned_pair((unsigned char *) (&icch->creationDate[i])));
+           sget_unsigned_pair((unsigned char *) (&icch->creationDate[i])));
     }
   }
   dpx_message("\n");
@@ -1057,9 +1057,9 @@ print_iccp_header (iccHeader *icch, unsigned char *checksum)
   } else {
     for (i = 0; i < 16; i++) {
       if (i == 0)
-	dpx_message("%02x",  icch->ID[i]);
+        dpx_message("%02x",  icch->ID[i]);
       else
-	dpx_message(":%02x", icch->ID[i]);
+        dpx_message(":%02x", icch->ID[i]);
     }
   }
   dpx_message("\n");
@@ -1067,9 +1067,9 @@ print_iccp_header (iccHeader *icch, unsigned char *checksum)
     dpx_message("pdf_color>> Calculated:\t");
     for (i = 0; i < 16; i++) {
       if (i == 0)
-	dpx_message("%02x", checksum[i]);
+        dpx_message("%02x", checksum[i]);
       else
-	dpx_message(":%02x", checksum[i]);
+        dpx_message(":%02x", checksum[i]);
     }
     dpx_message("\n");
   }
@@ -1097,9 +1097,9 @@ iccp_devClass_allowed (int dev_class)
 #endif
   default:
     if (dev_class != str2iccSig("scnr") &&
-	dev_class != str2iccSig("mntr") &&
-	dev_class != str2iccSig("prtr") &&
-	dev_class != str2iccSig("spac")) {
+        dev_class != str2iccSig("mntr") &&
+        dev_class != str2iccSig("prtr") &&
+        dev_class != str2iccSig("spac")) {
       return 0;
     }
     break;
@@ -1111,7 +1111,7 @@ iccp_devClass_allowed (int dev_class)
 
 int
 iccp_load_profile (const char *ident,
-		   const void *profile, int proflen)
+                   const void *profile, int proflen)
 {
   int       cspc_id;
   pdf_obj  *resource;
@@ -1130,12 +1130,12 @@ iccp_load_profile (const char *ident,
   }
 
   if (!iccp_version_supported((icch.version >> 24) & 0xff,
-			      (icch.version >> 16) & 0xff)) {
+                              (icch.version >> 16) & 0xff)) {
     dpx_warning("ICC profile format spec. version %d.%01d.%01d"
-	 " not supported in current PDF version setting.",
-	 (icch.version >> 24) & 0xff,
-	 (icch.version >> 20) & 0x0f,
-	 (icch.version >> 16) & 0x0f);
+         " not supported in current PDF version setting.",
+         (icch.version >> 24) & 0xff,
+         (icch.version >> 20) & 0x0f,
+         (icch.version >> 16) & 0x0f);
     dpx_warning("ICC profile not embedded.");
     print_iccp_header(&icch, NULL);
     return -1;
@@ -1173,7 +1173,7 @@ iccp_load_profile (const char *ident,
   memcpy(cdata->checksum, checksum, 16);
 
   cspc_id = pdf_colorspace_findresource(ident,
-					PDF_COLORSPACE_TYPE_ICCBASED, cdata);
+                                        PDF_COLORSPACE_TYPE_ICCBASED, cdata);
   if (cspc_id >= 0) {
     if (verbose)
       dpx_message("(ICCP:[id=%d])", cspc_id);
@@ -1192,14 +1192,14 @@ iccp_load_profile (const char *ident,
 
   stream_dict = pdf_stream_dict(stream);
   pdf_add_dict(stream_dict, pdf_new_name("N"),
-	       pdf_new_number(get_num_components_iccbased(cdata)));
+               pdf_new_number(get_num_components_iccbased(cdata)));
 
   pdf_add_stream (stream, profile, proflen);
   pdf_release_obj(stream);
 
   cspc_id = pdf_colorspace_defineresource(ident,
-					  PDF_COLORSPACE_TYPE_ICCBASED,
-					  cdata, resource);
+                                          PDF_COLORSPACE_TYPE_ICCBASED,
+                                          cdata, resource);
 
   return cspc_id;
 }
@@ -1285,18 +1285,18 @@ pdf_colorspace_load_ICCBased (const char *ident, const char *filename)
   }
   if (icch.size > size) {
     dpx_warning("File size smaller than recorded in header: %ld %ld",
-	 icch.size, size);
+         icch.size, size);
     fclose(fp);
     return -1;
   }
 
   if (!iccp_version_supported((icch.version >> 24) & 0xff,
-			      (icch.version >> 16) & 0xff)) {
+                              (icch.version >> 16) & 0xff)) {
     dpx_warning("ICC profile format spec. version %d.%01d.%01d"
-	 " not supported in current PDF version setting.",
-	 (icch.version >> 24) & 0xff,
-	 (icch.version >> 20) & 0x0f,
-	 (icch.version >> 16) & 0x0f);
+         " not supported in current PDF version setting.",
+         (icch.version >> 24) & 0xff,
+         (icch.version >> 20) & 0x0f,
+         (icch.version >> 16) & 0x0f);
     dpx_warning("ICC profile not embedded.");
     print_iccp_header(&icch, NULL);
     fclose(fp);
@@ -1345,7 +1345,7 @@ pdf_colorspace_load_ICCBased (const char *ident, const char *filename)
   memcpy(cdata->checksum, checksum, 16);
 
   cspc_id = pdf_colorspace_findresource(ident,
-					PDF_COLORSPACE_TYPE_ICCBASED, cdata);
+                                        PDF_COLORSPACE_TYPE_ICCBASED, cdata);
   if (cspc_id >= 0) {
     if (verbose)
       dpx_message("(ICCP:[id=%d])", cspc_id);
@@ -1364,12 +1364,12 @@ pdf_colorspace_load_ICCBased (const char *ident, const char *filename)
 
   stream_dict = pdf_stream_dict(stream);
   pdf_add_dict(stream_dict, pdf_new_name("N"),
-	       pdf_new_number(get_num_components_iccbased(cdata)));
+               pdf_new_number(get_num_components_iccbased(cdata)));
   pdf_release_obj(stream);
 
   cspc_id = pdf_colorspace_defineresource(ident,
-					  PDF_COLORSPACE_TYPE_ICCBASED,
-					  cdata, resource);
+                                          PDF_COLORSPACE_TYPE_ICCBASED,
+                                          cdata, resource);
 
   return cspc_id;
 }
@@ -1395,7 +1395,7 @@ static struct {
 
 int
 pdf_colorspace_findresource (const char *ident,
-			     int type, const void *cdata)
+                             int type, const void *cdata)
 {
   pdf_colorspace *colorspace;
   int  cspc_id, cmp = -1;
@@ -1409,7 +1409,7 @@ pdf_colorspace_findresource (const char *ident,
     switch (colorspace->subtype) {
     case PDF_COLORSPACE_TYPE_ICCBASED:
       cmp = compare_iccbased(ident, cdata,
-			     colorspace->ident, colorspace->cdata);
+                             colorspace->ident, colorspace->cdata);
       break;
     }
     if (!cmp)
@@ -1477,7 +1477,7 @@ pdf_flush_colorspace (pdf_colorspace *colorspace)
 
 int
 pdf_colorspace_defineresource (const char *ident,
-			       int subtype, void *cdata, pdf_obj *resource)
+                               int subtype, void *cdata, pdf_obj *resource)
 {
   int  cspc_id;
   pdf_colorspace *colorspace;
@@ -1485,7 +1485,7 @@ pdf_colorspace_defineresource (const char *ident,
   if (cspc_cache.count >= cspc_cache.capacity) {
     cspc_cache.capacity   += 16;
     cspc_cache.colorspaces = RENEW(cspc_cache.colorspaces,
-				   cspc_cache.capacity, pdf_colorspace);
+                                   cspc_cache.capacity, pdf_colorspace);
   }
   cspc_id    = cspc_cache.count;
   colorspace = &cspc_cache.colorspaces[cspc_id];
@@ -1504,14 +1504,14 @@ pdf_colorspace_defineresource (const char *ident,
     if (verbose > 1) {
       switch (subtype) {
       case PDF_COLORSPACE_TYPE_ICCBASED:
-	dpx_message("[ICCBased]");
-	break;
+        dpx_message("[ICCBased]");
+        break;
       case PDF_COLORSPACE_TYPE_CALRGB:
-	dpx_message("[CalRGB]");
-	break;
+        dpx_message("[CalRGB]");
+        break;
       case PDF_COLORSPACE_TYPE_CALGRAY:
-	dpx_message("[CalGray]");
-	break;
+        dpx_message("[CalGray]");
+        break;
       }
     }
     dpx_message(")");

--- a/tectonic/dpx-pdfcolor.c
+++ b/tectonic/dpx-pdfcolor.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfcolor.h
+++ b/tectonic/dpx-pdfcolor.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfcolor.h
+++ b/tectonic/dpx-pdfcolor.h
@@ -76,11 +76,11 @@ extern int        pdf_color_is_valid      (const pdf_color *color);
 /* Not check size */
 extern pdf_obj *iccp_get_rendering_intent (const void *profile, int proflen);
 extern int      iccp_check_colorspace     (int colortype,
-					   const void *profile, int proflen);
+                                           const void *profile, int proflen);
 
 /* returns colorspace ID */
 extern int      iccp_load_profile (const char *ident,
-				   const void *profile, int proflen);
+                                   const void *profile, int proflen);
 
 extern void     pdf_init_colors  (void);
 extern void     pdf_close_colors (void);
@@ -92,7 +92,7 @@ extern int      pdf_get_colorspace_subtype        (int cspc_id);
 
 /* Not working */
 extern int      pdf_colorspace_load_ICCBased      (const char *ident,
-						   const char *profile_filename);
+                                                   const char *profile_filename);
 #endif
 
 /* Color special

--- a/tectonic/dpx-pdfdev.c
+++ b/tectonic/dpx-pdfdev.c
@@ -143,8 +143,8 @@ static int
 p_dtoa (double value, int prec, char *buf)
 {
   const int32_t p[10] = { 1, 10, 100, 1000, 10000,
-                                   100000, 1000000, 10000000,
-                       100000000, 1000000000 };
+                          100000, 1000000, 10000000,
+                          100000000, 1000000000 };
   double i, f;
   int32_t g;
   char  *c = buf;

--- a/tectonic/dpx-pdfdev.c
+++ b/tectonic/dpx-pdfdev.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -336,7 +336,7 @@ static char format_buffer[FORMAT_BUF_SIZE];
  * and font's WMode separately.
  *
  * 000/101 WMODE_HH/VV  h(v) font, h(v) direction.
- * 001    WMODE_HV    -90 deg. rotated  
+ * 001    WMODE_HV    -90 deg. rotated
  * 100    WMODE_VH    +90 deg. rotated
  * 011    WMODE_HD    +90 deg. rotated
  * 111    WMODE_VD    180 deg. rotated
@@ -828,7 +828,7 @@ string_mode (spt_t xpos, spt_t ypos, double slant, double extend, int rotate)
  * VF code was added.  The VF spec says to instantiate the
  * first font contained in the VF file before drawing a virtual
  * character.  However, that font may not be used for
- * many characters (e.g. small caps fonts).  For this reason, 
+ * many characters (e.g. small caps fonts).  For this reason,
  * dev_select_font() should not force a "physical" font selection.
  * This routine prevents a PDF Tf font selection until there's
  * really a character in that font.
@@ -879,7 +879,7 @@ dev_set_font (int font_id)
     real_font->used_chars = pdf_get_font_usedchars(real_font->font_id);
   }
 
-  if (!real_font->used_on_this_page) { 
+  if (!real_font->used_on_this_page) {
     pdf_doc_add_page_resource("Font",
                               real_font->short_name,
                               pdf_link_obj(real_font->resource));
@@ -1002,7 +1002,7 @@ handle_multibyte_string (struct dev_font *font,
         sbuf1[len  ] = font->ucs_group;
         if ((p[i] & 0xf8) == 0xd8) {
           int c;
-          /* Check for valid surrogate pair.  */ 
+          /* Check for valid surrogate pair.  */
           if ((p[i] & 0xfc) != 0xd8 || i + 2 >= length || (p[i+2] & 0xfc) != 0xdc) {
             dpx_warning("Invalid surrogate p[%d]=%02X...", i, p[i]);
             return -1;
@@ -1233,7 +1233,7 @@ pdf_dev_set_string (spt_t xpos, spt_t ypos,
      * Same issues as earlier. Use floating point for simplicity.
      * This routine needs to be fast, so we don't call sprintf() or strcpy().
      */
-    text_state.offset -= 
+    text_state.offset -=
       (spt_t) (kern * font->extend * (font->sptsize / 1000.0));
     format_buffer[len++] = text_state.is_mb ? '>' : ')';
     if (font->wmode)
@@ -1418,15 +1418,15 @@ print_fontmap (const char *font_name, fontmap_rec *mrec)
     dpx_message("[extend:%g]", mrec->opt.extend);
   if (mrec->opt.slant  != 0.0)
     dpx_message("[slant:%g]",  mrec->opt.slant);
-  if (mrec->opt.bold   != 0.0) 
+  if (mrec->opt.bold   != 0.0)
     dpx_message("[bold:%g]",   mrec->opt.bold);
   if (mrec->opt.flags & FONTMAP_OPT_NOEMBED)
     dpx_message("[noemb]");
   if (mrec->opt.mapc >= 0)
     dpx_message("[map:<%02x>]", mrec->opt.mapc);
-  if (mrec->opt.charcoll)  
+  if (mrec->opt.charcoll)
     dpx_message("[csi:%s]",     mrec->opt.charcoll);
-  if (mrec->opt.index) 
+  if (mrec->opt.index)
     dpx_message("[index:%d]",   mrec->opt.index);
 
   switch (mrec->opt.style) {
@@ -1446,7 +1446,7 @@ print_fontmap (const char *font_name, fontmap_rec *mrec)
 
 /* _FIXME_
  * Font is identified with font_name and point_size as in DVI here.
- * However, except for PDF_FONTTYPE_BITMAP, we can share the 
+ * However, except for PDF_FONTTYPE_BITMAP, we can share the
  * short_name, resource and used_chars between multiple instances
  * of the same font at different sizes.
  */
@@ -1531,7 +1531,7 @@ pdf_dev_locate_font (const char *font_name, spt_t ptsize)
   font->wmode      = pdf_get_font_wmode   (font->font_id);
   font->enc_id     = pdf_get_font_encoding(font->font_id);
 
-  font->resource   = NULL; /* Don't ref obj until font is actually used. */  
+  font->resource   = NULL; /* Don't ref obj until font is actually used. */
   font->used_chars = NULL;
 
   font->extend     = 1.0;

--- a/tectonic/dpx-pdfdev.c
+++ b/tectonic/dpx-pdfdev.c
@@ -143,7 +143,7 @@ static int
 p_dtoa (double value, int prec, char *buf)
 {
   const int32_t p[10] = { 1, 10, 100, 1000, 10000,
-		                   100000, 1000000, 10000000,
+                                   100000, 1000000, 10000000,
                        100000000, 1000000000 };
   double i, f;
   int32_t g;
@@ -1889,7 +1889,7 @@ pdf_dev_put_image (int             id,
     pdf_coord corner[4];
 
     pdf_dev_set_rect(&rect, 65536 * ref_x, 65536 * ref_y,
-	65536 * (r.urx - r.llx), 65536 * (r.ury - r.lly), 0);
+        65536 * (r.urx - r.llx), 65536 * (r.ury - r.lly), 0);
 
     corner[0].x = rect.llx; corner[0].y = rect.lly;
     corner[1].x = rect.llx; corner[1].y = rect.ury;
@@ -1911,13 +1911,13 @@ pdf_dev_put_image (int             id,
     rect.ury = corner[0].y;
     for (i = 0; i < 4; ++i) {
       if (corner[i].x < rect.llx)
-	rect.llx = corner[i].x;
+        rect.llx = corner[i].x;
       if (corner[i].x > rect.urx)
-	rect.urx = corner[i].x;
+        rect.urx = corner[i].x;
       if (corner[i].y < rect.lly)
-	rect.lly = corner[i].y;
+        rect.lly = corner[i].y;
       if (corner[i].y > rect.ury)
-	rect.ury = corner[i].y;
+        rect.ury = corner[i].y;
     }
 
     pdf_doc_expand_box(&rect);

--- a/tectonic/dpx-pdfdev.h
+++ b/tectonic/dpx-pdfdev.h
@@ -137,15 +137,15 @@ typedef struct
  *   2 - input string is in 16-bit encoding.
  */
 extern void   pdf_dev_set_string (spt_t xpos, spt_t ypos,
-				  const void *instr_ptr, int instr_len,
-				  spt_t text_width,
-				  int   font_id, int ctype);
+                                  const void *instr_ptr, int instr_len,
+                                  spt_t text_width,
+                                  int   font_id, int ctype);
 extern void   pdf_dev_set_rule   (spt_t xpos, spt_t ypos,
-				  spt_t width, spt_t height);
+                                  spt_t width, spt_t height);
 
 /* Place XObject */
 extern int    pdf_dev_put_image  (int xobj_id,
-				  transform_info *p, double ref_x, double ref_y);
+                                  transform_info *p, double ref_x, double ref_y);
 
 /* The design_size and ptsize required by PK font support...
  */
@@ -178,8 +178,8 @@ extern void   pdf_dev_set_dirmode     (int dir_mode);
  * Unit conversion spt_t to bp and transformation applied within it.
  */
 extern void   pdf_dev_set_rect   (pdf_rect *rect,
-				  spt_t x_pos, spt_t y_pos,
-				  spt_t width, spt_t height, spt_t depth);
+                                  spt_t x_pos, spt_t y_pos,
+                                  spt_t width, spt_t height, spt_t depth);
 
 /* Accessor to various device parameters.
  */

--- a/tectonic/dpx-pdfdev.h
+++ b/tectonic/dpx-pdfdev.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfdoc.h
+++ b/tectonic/dpx-pdfdoc.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfdoc.h
+++ b/tectonic/dpx-pdfdoc.h
@@ -58,7 +58,7 @@ extern pdf_obj *pdf_doc_get_reference  (const char *category);
 
 extern int      pdf_doc_get_page_count (pdf_file *pf);
 extern pdf_obj *pdf_doc_get_page (pdf_file *pf, int page_no, int options,
-				  pdf_rect *bbox, pdf_obj **resources_p);
+                                  pdf_rect *bbox, pdf_obj **resources_p);
 
 extern int      pdf_doc_current_page_number    (void);
 extern pdf_obj *pdf_doc_current_page_resources (void);
@@ -72,7 +72,7 @@ extern pdf_obj *pdf_doc_ref_page (unsigned page_no);
  * There should be something for number tree.
  */
 extern int      pdf_doc_add_names       (const char *category,
-					 const void *key, int keylen, pdf_obj *value);
+                                         const void *key, int keylen, pdf_obj *value);
 
 extern void     pdf_doc_set_bop_content (const char *str, unsigned length);
 extern void     pdf_doc_set_eop_content (const char *str, unsigned length);
@@ -85,13 +85,13 @@ extern void     pdf_doc_set_mediabox (unsigned page_no, const pdf_rect *mediabox
 
 extern void     pdf_doc_add_page_content  (const char *buffer, unsigned length);
 extern void     pdf_doc_add_page_resource (const char *category,
-					   const char *resource_name, pdf_obj *resources);
+                                           const char *resource_name, pdf_obj *resources);
 
 /* Article thread */
 extern void     pdf_doc_begin_article (const char *article_id, pdf_obj *info);
 extern void     pdf_doc_add_bead      (const char *article_id,
-				       const char *bead_id,
-				       int page_no, const pdf_rect *rect);
+                                       const char *bead_id,
+                                       int page_no, const pdf_rect *rect);
 
 /* Bookmarks */
 extern int      pdf_doc_bookmarks_up    (void);
@@ -102,16 +102,16 @@ extern int      pdf_doc_bookmarks_depth (void);
 
 /* Returns xobj_id of started xform. */
 extern int      pdf_doc_begin_grabbing (const char *ident,
-					double ref_x, double ref_y,
-					const pdf_rect *cropbox);
+                                        double ref_x, double ref_y,
+                                        const pdf_rect *cropbox);
 extern void     pdf_doc_end_grabbing   (pdf_obj *attrib);
 
 
 /* Annotation */
 extern void     pdf_doc_add_annot   (unsigned page_no,
-				     const pdf_rect *rect,
-				     pdf_obj *annot_dict,
-				     int new_annot);
+                                     const pdf_rect *rect,
+                                     pdf_obj *annot_dict,
+                                     int new_annot);
 
 /* Annotation with auto- clip and line (or page) break */
 extern void     pdf_doc_begin_annot (pdf_obj *dict);

--- a/tectonic/dpx-pdfdraw.c
+++ b/tectonic/dpx-pdfdraw.c
@@ -852,7 +852,7 @@ pdf_dev__flushpath (pdf_path  *pa,
       b[len++] = PE_OPCHR(pe);
       if (len + 128 > b_len) {
         pdf_doc_add_page_content(b, len);  /* op: m l c v y h */
-	len = 0;
+        len = 0;
       }
     }
     if (len > 0) {
@@ -1266,7 +1266,7 @@ pdf_dev_set_color (const pdf_color *color, char mask, int force)
   assert(pdf_color_is_valid(color));
 
   if (!(pdf_dev_get_param(PDF_DEV_PARAM_COLORMODE) &&
-	(force || pdf_color_compare(color, current))))
+        (force || pdf_color_compare(color, current))))
     /* If "color" is already the current color, then do nothing
      * unless a color operator is forced
      */

--- a/tectonic/dpx-pdfdraw.c
+++ b/tectonic/dpx-pdfdraw.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -38,7 +38,7 @@
 
 /*
  * Numbers are rounding to 0-5 fractional digits
- * in output routine. 
+ * in output routine.
  */
 #define detM(M) ((M).a * (M).d - (M).b * (M).c)
 #define detP(M) ((M)->a * (M)->d - (M)->b * (M)->c)
@@ -94,7 +94,7 @@ pdf_coord__sort_compar_X (const void *pp1, const void *pp2)
     return 0;
   else
     return (int) dsign(p1->x - p2->x);
- 
+
   return 1;
 }
 
@@ -108,7 +108,7 @@ pdf_coord__sort_compar_Y (const void *pp1, const void *pp2)
     return 0;
   else
     return (int) dsign(p1->y - p2->y);
- 
+
   return 1;
 }
 #endif
@@ -130,17 +130,17 @@ pdf_coord__transform (pdf_coord *p, const pdf_tmatrix *M)
 static /* __inline__ */ int
 pdf_coord__itransform (pdf_coord *p, const pdf_tmatrix *M)
 {
-  pdf_tmatrix W;  
+  pdf_tmatrix W;
   double      x, y;
   int         error;
 
   error = inversematrix(&W, M);
-  if (error) 
+  if (error)
     return error;
 
   x = p->x;  y = p->y;
   p->x = x * W.a + y * W.c + W.e;
-  p->y = x * W.b + y * W.d + W.f;  
+  p->y = x * W.b + y * W.d + W.f;
 
   return 0;
 }
@@ -161,12 +161,12 @@ pdf_coord__dtransform (pdf_coord *p, const pdf_tmatrix *M)
 static /* __inline__ */ int
 pdf_coord__idtransform (pdf_coord *p, const pdf_tmatrix *M)
 {
-  pdf_tmatrix W;  
+  pdf_tmatrix W;
   double      x, y;
   int         error;
 
   error = inversematrix(&W, M);
-  if (error) 
+  if (error)
     return error;
 
   x = p->x;  y = p->y;
@@ -181,7 +181,7 @@ pdf_coord__idtransform (pdf_coord *p, const pdf_tmatrix *M)
 void
 pdf_invertmatrix (pdf_tmatrix *M)
 {
-  pdf_tmatrix W;  
+  pdf_tmatrix W;
   double      det;
 
   assert(M);
@@ -228,17 +228,17 @@ static const struct {
 #define PE_TYPE__INVALID  -1
 #define PE_TYPE__MOVETO    0
   {'m', 1, "moveto"  },
-#define PE_TYPE__LINETO    1 
+#define PE_TYPE__LINETO    1
   {'l', 1, "lineto"  },
-#define PE_TYPE__CURVETO   2 
+#define PE_TYPE__CURVETO   2
   {'c', 3, "curveto" },
   /* no PS correspondence for v and y */
-#define PE_TYPE__CURVETO_V 3 
+#define PE_TYPE__CURVETO_V 3
   {'v', 2, "vcurveto"}, /* current point replicated */
-#define PE_TYPE__CURVETO_Y 4 
+#define PE_TYPE__CURVETO_Y 4
   {'y', 2, "ycurveto"}, /* last point replicated */
 #define PE_TYPE__CLOSEPATH 5
-  {'h', 0, "closepath"}, 
+  {'h', 0, "closepath"},
 #define PE_TYPE__TERMINATE 6
   {' ', 0,  NULL}
 };
@@ -274,7 +274,7 @@ pdf_path__clearpath (pdf_path *p)
   assert(p);
 
   p->num_paths = 0;
-  
+
   return;
 }
 
@@ -289,7 +289,7 @@ pdf_path__growpath  (pdf_path *p, int max_pe)
 
   return 0;
 }
-    
+
 static void
 clear_a_path (pdf_path *p)
 {
@@ -336,7 +336,7 @@ pdf_path__moveto  (pdf_path        *pa,
                    const pdf_coord *p0)
 {
   pa_elem  *pe;
-  
+
   pdf_path__growpath(pa, PA_LENGTH(pa) + 1);
   if (PA_LENGTH(pa) > 0) {
     pe = &pa->path[pa->num_paths-1];
@@ -351,16 +351,16 @@ pdf_path__moveto  (pdf_path        *pa,
   pe->p[0].x = cp->x = p0->x;
   pe->p[0].y = cp->y = p0->y;
 
-  return 0;  
+  return 0;
 }
 
 /* Do 'compression' of path while adding new path elements.
  * Sequantial moveto command will be replaced with a
  * single moveto. If cp is not equal to the last point in pa,
  * then moveto is inserted (starting new subpath).
- * FIXME: 
+ * FIXME:
  * 'moveto' must be used to enforce starting new path.
- * This affects how 'closepath' is treated.     
+ * This affects how 'closepath' is treated.
  */
 static pa_elem *
 pdf_path__next_pe (pdf_path *pa, const pdf_coord *cp)
@@ -376,7 +376,7 @@ pdf_path__next_pe (pdf_path *pa, const pdf_coord *cp)
 
     return &pa->path[pa->num_paths++];
   }
-    
+
   pe = &pa->path[pa->num_paths-1];
   switch (pe->type) {
   case PE_TYPE__MOVETO:
@@ -508,7 +508,7 @@ pdf_path__curveto_QB (pdf_path        *pa,
   q1.x = p0->x + QB_ONE_THIRD * (p1->x - p0->x);
   q1.y = p0->y + QB_ONE_THIRD * (p1->y - p0->y);
   /* q2 == p1 */
- 
+
   return pdf_path__curveto(pa, cp, &q0, &q1, p1);
 }
 #endif
@@ -572,7 +572,7 @@ pdf_path__elliptarc (pdf_path         *pa,
     pdf_path__moveto(pa, cp, &p0);
   } else if (!COORD_EQUAL(cp, &p0)) {
     pdf_path__lineto(pa, cp, &p0); /* add line seg */
-  } 
+  }
   for (i = 0; !error && i < n_c; i++) {
     q = a_0 + i * d_a;
     e0.x = cos(q); e0.y = sin(q);
@@ -583,7 +583,7 @@ pdf_path__elliptarc (pdf_path         *pa,
     *  d2 = p2 - p3 = g ( sin b, -cos b)
     * and from symmetry
     *  g^2 = f^2
-    */ 
+    */
     p0.x = r_x * e0.x; /* s.p. */
     p0.y = r_y * e0.y;
     p3.x = r_x * e1.x; /* e.p. */
@@ -645,7 +645,7 @@ pdf_path__closepath (pdf_path *pa, pdf_coord *cp /* no arg */)
 
 /*
  *  x y width height re
- * 
+ *
  * is equivalent to
  *
  *  x y m
@@ -654,7 +654,7 @@ pdf_path__closepath (pdf_path *pa, pdf_coord *cp /* no arg */)
  *  x (y + height) l
  *  h
  */
-/* Just for quick test */ 
+/* Just for quick test */
 static /* __inline__ */ int
 pdf_path__isarect (pdf_path *pa,
                    int       f_ir /* fill-rule is ignorable */
@@ -721,14 +721,14 @@ INVERTIBLE_MATRIX (const pdf_tmatrix *M)
  *
  * Draw isolated rectangle without actually doing
  * gsave/grestore operation.
- * 
+ *
  * TODO:
  *  linestyle, fill-opacity, stroke-opacity,....
  *  As this routine draw a single graphics object
  *  each time, there should be options for specifying
  *  various drawing styles, which might inherite
  *  current graphcs state parameter.
- */ 
+ */
 static int
 pdf_dev__rectshape (const pdf_rect    *r,
                     const pdf_tmatrix *M,
@@ -821,7 +821,7 @@ pdf_dev__flushpath (pdf_path  *pa,
 
   path_added = 0;
   graphics_mode();
-  isrect = pdf_path__isarect(pa, ignore_rule); 
+  isrect = pdf_path__isarect(pa, ignore_rule);
   if (isrect) {
     pe  = &(pa->path[0]);
     pe1 = &(pa->path[2]);
@@ -1071,7 +1071,7 @@ copy_a_gstate (pdf_gstate *gs1, pdf_gstate *gs2)
 
   return;
 }
-    
+
 void
 pdf_dev_init_gstates (void)
 {
@@ -1346,8 +1346,8 @@ pdf_dev_concat (const pdf_tmatrix *M)
  * array num d  D   line dash
  * int ri       RI  renderint intnet
  * int i        FL  flatness tolerance (0-100)
- * name gs      --  name: res. name of ExtGState dict.  
- */      
+ * name gs      --  name: res. name of ExtGState dict.
+ */
 int
 pdf_dev_setmiterlimit (double mlimit)
 {
@@ -1406,7 +1406,7 @@ int
 pdf_dev_setlinewidth (double width)
 {
   m_stack    *gss = &gs_stack;
-  pdf_gstate *gs  = m_stack_top(gss);  
+  pdf_gstate *gs  = m_stack_top(gss);
   int         len = 0;
   char       *buf = fmt_buf;
 
@@ -1778,7 +1778,7 @@ pdf_dev_bspline (double x0, double y0,
   m_stack    *gss = &gs_stack;
   pdf_gstate *gs  = m_stack_top(gss);
   pdf_path   *cpa = &gs->path;
-  pdf_coord  *cpt = &gs->cp;  
+  pdf_coord  *cpt = &gs->cp;
   pdf_coord   p1, p2, p3;
 
   p1.x = x0 + 2.0 * (x1 - x0) / 3.0;
@@ -1833,7 +1833,7 @@ pdf_dev_rectclip (double x, double y,
   r.lly = y;
   r.urx = x + w;
   r.ury = y + h;
-  
+
   return  pdf_dev__rectshape(&r, NULL, 'W');
 }
 

--- a/tectonic/dpx-pdfdraw.h
+++ b/tectonic/dpx-pdfdraw.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -94,7 +94,7 @@ extern int    pdf_dev_arc           (double c_x, double c_y, double r,
                                      double a_0, double a_1);
 extern int    pdf_dev_arcn          (double c_x, double c_y, double r,
                                      double a_0, double a_1);
-  
+
 #define PDF_FILL_RULE_NONZERO 0
 #define PDF_FILL_RULE_EVENODD 1
 
@@ -114,7 +114,7 @@ extern int    pdf_dev_rectstroke    (double x, double y,
 extern int    pdf_dev_rectfill      (double x, double y, double w, double h);
 extern int    pdf_dev_rectclip      (double x, double y, double w, double h);
 extern int    pdf_dev_rectadd       (double x, double y, double w, double h);
- 
+
 extern int    pdf_dev_flushpath     (char p_op, int fill_rule);
 
 extern int    pdf_dev_concat        (const pdf_tmatrix *M);
@@ -146,9 +146,9 @@ extern int    pdf_dev_bspline       (double x0, double y0,
                                      double x1, double y1,
                                      double x2, double y2);
 
- 
+
 extern void   pdf_invertmatrix      (pdf_tmatrix *M);
-  
+
 /* The depth here is the depth of q/Q nesting.
  * We must remember current depth of nesting when starting a page or xform,
  * and must recover until that depth at the end of page/xform.

--- a/tectonic/dpx-pdfencoding.c
+++ b/tectonic/dpx-pdfencoding.c
@@ -122,29 +122,29 @@ create_encoding_resource (pdf_encoding *encoding, pdf_encoding *baseenc)
     assert(!encoding->resource);
 
     differences = make_encoding_differences(encoding->glyphs,
-					    baseenc ? baseenc->glyphs : NULL,
-					    encoding->is_used);
+                                            baseenc ? baseenc->glyphs : NULL,
+                                            encoding->is_used);
 
     if (differences) {
-	pdf_obj *resource = pdf_new_dict();
-	if (baseenc)
-	    pdf_add_dict(resource, pdf_new_name("BaseEncoding"),
-			 pdf_link_obj(baseenc->resource));
-	pdf_add_dict(resource, pdf_new_name("Differences"),  differences);
-	return resource;
+        pdf_obj *resource = pdf_new_dict();
+        if (baseenc)
+            pdf_add_dict(resource, pdf_new_name("BaseEncoding"),
+                         pdf_link_obj(baseenc->resource));
+        pdf_add_dict(resource, pdf_new_name("Differences"),  differences);
+        return resource;
     } else {
-	/* Fix a bug with the MinionPro package using MnSymbol fonts
-	 * in its virtual fonts:
-	 *
-	 * Some font may have font_id even if no character is used.
-	 * For example, suppose that a virtual file A.vf uses two
-	 * other fonts, B and C. Even if only characters of B are used
-	 * in a DVI document, C will have font_id too.
-	 * In this case, both baseenc and differences can be NULL.
-	 *
-	 * Actually these fonts will be ignored in pdffont.c.
-	 */
-	return baseenc ? pdf_link_obj(baseenc->resource) : NULL;
+        /* Fix a bug with the MinionPro package using MnSymbol fonts
+         * in its virtual fonts:
+         *
+         * Some font may have font_id even if no character is used.
+         * For example, suppose that a virtual file A.vf uses two
+         * other fonts, B and C. Even if only characters of B are used
+         * in a DVI document, C will have font_id too.
+         * In this case, both baseenc and differences can be NULL.
+         *
+         * Actually these fonts will be ignored in pdffont.c.
+         */
+        return baseenc ? pdf_link_obj(baseenc->resource) : NULL;
     }
 }
 
@@ -154,12 +154,12 @@ pdf_flush_encoding (pdf_encoding *encoding)
     assert(encoding);
 
     if (encoding->resource) {
-	pdf_release_obj(encoding->resource);
-	encoding->resource  = NULL;
+        pdf_release_obj(encoding->resource);
+        encoding->resource  = NULL;
     }
     if (encoding->tounicode) {
-	pdf_release_obj(encoding->tounicode);
-	encoding->tounicode = NULL;
+        pdf_release_obj(encoding->tounicode);
+        encoding->tounicode = NULL;
     }
 
     return;
@@ -173,22 +173,22 @@ pdf_clean_encoding_struct (pdf_encoding *encoding)
     assert(encoding);
 
     if (encoding->resource)
-	_tt_abort("Object not flushed.");
+        _tt_abort("Object not flushed.");
 
     if (encoding->tounicode)
-	pdf_release_obj(encoding->tounicode);
+        pdf_release_obj(encoding->tounicode);
     if (encoding->ident)
-	free(encoding->ident);
+        free(encoding->ident);
     if (encoding->enc_name)
-	free(encoding->enc_name);
+        free(encoding->enc_name);
 
     encoding->ident    = NULL;
     encoding->enc_name = NULL;
 
     for (code = 0; code < 256; code++) {
-	if (encoding->glyphs[code])
-	    free(encoding->glyphs[code]);
-	encoding->glyphs[code] = NULL;
+        if (encoding->glyphs[code])
+            free(encoding->glyphs[code]);
+        encoding->glyphs[code] = NULL;
     }
     encoding->ident    = NULL;
     encoding->enc_name = NULL;
@@ -215,10 +215,10 @@ is_similar_charset (char **enc_vec, const char **enc_vec2)
     int   code, same = 0;
 
     for (code = 0; code < 256; code++)
-	if (!(enc_vec[code] && strcmp(enc_vec[code], enc_vec2[code]))
-	    && ++same >= 64)
-	    /* is 64 a good level? */
-	    return 1;
+        if (!(enc_vec[code] && strcmp(enc_vec[code], enc_vec2[code]))
+            && ++same >= 64)
+            /* is 64 a good level? */
+            return 1;
 
     return 0;
 }
@@ -242,23 +242,23 @@ make_encoding_differences (char **enc_vec, char **baseenc, const char *is_used)
      */
     differences = pdf_new_array();
     for (code = 0; code < 256; code++) {
-	/* We skip NULL (= ".notdef"). Any character code mapped to ".notdef"
-	 * glyph should not be used in the document.
-	 */
-	if ((is_used && !is_used[code]) || !enc_vec[code])
-	    skipping = 1;
-	else if (!baseenc || !baseenc[code] ||
-		 strcmp(baseenc[code], enc_vec[code]) != 0) {
-	    /*
-	     * Difference found.
-	     */
-	    if (skipping)
-		pdf_add_array(differences, pdf_new_number(code));
-	    pdf_add_array(differences,   pdf_new_name(enc_vec[code]));
-	    skipping = 0;
-	    count++;
-	} else
-	    skipping = 1;
+        /* We skip NULL (= ".notdef"). Any character code mapped to ".notdef"
+         * glyph should not be used in the document.
+         */
+        if ((is_used && !is_used[code]) || !enc_vec[code])
+            skipping = 1;
+        else if (!baseenc || !baseenc[code] ||
+                 strcmp(baseenc[code], enc_vec[code]) != 0) {
+            /*
+             * Difference found.
+             */
+            if (skipping)
+                pdf_add_array(differences, pdf_new_number(code));
+            pdf_add_array(differences,   pdf_new_name(enc_vec[code]));
+            skipping = 0;
+            count++;
+        } else
+            skipping = 1;
     }
 
     /*
@@ -266,8 +266,8 @@ make_encoding_differences (char **enc_vec, char **baseenc, const char *is_used)
      * any differences. We return NULL.
      */
     if (count == 0) {
-	pdf_release_obj(differences);
-	differences = NULL;
+        pdf_release_obj(differences);
+        differences = NULL;
     }
 
     return differences;
@@ -286,20 +286,20 @@ load_encoding_file (const char *filename)
     int code, fsize, enc_id;
 
     if (!filename)
-	return -1;
+        return -1;
 
     if (verbose)
-	dpx_message("(Encoding:%s", filename);
+        dpx_message("(Encoding:%s", filename);
 
     handle = dpx_tt_open(filename, ".enc", kpse_enc_format);
     if (handle == NULL)
-	return -1;
+        return -1;
 
     fsize = ttstub_input_get_size(handle);
     wbuf = NEW(fsize + 1, char);
     wbuf[fsize] = '\0';
     if (ttstub_input_read (handle, wbuf, fsize) != fsize)
-	_tt_abort("error reading %s", filename);
+        _tt_abort("error reading %s", filename);
     ttstub_input_close(handle);
 
     p = wbuf;
@@ -311,48 +311,48 @@ load_encoding_file (const char *filename)
      * Skip comment lines.
      */
     while (p < endptr && p[0] == '%') {
-	pdfparse_skip_line (&p, endptr);
-	skip_white(&p, endptr);
+        pdfparse_skip_line (&p, endptr);
+        skip_white(&p, endptr);
     }
 
     if (p[0] == '/')
-	enc_name = parse_pdf_name(&p, endptr);
+        enc_name = parse_pdf_name(&p, endptr);
 
     skip_white(&p, endptr);
     encoding_array = parse_pdf_array(&p, endptr, NULL);
     free(wbuf);
 
     if (!encoding_array) {
-	if (enc_name)
-	    pdf_release_obj(enc_name);
-	return -1;
+        if (enc_name)
+            pdf_release_obj(enc_name);
+        return -1;
     }
 
     for (code = 0; code < 256; code++)
-	enc_vec[code] = pdf_name_value(pdf_get_array(encoding_array, code));
+        enc_vec[code] = pdf_name_value(pdf_get_array(encoding_array, code));
 
     enc_id = pdf_encoding_new_encoding(enc_name ? pdf_name_value(enc_name) : NULL,
-				       filename, enc_vec, NULL, 0);
+                                       filename, enc_vec, NULL, 0);
 
     if (enc_name) {
-	if (verbose > 1)
-	    dpx_message("[%s]", pdf_name_value(enc_name));
-	pdf_release_obj(enc_name);
+        if (verbose > 1)
+            dpx_message("[%s]", pdf_name_value(enc_name));
+        pdf_release_obj(enc_name);
     }
 
     pdf_release_obj(encoding_array);
 
     if (verbose)
-	dpx_message(")");
+        dpx_message(")");
 
     return enc_id;
 }
 
 
 #define CHECK_ID(n) do {				\
-	if ((n) < 0 || (n) >= enc_cache.count) {	\
-	    _tt_abort("Invalid encoding id: %d", (n));	\
-	}						\
+        if ((n) < 0 || (n) >= enc_cache.count) {	\
+            _tt_abort("Invalid encoding id: %d", (n));	\
+        }						\
     } while (0)
 
 #define CACHE_ALLOC_SIZE 16u
@@ -376,11 +376,11 @@ pdf_init_encodings (void)
      * PDF Predefined Encodings
      */
     pdf_encoding_new_encoding("WinAnsiEncoding", "WinAnsiEncoding",
-			      WinAnsiEncoding, NULL, FLAG_IS_PREDEFINED);
+                              WinAnsiEncoding, NULL, FLAG_IS_PREDEFINED);
     pdf_encoding_new_encoding("MacRomanEncoding", "MacRomanEncoding",
-			      MacRomanEncoding, NULL, FLAG_IS_PREDEFINED);
+                              MacRomanEncoding, NULL, FLAG_IS_PREDEFINED);
     pdf_encoding_new_encoding("MacExpertEncoding", "MacExpertEncoding",
-			      MacExpertEncoding, NULL, FLAG_IS_PREDEFINED);
+                              MacExpertEncoding, NULL, FLAG_IS_PREDEFINED);
 
     return;
 }
@@ -409,9 +409,9 @@ pdf_encoding_new_encoding (const char *enc_name, const char *ident,
 
     enc_id   = enc_cache.count;
     if (enc_cache.count++ >= enc_cache.capacity) {
-	enc_cache.capacity += 16;
-	enc_cache.encodings = RENEW(enc_cache.encodings,
-				    enc_cache.capacity,  pdf_encoding);
+        enc_cache.capacity += 16;
+        enc_cache.encodings = RENEW(enc_cache.encodings,
+                                    enc_cache.capacity,  pdf_encoding);
     }
     encoding = &enc_cache.encodings[enc_id];
 
@@ -425,28 +425,28 @@ pdf_encoding_new_encoding (const char *enc_name, const char *ident,
     encoding->flags = flags;
 
     for (code = 0; code < 256; code++)
-	if (encoding_vec[code] && strcmp(encoding_vec[code], ".notdef")) {
-	    encoding->glyphs[code] = NEW(strlen(encoding_vec[code])+1, char);
-	    strcpy(encoding->glyphs[code], encoding_vec[code]);
-	}
+        if (encoding_vec[code] && strcmp(encoding_vec[code], ".notdef")) {
+            encoding->glyphs[code] = NEW(strlen(encoding_vec[code])+1, char);
+            strcpy(encoding->glyphs[code], encoding_vec[code]);
+        }
 
     if (!baseenc_name && !(flags & FLAG_IS_PREDEFINED)
-	&& is_similar_charset(encoding->glyphs, WinAnsiEncoding)) {
-	/* Dvipdfmx default setting. */
-	baseenc_name = "WinAnsiEncoding";
+        && is_similar_charset(encoding->glyphs, WinAnsiEncoding)) {
+        /* Dvipdfmx default setting. */
+        baseenc_name = "WinAnsiEncoding";
     }
 
     /* TODO: make base encoding configurable */
     if (baseenc_name) {
-	int baseenc_id = pdf_encoding_findresource(baseenc_name);
-	if (baseenc_id < 0 || !pdf_encoding_is_predefined(baseenc_id))
-	    _tt_abort("Illegal base encoding %s for encoding %s\n",
-		  baseenc_name, encoding->enc_name);
-	encoding->baseenc = &enc_cache.encodings[baseenc_id];
+        int baseenc_id = pdf_encoding_findresource(baseenc_name);
+        if (baseenc_id < 0 || !pdf_encoding_is_predefined(baseenc_id))
+            _tt_abort("Illegal base encoding %s for encoding %s\n",
+                  baseenc_name, encoding->enc_name);
+        encoding->baseenc = &enc_cache.encodings[baseenc_id];
     }
 
     if (flags & FLAG_IS_PREDEFINED)
-	encoding->resource = pdf_new_name(encoding->enc_name);
+        encoding->resource = pdf_new_name(encoding->enc_name);
 
     return enc_id;
 }
@@ -459,24 +459,24 @@ void pdf_encoding_complete (void)
     int  enc_id;
 
     for (enc_id = 0; enc_id < enc_cache.count; enc_id++) {
-	if (!pdf_encoding_is_predefined(enc_id)) {
-	    pdf_encoding *encoding = &enc_cache.encodings[enc_id];
-	    /* Section 5.5.4 of the PDF 1.5 reference says that the encoding
-	     * of a Type 3 font must be completely described by a Differences
-	     * array, but implementation note 56 explains that this is rather
-	     * an incorrect implementation in Acrobat 4 and earlier. Hence,
-	     * we do use a base encodings for PDF versions >= 1.3.
-	     */
-	    int with_base = !(encoding->flags & FLAG_USED_BY_TYPE3)
-		|| pdf_get_version() >= 4;
-	    assert(!encoding->resource);
-	    encoding->resource = create_encoding_resource(encoding,
-							  with_base ? encoding->baseenc : NULL);
-	    assert(!encoding->tounicode);
-	    encoding->tounicode = pdf_create_ToUnicode_CMap(encoding->enc_name,
-							    encoding->glyphs,
-							    encoding->is_used);
-	}
+        if (!pdf_encoding_is_predefined(enc_id)) {
+            pdf_encoding *encoding = &enc_cache.encodings[enc_id];
+            /* Section 5.5.4 of the PDF 1.5 reference says that the encoding
+             * of a Type 3 font must be completely described by a Differences
+             * array, but implementation note 56 explains that this is rather
+             * an incorrect implementation in Acrobat 4 and earlier. Hence,
+             * we do use a base encodings for PDF versions >= 1.3.
+             */
+            int with_base = !(encoding->flags & FLAG_USED_BY_TYPE3)
+                || pdf_get_version() >= 4;
+            assert(!encoding->resource);
+            encoding->resource = create_encoding_resource(encoding,
+                                                          with_base ? encoding->baseenc : NULL);
+            assert(!encoding->tounicode);
+            encoding->tounicode = pdf_create_ToUnicode_CMap(encoding->enc_name,
+                                                            encoding->glyphs,
+                                                            encoding->is_used);
+        }
     }
 }
 
@@ -486,16 +486,16 @@ pdf_close_encodings (void)
     int  enc_id;
 
     if (enc_cache.encodings) {
-	for (enc_id = 0; enc_id < enc_cache.count; enc_id++) {
-	    pdf_encoding *encoding;
+        for (enc_id = 0; enc_id < enc_cache.count; enc_id++) {
+            pdf_encoding *encoding;
 
-	    encoding = &enc_cache.encodings[enc_id];
-	    if (encoding) {
-		pdf_flush_encoding(encoding);
-		pdf_clean_encoding_struct(encoding);
-	    }
-	}
-	free(enc_cache.encodings);
+            encoding = &enc_cache.encodings[enc_id];
+            if (encoding) {
+                pdf_flush_encoding(encoding);
+                pdf_clean_encoding_struct(encoding);
+            }
+        }
+        free(enc_cache.encodings);
     }
     enc_cache.encodings = NULL;
     enc_cache.count     = 0;
@@ -510,13 +510,13 @@ pdf_encoding_findresource (const char *enc_name)
 
     assert(enc_name);
     for (enc_id = 0; enc_id < enc_cache.count; enc_id++) {
-	encoding = &enc_cache.encodings[enc_id];
-	if (encoding->ident &&
-	    !strcmp(enc_name, encoding->ident))
-	    return enc_id;
-	else if (encoding->enc_name &&
-		 !strcmp(enc_name, encoding->enc_name))
-	    return enc_id;
+        encoding = &enc_cache.encodings[enc_id];
+        if (encoding->ident &&
+            !strcmp(enc_name, encoding->ident))
+            return enc_id;
+        else if (encoding->enc_name &&
+                 !strcmp(enc_name, encoding->enc_name))
+            return enc_id;
     }
 
     return load_encoding_file(enc_name);
@@ -611,12 +611,12 @@ pdf_encoding_add_usedchars (int encoding_id, const char *is_used)
     CHECK_ID(encoding_id);
 
     if (!is_used || pdf_encoding_is_predefined(encoding_id))
-	return;
+        return;
 
     encoding = &enc_cache.encodings[encoding_id];
 
     for (code = 0; code <= 0xff; code++)
-	encoding->is_used[code] |= is_used[code];
+        encoding->is_used[code] |= is_used[code];
 }
 
 pdf_obj *
@@ -664,27 +664,27 @@ pdf_create_ToUnicode_CMap (const char *enc_name,
 
     all_predef = 1;
     for (code = 0; code <= 0xff; code++) {
-	if (is_used && !is_used[code])
-	    continue;
+        if (is_used && !is_used[code])
+            continue;
 
-	if (enc_vec[code]) {
-	    int32_t len;
-	    int    fail_count = 0;
-	    agl_name *agln = agl_lookup_list(enc_vec[code]);
-	    /* Adobe glyph naming conventions are not used by viewers,
-	     * hence even ligatures (e.g, "f_i") must be explicitly defined
-	     */
-	    if (pdf_get_version() < 5 || !agln || !agln->is_predef) {
-		wbuf[0] = (code & 0xff);
-		p      = wbuf + 1;
-		endptr = wbuf + WBUF_SIZE;
-		len = agl_sput_UTF16BE(enc_vec[code], &p, endptr, &fail_count);
-		if (len >= 1 && !fail_count) {
-		    CMap_add_bfchar(cmap, wbuf, 1, wbuf + 1, len);
-		    all_predef &= agln && agln->is_predef;
-		}
-	    }
-	}
+        if (enc_vec[code]) {
+            int32_t len;
+            int    fail_count = 0;
+            agl_name *agln = agl_lookup_list(enc_vec[code]);
+            /* Adobe glyph naming conventions are not used by viewers,
+             * hence even ligatures (e.g, "f_i") must be explicitly defined
+             */
+            if (pdf_get_version() < 5 || !agln || !agln->is_predef) {
+                wbuf[0] = (code & 0xff);
+                p      = wbuf + 1;
+                endptr = wbuf + WBUF_SIZE;
+                len = agl_sput_UTF16BE(enc_vec[code], &p, endptr, &fail_count);
+                if (len >= 1 && !fail_count) {
+                    CMap_add_bfchar(cmap, wbuf, 1, wbuf + 1, len);
+                    all_predef &= agln && agln->is_predef;
+                }
+            }
+        }
     }
 
     stream = all_predef ? NULL : CMap_create_stream(cmap);
@@ -704,27 +704,27 @@ pdf_load_ToUnicode_stream (const char *ident)
     rust_input_handle_t handle = NULL;
 
     if (!ident)
-	return NULL;
+        return NULL;
 
     handle = ttstub_input_open(ident, kpse_cmap_format, 0);
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     if (CMap_parse_check_sig(handle) < 0) {
-	ttstub_input_close(handle);
-	return NULL;
+        ttstub_input_close(handle);
+        return NULL;
     }
 
     cmap = CMap_new();
     if (CMap_parse(cmap, handle) < 0) {
-	dpx_warning("Reading CMap file \"%s\" failed.", ident);
+        dpx_warning("Reading CMap file \"%s\" failed.", ident);
     } else {
-	if (verbose)
-	    dpx_message("(CMap:%s)", ident);
+        if (verbose)
+            dpx_message("(CMap:%s)", ident);
 
-	stream = CMap_create_stream(cmap);
-	if (!stream)
-	    dpx_warning("Failed to creat ToUnicode CMap stream for \"%s\".", ident);
+        stream = CMap_create_stream(cmap);
+        if (!stream)
+            dpx_warning("Failed to creat ToUnicode CMap stream for \"%s\".", ident);
     }
 
     CMap_release(cmap);

--- a/tectonic/dpx-pdfencoding.c
+++ b/tectonic/dpx-pdfencoding.c
@@ -349,10 +349,10 @@ load_encoding_file (const char *filename)
 }
 
 
-#define CHECK_ID(n) do {				\
-        if ((n) < 0 || (n) >= enc_cache.count) {	\
-            _tt_abort("Invalid encoding id: %d", (n));	\
-        }						\
+#define CHECK_ID(n) do {                               \
+        if ((n) < 0 || (n) >= enc_cache.count) {       \
+            _tt_abort("Invalid encoding id: %d", (n)); \
+        }                                              \
     } while (0)
 
 #define CACHE_ALLOC_SIZE 16u

--- a/tectonic/dpx-pdfencoding.h
+++ b/tectonic/dpx-pdfencoding.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -30,7 +30,7 @@ extern void      pdf_encoding_set_verbose    (void);
 extern void      pdf_init_encodings          (void);
 extern void      pdf_close_encodings         (void);
 
-/* Creates Encoding resource and ToUnicode CMap 
+/* Creates Encoding resource and ToUnicode CMap
  * for all non-predefined encodings.
  */
 extern void      pdf_encoding_complete       (void);
@@ -53,7 +53,7 @@ extern void      pdf_encoding_used_by_type3  (int enc_id);
 extern char     *pdf_encoding_get_name       (int enc_id);
 extern char    **pdf_encoding_get_encoding   (int enc_id);
 
-/* 
+/*
  * pdf_create_ToUnicode_CMap() returns stream object but not
  * reference. This need to be renamed to other name like
  * pdf_create_ToUnicode_stream().
@@ -72,7 +72,7 @@ extern pdf_obj * pdf_encoding_get_tounicode  (int encoding_id);
 
 /* Just load CMap identified with 'ident'. (parsed)
  * PDF stream object (not reference) returned.
- */ 
+ */
 extern pdf_obj  *pdf_load_ToUnicode_stream   (const char *ident);
 
 #endif /* _PDFENCODINGS_H_ */

--- a/tectonic/dpx-pdfencoding.h
+++ b/tectonic/dpx-pdfencoding.h
@@ -59,14 +59,14 @@ extern char    **pdf_encoding_get_encoding   (int enc_id);
  * pdf_create_ToUnicode_stream().
  */
 extern pdf_obj  *pdf_create_ToUnicode_CMap   (const char *enc_name,
-					      char **enc_vec,
-					      const char *is_used);
+                                              char **enc_vec,
+                                              const char *is_used);
 
 /* pdf_encoding_copy_usedchars adds the given vector of used characters
  * to the corresponding vector of the encoding.
  */
 extern void      pdf_encoding_add_usedchars (int encoding_id,
-					      const char *is_used);
+                                              const char *is_used);
 
 extern pdf_obj * pdf_encoding_get_tounicode  (int encoding_id);
 

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -576,7 +576,7 @@ pdf_enc_set_passwd (unsigned int bits, unsigned int perm,
       strncpy(input, getpass("Owner password: "), MAX_PWD_LEN);
       retry_passwd = getpass("Re-enter owner password: ");
       if (!strncmp(input, retry_passwd, MAX_PWD_LEN))
-	break;
+        break;
       fputs("Password is not identical.\nTry again.\n", stderr);
       fflush(stderr);
     }
@@ -591,7 +591,7 @@ pdf_enc_set_passwd (unsigned int bits, unsigned int perm,
       strncpy(input, getpass("User password: "), MAX_PWD_LEN);
       retry_passwd = getpass("Re-enter user password: ");
       if (!strncmp(input, retry_passwd, MAX_PWD_LEN))
-	break;
+        break;
       fputs("Password is not identical.\nTry again.\n", stderr);
       fflush(stderr);
     }

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -724,7 +724,7 @@ pdf_encrypt_obj (void)
     pdf_add_dict(doc_encrypt, pdf_new_name("O"), pdf_new_string(p->O, 48));
     pdf_add_dict(doc_encrypt, pdf_new_name("U"), pdf_new_string(p->U, 48));
   }
-  pdf_add_dict(doc_encrypt,	pdf_new_name("P"), pdf_new_number(p->P));
+  pdf_add_dict(doc_encrypt, pdf_new_name("P"), pdf_new_number(p->P));
 
   if (p->V == 5) {
     unsigned char perms[16], *cipher = NULL;

--- a/tectonic/dpx-pdfencrypt.h
+++ b/tectonic/dpx-pdfencrypt.h
@@ -1,20 +1,20 @@
-/*  
+/*
 
     This is dvipdfmx, an eXtended version of dvipdfm by Mark A. Wicks.
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdffont.c
+++ b/tectonic/dpx-pdffont.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2008-2016 by Jin-Hwan Cho, Matthias Franz, and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -293,7 +293,7 @@ static struct {
 void
 pdf_init_fonts (void)
 {
-  assert(font_cache.fonts == NULL);  
+  assert(font_cache.fonts == NULL);
 
   agl_init_map();
   otl_init_conf();
@@ -805,7 +805,7 @@ pdf_font_findresource (const char *tex_name,
   return  font_id;
 }
 
-int 
+int
 pdf_font_is_in_use (pdf_font *font)
 {
   assert(font);

--- a/tectonic/dpx-pdffont.c
+++ b/tectonic/dpx-pdffont.c
@@ -209,30 +209,30 @@ pdf_flush_font (pdf_font *font)
   if (font->resource && font->reference) {
     if (font->subtype != PDF_FONT_FONTTYPE_TYPE3) {
       if (pdf_font_get_flag(font, PDF_FONT_FLAG_NOEMBED)) {
-	pdf_add_dict(font->resource,
-		     pdf_new_name("BaseFont"), pdf_new_name(font->fontname));
-	if (font->descriptor) {
-	  pdf_add_dict(font->descriptor,
-		       pdf_new_name("FontName"), pdf_new_name(font->fontname));
-	}
+        pdf_add_dict(font->resource,
+                     pdf_new_name("BaseFont"), pdf_new_name(font->fontname));
+        if (font->descriptor) {
+          pdf_add_dict(font->descriptor,
+                       pdf_new_name("FontName"), pdf_new_name(font->fontname));
+        }
       } else {
-	if (!font->fontname) {
-	  _tt_abort("Undefined in fontname... (%s)", font->ident);
-	}
-	fontname  = NEW(7+strlen(font->fontname)+1, char);
-	uniqueTag = pdf_font_get_uniqueTag(font);
-	sprintf(fontname, "%6s+%s", uniqueTag, font->fontname);
-	pdf_add_dict(font->resource,
-		     pdf_new_name("BaseFont"), pdf_new_name(fontname));
-	if (font->descriptor) {
-	  pdf_add_dict(font->descriptor,
-		       pdf_new_name("FontName"), pdf_new_name(fontname));
-	}
-	free(fontname);
+        if (!font->fontname) {
+          _tt_abort("Undefined in fontname... (%s)", font->ident);
+        }
+        fontname  = NEW(7+strlen(font->fontname)+1, char);
+        uniqueTag = pdf_font_get_uniqueTag(font);
+        sprintf(fontname, "%6s+%s", uniqueTag, font->fontname);
+        pdf_add_dict(font->resource,
+                     pdf_new_name("BaseFont"), pdf_new_name(fontname));
+        if (font->descriptor) {
+          pdf_add_dict(font->descriptor,
+                       pdf_new_name("FontName"), pdf_new_name(fontname));
+        }
+        free(fontname);
       }
       if (font->descriptor) {
-	pdf_add_dict(font->resource,
-		     pdf_new_name("FontDescriptor"), pdf_ref_obj(font->descriptor));
+        pdf_add_dict(font->resource,
+                     pdf_new_name("FontDescriptor"), pdf_ref_obj(font->descriptor));
       }
     }
   }
@@ -483,24 +483,24 @@ pdf_close_fonts (void)
 
     if (__verbose) {
       if (font->subtype != PDF_FONT_FONTTYPE_TYPE0) {
-	dpx_message("(%s", pdf_font_get_ident(font));
-	if (__verbose > 2 &&
-	    !pdf_font_get_flag(font, PDF_FONT_FLAG_NOEMBED)) {
-	  dpx_message("[%s+%s]",
-	       pdf_font_get_uniqueTag(font),
-	       pdf_font_get_fontname(font));
-	} else if (__verbose > 1) {
-	  dpx_message("[%s]",
-	       pdf_font_get_fontname(font));
-	}
-	if (__verbose > 1) {
-	  if (pdf_font_get_encoding(font) >= 0) {
-	    dpx_message("[%s]",
-		 pdf_encoding_get_name(pdf_font_get_encoding(font)));
-	  } else {
-	    dpx_message("[built-in]");
-	  }
-	}
+        dpx_message("(%s", pdf_font_get_ident(font));
+        if (__verbose > 2 &&
+            !pdf_font_get_flag(font, PDF_FONT_FLAG_NOEMBED)) {
+          dpx_message("[%s+%s]",
+               pdf_font_get_uniqueTag(font),
+               pdf_font_get_fontname(font));
+        } else if (__verbose > 1) {
+          dpx_message("[%s]",
+               pdf_font_get_fontname(font));
+        }
+        if (__verbose > 1) {
+          if (pdf_font_get_encoding(font) >= 0) {
+            dpx_message("[%s]",
+                 pdf_encoding_get_name(pdf_font_get_encoding(font)));
+          } else {
+            dpx_message("[built-in]");
+          }
+        }
 
       }
     }
@@ -512,23 +512,23 @@ pdf_close_fonts (void)
     switch (font->subtype) {
     case PDF_FONT_FONTTYPE_TYPE1:
       if (__verbose)
-	dpx_message("[Type1]");
+        dpx_message("[Type1]");
       if (!pdf_font_get_flag(font, PDF_FONT_FLAG_BASEFONT))
-	pdf_font_load_type1(font);
+        pdf_font_load_type1(font);
       break;
     case PDF_FONT_FONTTYPE_TYPE1C:
       if (__verbose)
-	dpx_message("[Type1C]");
+        dpx_message("[Type1C]");
       pdf_font_load_type1c(font);
       break;
     case PDF_FONT_FONTTYPE_TRUETYPE:
       if (__verbose)
-	dpx_message("[TrueType]");
+        dpx_message("[TrueType]");
       pdf_font_load_truetype(font);
       break;
     case PDF_FONT_FONTTYPE_TYPE3:
       if (__verbose)
-	dpx_message("[Type3/PK]");
+        dpx_message("[Type3/PK]");
       pdf_font_load_pkfont (font);
       break;
     case PDF_FONT_FONTTYPE_TYPE0:
@@ -543,7 +543,7 @@ pdf_close_fonts (void)
 
     if (__verbose) {
       if (font->subtype != PDF_FONT_FONTTYPE_TYPE0)
-	dpx_message(")");
+        dpx_message(")");
     }
   }
 
@@ -557,22 +557,22 @@ pdf_close_fonts (void)
       pdf_obj *tounicode;
 
       /* Predefined encodings (and those simplified to them) are embedded
-	 as direct objects, but this is purely a matter of taste. */
+         as direct objects, but this is purely a matter of taste. */
       if (enc_obj)
         pdf_add_dict(font->resource,
-		     pdf_new_name("Encoding"),
-		     PDF_OBJ_NAMETYPE(enc_obj) ? pdf_link_obj(enc_obj) : pdf_ref_obj(enc_obj));
+                     pdf_new_name("Encoding"),
+                     PDF_OBJ_NAMETYPE(enc_obj) ? pdf_link_obj(enc_obj) : pdf_ref_obj(enc_obj));
 
       if (!pdf_lookup_dict(font->resource, "ToUnicode")
-	  && (tounicode = pdf_encoding_get_tounicode(font->encoding_id)))
-	pdf_add_dict(font->resource,
-		     pdf_new_name("ToUnicode"), pdf_ref_obj(tounicode));
+          && (tounicode = pdf_encoding_get_tounicode(font->encoding_id)))
+        pdf_add_dict(font->resource,
+                     pdf_new_name("ToUnicode"), pdf_ref_obj(tounicode));
     } else if (font->subtype == PDF_FONT_FONTTYPE_TRUETYPE) {
       /* encoding_id < 0 means MacRoman here (but not really)
        * We use MacRoman as "default" encoding. */
       pdf_add_dict(font->resource,
                    pdf_new_name("Encoding"),
-		   pdf_new_name("MacRomanEncoding"));
+                   pdf_new_name("MacRomanEncoding"));
     }
 
     pdf_flush_font(font);
@@ -596,7 +596,7 @@ pdf_close_fonts (void)
 
 int
 pdf_font_findresource (const char *tex_name,
-		       double font_scale, fontmap_rec *mrec)
+                       double font_scale, fontmap_rec *mrec)
 {
   int          font_id = -1;
   pdf_font    *font;
@@ -613,48 +613,48 @@ pdf_font_findresource (const char *tex_name,
     if (MAYBE_CMAP(mrec->enc_name)) {
       cmap_id = CMap_cache_find(mrec->enc_name);
       if (cmap_id >= 0) {
-	CMap  *cmap;
-	int    cmap_type, minbytes;
+        CMap  *cmap;
+        int    cmap_type, minbytes;
 
-	cmap      = CMap_cache_get(cmap_id);
-	cmap_type = CMap_get_type (cmap);
-	minbytes  = CMap_get_profile(cmap, CMAP_PROF_TYPE_INBYTES_MIN);
-	/*
-	 * Check for output encoding.
-	 */
-	if (cmap_type != CMAP_TYPE_IDENTITY    &&
-	    cmap_type != CMAP_TYPE_CODE_TO_CID &&
-	    cmap_type != CMAP_TYPE_TO_UNICODE) {
-	  dpx_warning("Only 16-bit encoding supported for output encoding.");
-	}
-	/*
-	 * Turn on map option.
-	 */
-	if (minbytes == 2 && mrec->opt.mapc < 0) {
-	  if (__verbose) {
-	    dpx_message("\n");
-	    dpx_message("pdf_font>> Input encoding \"%s\" requires at least 2 bytes.\n",
-		 CMap_get_name(cmap));
-	    dpx_message("pdf_font>> The -m <00> option will be assumed for \"%s\".\n", mrec->font_name);
-	  }
-	  mrec->opt.mapc = 0; /* _FIXME_ */
-	}
+        cmap      = CMap_cache_get(cmap_id);
+        cmap_type = CMap_get_type (cmap);
+        minbytes  = CMap_get_profile(cmap, CMAP_PROF_TYPE_INBYTES_MIN);
+        /*
+         * Check for output encoding.
+         */
+        if (cmap_type != CMAP_TYPE_IDENTITY    &&
+            cmap_type != CMAP_TYPE_CODE_TO_CID &&
+            cmap_type != CMAP_TYPE_TO_UNICODE) {
+          dpx_warning("Only 16-bit encoding supported for output encoding.");
+        }
+        /*
+         * Turn on map option.
+         */
+        if (minbytes == 2 && mrec->opt.mapc < 0) {
+          if (__verbose) {
+            dpx_message("\n");
+            dpx_message("pdf_font>> Input encoding \"%s\" requires at least 2 bytes.\n",
+                 CMap_get_name(cmap));
+            dpx_message("pdf_font>> The -m <00> option will be assumed for \"%s\".\n", mrec->font_name);
+          }
+          mrec->opt.mapc = 0; /* _FIXME_ */
+        }
       } else if (!strcmp(mrec->enc_name, "unicode")) {
-	cmap_id = otf_load_Unicode_CMap(mrec->font_name,
-					mrec->opt.index, mrec->opt.otl_tags,
-					((mrec->opt.flags & FONTMAP_OPT_VERT) ? 1 : 0));
-	if (cmap_id < 0) {
-	  cmap_id = t1_load_UnicodeCMap(mrec->font_name, mrec->opt.otl_tags,
-					((mrec->opt.flags & FONTMAP_OPT_VERT) ? 1 : 0));
-	}
-	if (cmap_id < 0)
-	  _tt_abort("Failed to read UCS2/UCS4 TrueType cmap...");
+        cmap_id = otf_load_Unicode_CMap(mrec->font_name,
+                                        mrec->opt.index, mrec->opt.otl_tags,
+                                        ((mrec->opt.flags & FONTMAP_OPT_VERT) ? 1 : 0));
+        if (cmap_id < 0) {
+          cmap_id = t1_load_UnicodeCMap(mrec->font_name, mrec->opt.otl_tags,
+                                        ((mrec->opt.flags & FONTMAP_OPT_VERT) ? 1 : 0));
+        }
+        if (cmap_id < 0)
+          _tt_abort("Failed to read UCS2/UCS4 TrueType cmap...");
       }
     }
     if (cmap_id < 0) {
       encoding_id = pdf_encoding_findresource(mrec->enc_name);
       if (encoding_id < 0)
-	_tt_abort("Could not find encoding file \"%s\".", mrec->enc_name);
+        _tt_abort("Could not find encoding file \"%s\".", mrec->enc_name);
     }
   }
 
@@ -670,25 +670,25 @@ pdf_font_findresource (const char *tex_name,
     }
 
     for (font_id = 0;
-	 font_id < font_cache.count; font_id++) {
+         font_id < font_cache.count; font_id++) {
       font = GET_FONT(font_id);
       if (font->subtype == PDF_FONT_FONTTYPE_TYPE0 &&
-	  font->font_id == type0_id &&
-	  font->encoding_id == cmap_id) {
-	found = 1;
-	if (__verbose) {
-	  dpx_message("\npdf_font>> Type0 font \"%s\" (cmap_id=%d) found at font_id=%d.\n",
-	       mrec->font_name, cmap_id, font_id);
-	}
-	break;
+          font->font_id == type0_id &&
+          font->encoding_id == cmap_id) {
+        found = 1;
+        if (__verbose) {
+          dpx_message("\npdf_font>> Type0 font \"%s\" (cmap_id=%d) found at font_id=%d.\n",
+               mrec->font_name, cmap_id, font_id);
+        }
+        break;
       }
     }
 
     if (!found) {
       font_id = font_cache.count;
       if (font_cache.count >= font_cache.capacity) {
-	font_cache.capacity += CACHE_ALLOC_SIZE;
-	font_cache.fonts     = RENEW(font_cache.fonts, font_cache.capacity, pdf_font);
+        font_cache.capacity += CACHE_ALLOC_SIZE;
+        font_cache.fonts     = RENEW(font_cache.fonts, font_cache.capacity, pdf_font);
       }
       font    = GET_FONT(font_id);
       pdf_init_font_struct(font);
@@ -700,7 +700,7 @@ pdf_font_findresource (const char *tex_name,
       font_cache.count++;
 
       if (__verbose) {
-	dpx_message("\npdf_font>> Type0 font \"%s\"", fontname);
+        dpx_message("\npdf_font>> Type0 font \"%s\"", fontname);
         dpx_message(" cmap_id=<%s,%d>", mrec->enc_name, font->encoding_id);
         dpx_message(" opened at font_id=<%s,%d>.\n", tex_name, font_id);
       }
@@ -713,48 +713,48 @@ pdf_font_findresource (const char *tex_name,
     int  found = 0;
 
     for (font_id = 0;
-	 font_id < font_cache.count; font_id++) {
+         font_id < font_cache.count; font_id++) {
       font = GET_FONT(font_id);
       switch (font->subtype) {
       case PDF_FONT_FONTTYPE_TYPE1:
       case PDF_FONT_FONTTYPE_TYPE1C:
       case PDF_FONT_FONTTYPE_TRUETYPE:
-	/* fontname here is font file name.
-	 * We must compare both font file name and encoding
-	 *
-	 * TODO: Embed a font only once if it is used
-	 *       with two different encodings
-	 */
-	if (!strcmp(fontname, font->ident)   &&
-	    encoding_id == font->encoding_id) {
+        /* fontname here is font file name.
+         * We must compare both font file name and encoding
+         *
+         * TODO: Embed a font only once if it is used
+         *       with two different encodings
+         */
+        if (!strcmp(fontname, font->ident)   &&
+            encoding_id == font->encoding_id) {
           if (mrec && mrec->opt.index == font->index)
             found = 1;
-	}
-	break;
+        }
+        break;
       case PDF_FONT_FONTTYPE_TYPE3:
-	/* There shouldn't be any encoding specified for PK font.
-	 * It must be always font's build-in encoding.
-	 *
-	 * TODO: a PK font with two encodings makes no sense. Change?
+        /* There shouldn't be any encoding specified for PK font.
+         * It must be always font's build-in encoding.
+         *
+         * TODO: a PK font with two encodings makes no sense. Change?
          */
-	if (!strcmp(fontname, font->ident) &&
-	    font_scale == font->point_size) {
-	  found = 1;
-	}
-	break;
+        if (!strcmp(fontname, font->ident) &&
+            font_scale == font->point_size) {
+          found = 1;
+        }
+        break;
       case PDF_FONT_FONTTYPE_TYPE0:
-	break;
+        break;
       default:
-	_tt_abort("Unknown font type: %d", font->subtype);
-	break;
+        _tt_abort("Unknown font type: %d", font->subtype);
+        break;
       }
 
       if (found) {
-	if (__verbose) {
-	  dpx_message("\npdf_font>> Simple font \"%s\" (enc_id=%d) found at id=%d.\n",
-	       fontname, encoding_id, font_id);
-	}
-	break;
+        if (__verbose) {
+          dpx_message("\npdf_font>> Simple font \"%s\" (enc_id=%d) found at id=%d.\n",
+               fontname, encoding_id, font_id);
+        }
+        break;
       }
     }
 
@@ -762,8 +762,8 @@ pdf_font_findresource (const char *tex_name,
     if (!found) {
       font_id = font_cache.count;
       if (font_cache.count >= font_cache.capacity) {
-	font_cache.capacity += CACHE_ALLOC_SIZE;
-	font_cache.fonts     = RENEW(font_cache.fonts, font_cache.capacity, pdf_font);
+        font_cache.capacity += CACHE_ALLOC_SIZE;
+        font_cache.fonts     = RENEW(font_cache.fonts, font_cache.capacity, pdf_font);
       }
 
       font = GET_FONT(font_id);
@@ -779,22 +779,22 @@ pdf_font_findresource (const char *tex_name,
       font->index       = (mrec && mrec->opt.index) ? mrec->opt.index : 0;
 
       if (pdf_font_open_type1(font) >= 0) {
-	font->subtype = PDF_FONT_FONTTYPE_TYPE1;
+        font->subtype = PDF_FONT_FONTTYPE_TYPE1;
       } else if (pdf_font_open_type1c(font) >= 0) {
-	font->subtype = PDF_FONT_FONTTYPE_TYPE1C;
+        font->subtype = PDF_FONT_FONTTYPE_TYPE1C;
       } else if (pdf_font_open_truetype(font) >= 0) {
-	font->subtype = PDF_FONT_FONTTYPE_TRUETYPE;
+        font->subtype = PDF_FONT_FONTTYPE_TRUETYPE;
       } else if (pdf_font_open_pkfont(font) >= 0) {
-	font->subtype = PDF_FONT_FONTTYPE_TYPE3;
+        font->subtype = PDF_FONT_FONTTYPE_TYPE3;
       } else {
-	pdf_clean_font_struct(font);
-	return -1;
+        pdf_clean_font_struct(font);
+        return -1;
       }
 
       font_cache.count++;
 
       if (__verbose) {
-	dpx_message("\npdf_font>> Simple font \"%s\"", fontname);
+        dpx_message("\npdf_font>> Simple font \"%s\"", fontname);
         dpx_message(" enc_id=<%s,%d>",
              (mrec && mrec->enc_name) ? mrec->enc_name : "builtin", font->encoding_id);
         dpx_message(" opened at font_id=<%s,%d>.\n", tex_name, font_id);
@@ -853,20 +853,20 @@ pdf_font_get_resource (pdf_font *font)
   if (!font->resource) {
     font->resource = pdf_new_dict();
     pdf_add_dict(font->resource,
-		 pdf_new_name("Type"),      pdf_new_name("Font"));
+                 pdf_new_name("Type"),      pdf_new_name("Font"));
     switch (font->subtype) {
     case PDF_FONT_FONTTYPE_TYPE1:
     case PDF_FONT_FONTTYPE_TYPE1C:
       pdf_add_dict(font->resource,
-		   pdf_new_name("Subtype"), pdf_new_name("Type1"));
+                   pdf_new_name("Subtype"), pdf_new_name("Type1"));
       break;
     case PDF_FONT_FONTTYPE_TYPE3:
       pdf_add_dict(font->resource,
-		   pdf_new_name("Subtype"), pdf_new_name("Type3"));
+                   pdf_new_name("Subtype"), pdf_new_name("Type3"));
       break;
     case PDF_FONT_FONTTYPE_TRUETYPE:
       pdf_add_dict(font->resource,
-		   pdf_new_name("Subtype"), pdf_new_name("TrueType"));
+                   pdf_new_name("Subtype"), pdf_new_name("TrueType"));
       break;
     default:
       break;
@@ -884,7 +884,7 @@ pdf_font_get_descriptor (pdf_font *font)
   if (!font->descriptor) {
     font->descriptor = pdf_new_dict();
     pdf_add_dict(font->descriptor,
-		 pdf_new_name("Type"), pdf_new_name("FontDescriptor"));
+                 pdf_new_name("Type"), pdf_new_name("FontDescriptor"));
   }
 
   return font->descriptor;

--- a/tectonic/dpx-pdffont.h
+++ b/tectonic/dpx-pdffont.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdffont.h
+++ b/tectonic/dpx-pdffont.h
@@ -58,7 +58,7 @@ extern void     pdf_close_fonts (void);
  * various optical sizes supported in the future.
  */
 extern int      pdf_font_findresource  (const char *font_name,
-					double font_scale, fontmap_rec *mrec);
+                                        double font_scale, fontmap_rec *mrec);
 
 extern int      pdf_get_font_subtype   (int font_id);
 extern pdf_obj *pdf_get_font_reference (int font_id);

--- a/tectonic/dpx-pdflimits.h
+++ b/tectonic/dpx-pdflimits.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfnames.c
+++ b/tectonic/dpx-pdfnames.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfnames.c
+++ b/tectonic/dpx-pdfnames.c
@@ -112,9 +112,9 @@ check_objects_defined (struct ht_table *ht_tab)
       value = ht_iter_getval(&iter);
       assert(value->object);
       if (PDF_OBJ_UNDEFINED(value->object)) {
-	pdf_names_add_object(ht_tab, key, keylen, pdf_new_null());
-	dpx_warning("Object @%s used, but not defined. Replaced by null.",
-	     printable_key(key, keylen));
+        pdf_names_add_object(ht_tab, key, keylen, pdf_new_null());
+        dpx_warning("Object @%s used, but not defined. Replaced by null.",
+             printable_key(key, keylen));
       }
     } while (ht_iter_next(&iter) >= 0);
     ht_clear_iter(&iter);
@@ -135,7 +135,7 @@ pdf_delete_name_tree (struct ht_table **names)
 
 int
 pdf_names_add_object (struct ht_table *names,
-		      const void *key, int keylen, pdf_obj *object)
+                      const void *key, int keylen, pdf_obj *object)
 {
   struct obj_data *value;
 
@@ -173,7 +173,7 @@ pdf_names_add_object (struct ht_table *names,
  */
 pdf_obj *
 pdf_names_lookup_reference (struct ht_table *names,
-			    const void *key, int keylen)
+                            const void *key, int keylen)
 {
   struct obj_data *value;
   pdf_obj *object;
@@ -199,7 +199,7 @@ pdf_names_lookup_reference (struct ht_table *names,
 
 pdf_obj *
 pdf_names_lookup_object (struct ht_table *names,
-			 const void *key, int keylen)
+                         const void *key, int keylen)
 {
   struct obj_data *value;
 
@@ -215,7 +215,7 @@ pdf_names_lookup_object (struct ht_table *names,
 
 int
 pdf_names_close_object (struct ht_table *names,
-			const void *key, int keylen)
+                        const void *key, int keylen)
 {
   struct obj_data *value;
 
@@ -313,13 +313,13 @@ build_name_tree (struct named_object *first, int num_leaves, int is_root)
       case PDF_DICT:
       case PDF_STREAM:
       case PDF_STRING:
-	pdf_add_array(names, pdf_ref_obj(cur->value));
-	break;
+        pdf_add_array(names, pdf_ref_obj(cur->value));
+        break;
       case PDF_OBJ_INVALID:
-	_tt_abort("Invalid object...: %s", printable_key(cur->key, cur->keylen));
+        _tt_abort("Invalid object...: %s", printable_key(cur->key, cur->keylen));
       default:
-	pdf_add_array(names, pdf_link_obj(cur->value));
-	break;
+        pdf_add_array(names, pdf_link_obj(cur->value));
+        break;
       }
       pdf_release_obj(cur->value);
       cur->value = NULL;
@@ -348,7 +348,7 @@ build_name_tree (struct named_object *first, int num_leaves, int is_root)
 
 static struct named_object *
 flat_table (struct ht_table *ht_tab, int *num_entries,
-	    struct ht_table *filter)
+            struct ht_table *filter)
 {
   struct named_object *objects;
   struct ht_iter       iter;
@@ -367,27 +367,27 @@ flat_table (struct ht_table *ht_tab, int *num_entries,
       key   = ht_iter_getkey(&iter, &keylen);
 
       if (filter) {
-	pdf_obj *new_obj = ht_lookup_table(filter, key, keylen);
+        pdf_obj *new_obj = ht_lookup_table(filter, key, keylen);
 
-	if (!new_obj)
-	  continue;
+        if (!new_obj)
+          continue;
 
-	key = pdf_string_value(new_obj);
-	keylen = pdf_string_length(new_obj);
+        key = pdf_string_value(new_obj);
+        keylen = pdf_string_length(new_obj);
       }
 
       value = ht_iter_getval(&iter);
       assert(value->object);
       if (PDF_OBJ_UNDEFINED(value->object)) {
-	dpx_warning("Object @%s\" not defined. Replaced by null.",
-	     printable_key(key, keylen));
-	objects[count].key    = (char *) key;
-	objects[count].keylen = keylen;
-	objects[count].value  = pdf_new_null();
+        dpx_warning("Object @%s\" not defined. Replaced by null.",
+             printable_key(key, keylen));
+        objects[count].key    = (char *) key;
+        objects[count].keylen = keylen;
+        objects[count].value  = pdf_new_null();
       } else if (value->object) {
-	objects[count].key    = (char *) key;
-	objects[count].keylen = keylen;
-	objects[count].value  = pdf_link_obj(value->object);
+        objects[count].key    = (char *) key;
+        objects[count].keylen = keylen;
+        objects[count].value  = pdf_link_obj(value->object);
       }
       count++;
     } while (ht_iter_next(&iter) >= 0);
@@ -402,7 +402,7 @@ flat_table (struct ht_table *ht_tab, int *num_entries,
 
 pdf_obj *
 pdf_names_create_tree (struct ht_table *names, int *count,
-		       struct ht_table *filter)
+                       struct ht_table *filter)
 {
   pdf_obj *name_tree;
   struct   named_object *flat;

--- a/tectonic/dpx-pdfnames.h
+++ b/tectonic/dpx-pdfnames.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -35,7 +35,7 @@ extern int      pdf_names_add_object       (struct ht_table *names,
 					    const void *key, int keylen, pdf_obj *object);
 extern pdf_obj *pdf_names_lookup_reference (struct ht_table *names,
 					    const void *key, int keylen);
-extern pdf_obj *pdf_names_lookup_object    (struct ht_table *names, 
+extern pdf_obj *pdf_names_lookup_object    (struct ht_table *names,
 					    const void *key, int keylen);
 extern int      pdf_names_close_object     (struct ht_table *names,
 					    const void *key, int keylen);

--- a/tectonic/dpx-pdfnames.h
+++ b/tectonic/dpx-pdfnames.h
@@ -32,17 +32,17 @@ extern struct ht_table *pdf_new_name_tree    (void);
 extern void             pdf_delete_name_tree (struct ht_table **names);
 
 extern int      pdf_names_add_object       (struct ht_table *names,
-					    const void *key, int keylen, pdf_obj *object);
+                                            const void *key, int keylen, pdf_obj *object);
 extern pdf_obj *pdf_names_lookup_reference (struct ht_table *names,
-					    const void *key, int keylen);
+                                            const void *key, int keylen);
 extern pdf_obj *pdf_names_lookup_object    (struct ht_table *names,
-					    const void *key, int keylen);
+                                            const void *key, int keylen);
 extern int      pdf_names_close_object     (struct ht_table *names,
-					    const void *key, int keylen);
+                                            const void *key, int keylen);
 
 /* Really create name tree... */
 extern pdf_obj *pdf_names_create_tree      (struct ht_table *names,
-					    int *count,
-					    struct ht_table *filter);
+                                            int *count,
+                                            struct ht_table *filter);
 
 #endif /*  _PDF_NAMES_H_ */

--- a/tectonic/dpx-pdfobj.c
+++ b/tectonic/dpx-pdfobj.c
@@ -345,14 +345,14 @@ pdf_out_init (const char *filename, int do_encryption, int enable_objstm)
     output_stream = NULL;
 
     if (filename == NULL)
-	_tt_abort("stdout PDF output not supported");
+        _tt_abort("stdout PDF output not supported");
 
     pdf_output_handle = ttstub_output_open(filename, 0);
     if (!pdf_output_handle) {
-	if (strlen(filename) < 128)
-	    _tt_abort("Unable to open \"%s\".", filename);
-	else
-	    _tt_abort("Unable to open file.");
+        if (strlen(filename) < 128)
+            _tt_abort("Unable to open \"%s\".", filename);
+        else
+            _tt_abort("Unable to open file.");
     }
 
     pdf_out(pdf_output_handle, "%PDF-1.", strlen("%PDF-1."));
@@ -497,8 +497,8 @@ pdf_out_flush (void)
             }
         }
 
-	ttstub_output_close(pdf_output_handle);
-	pdf_output_handle = NULL;
+        ttstub_output_close(pdf_output_handle);
+        pdf_output_handle = NULL;
     }
 }
 
@@ -511,7 +511,7 @@ pdf_error_cleanup (void)
      */
     if (pdf_output_handle) {
         ttstub_output_close(pdf_output_handle);
-	pdf_output_handle = NULL;
+        pdf_output_handle = NULL;
     }
 }
 
@@ -562,7 +562,7 @@ void pdf_out_char (rust_output_handle_t handle, char c)
     if (output_stream && handle == pdf_output_handle)
         pdf_add_stream(output_stream, &c, 1);
     else {
-	ttstub_output_putc(handle, c);
+        ttstub_output_putc(handle, c);
         /* Keep tallys for xref table *only* if writing a pdf file. */
         if (handle == pdf_output_handle) {
             pdf_output_file_position += 1;
@@ -587,7 +587,7 @@ void pdf_out (rust_output_handle_t handle, const void *buffer, int length)
     if (output_stream && handle == pdf_output_handle)
         pdf_add_stream(output_stream, buffer, length);
     else {
-	ttstub_output_write(handle, buffer, length);
+        ttstub_output_write(handle, buffer, length);
         /* Keep tallys for xref table *only* if writing a pdf file */
         if (handle == pdf_output_handle) {
             pdf_output_file_position += length;
@@ -2632,13 +2632,13 @@ tt_mfreadln (char *buf, int size, rust_input_handle_t handle)
     int len = 0;
 
     while ((c = ttstub_input_getc(handle)) != EOF && c != '\n' && c != '\r') {
-	if (len >= size)
-	    return -2;
-	buf[len++] = (char) c;
+        if (len >= size)
+            return -2;
+        buf[len++] = (char) c;
     }
 
     if (c == EOF && len == 0)
-	return -1;
+        return -1;
 
     if (c == '\r' && (c = ttstub_input_getc(handle)) >= 0 && (c != '\n'))
         ttstub_input_ungetc(handle, c);
@@ -2660,9 +2660,9 @@ backup_line (rust_input_handle_t handle)
     if (ttstub_input_seek(handle, 0, SEEK_CUR) > 1) {
         do
             ttstub_input_seek(handle, -2, SEEK_CUR);
-	while (ttstub_input_seek(handle, 0, SEEK_CUR) > 0 &&
-	       (ch = ttstub_input_getc(handle)) >= 0 &&
-	       (ch != '\n' && ch != '\r' ));
+        while (ttstub_input_seek(handle, 0, SEEK_CUR) > 0 &&
+               (ch = ttstub_input_getc(handle)) >= 0 &&
+               (ch != '\n' && ch != '\r' ));
     }
 
     if (ch < 0)
@@ -2680,7 +2680,7 @@ find_xref (rust_input_handle_t handle, int file_size)
 
     do {
         int currentpos;
-	int n;
+        int n;
 
         if (!backup_line(handle)) {
             tries = 0;
@@ -2688,9 +2688,9 @@ find_xref (rust_input_handle_t handle, int file_size)
         }
 
         currentpos = ttstub_input_seek(handle, 0, SEEK_CUR);
-	n = MIN(strlen("startxref"), file_size - currentpos);
-	ttstub_input_read(handle, work_buffer, n);
-	ttstub_input_seek(handle, currentpos, SEEK_SET);
+        n = MIN(strlen("startxref"), file_size - currentpos);
+        ttstub_input_read(handle, work_buffer, n);
+        ttstub_input_seek(handle, currentpos, SEEK_SET);
         tries--;
     } while (tries > 0 && strncmp(work_buffer, "startxref", strlen("startxref")));
 
@@ -2704,7 +2704,7 @@ find_xref (rust_input_handle_t handle, int file_size)
 
     if (len <= 0) {
         dpx_warning("Reading xref location data failed... Not a PDF file?");
-	return 0;
+        return 0;
     }
 
     start = work_buffer;
@@ -3158,7 +3158,7 @@ parse_xref_table (pdf_file *pf, int xref_pos)
              * parse_trailer would fail.
              */
             current_pos += p - buf; /* Jump to the beginning of "trailer" keyword. */
-	    ttstub_input_seek(pf->handle, current_pos, SEEK_SET);
+            ttstub_input_seek(pf->handle, current_pos, SEEK_SET);
             break;
         }
 
@@ -3670,10 +3670,10 @@ check_for_pdf_version (rust_input_handle_t handle)
 
     ttstub_input_seek(handle, 0, SEEK_SET);
     if (ttstub_input_read(handle, buffer, sizeof(buffer) - 1) != sizeof(buffer) - 1)
-	return -1;
+        return -1;
 
     if (sscanf(buffer, "%%PDF-1.%u", &minor) != 1)
-	return -1;
+        return -1;
 
     return minor;
 }

--- a/tectonic/dpx-pdfobj.h
+++ b/tectonic/dpx-pdfobj.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -133,7 +133,7 @@ extern pdf_obj *pdf_dict_keys   (pdf_obj *dict);
  * pdf_link_obj() it rather than allocate/free-ing them each time. But I
  * already removed that.
  */
-extern int      pdf_add_dict     (pdf_obj *dict, pdf_obj *key,    pdf_obj *value); 
+extern int      pdf_add_dict     (pdf_obj *dict, pdf_obj *key,    pdf_obj *value);
 #if 0
 extern void     pdf_put_dict     (pdf_obj *dict, const char *key, pdf_obj *value);
 #endif

--- a/tectonic/dpx-pdfparse.c
+++ b/tectonic/dpx-pdfparse.c
@@ -48,11 +48,11 @@
 #endif
 
 #define is_space(c) ((c) == ' '  || (c) == '\t' || (c) == '\f' || \
-		     (c) == '\r' || (c) == '\n' || (c) == '\0')
+                     (c) == '\r' || (c) == '\n' || (c) == '\0')
 #define is_delim(c) ((c) == '(' || (c) == ')' || \
                      (c) == '/' || \
                      (c) == '<' || (c) == '>' || \
-		     (c) == '[' || (c) == ']' || \
+                     (c) == '[' || (c) == ']' || \
                      (c) == '%')
 #define PDF_TOKEN_END(p,e) ((p) >= (e) || is_space(*(p)) || is_delim(*(p)))
 
@@ -350,12 +350,12 @@ parse_pdf_name (const char **pp, const char *endptr)
       dpx_warning("Null char not allowed in PDF name object. (ignored)");
     } else if (len < STRING_BUFFER_SIZE) {
       if (len == PDF_NAME_LEN_MAX) {
-	dpx_warning("PDF name length too long. (>= %d bytes)", PDF_NAME_LEN_MAX);
+        dpx_warning("PDF name length too long. (>= %d bytes)", PDF_NAME_LEN_MAX);
       }
       name[len++] = ch;
     } else {
       dpx_warning("PDF name length too long. (>= %d bytes, truncated)",
-	   STRING_BUFFER_SIZE);
+           STRING_BUFFER_SIZE);
     }
   }
   if (len < 1) {
@@ -374,14 +374,14 @@ parse_pdf_boolean (const char **pp, const char *endptr)
   if (*pp + 4 <= endptr &&
       !strncmp(*pp, "true", 4)) {
     if (*pp + 4 == endptr ||
-	istokensep(*(*pp + 4))) {
+        istokensep(*(*pp + 4))) {
       *pp += 4;
       return pdf_new_boolean(1);
     }
   } else if (*pp + 5 <= endptr &&
-	     !strncmp(*pp, "false", 5)) {
+             !strncmp(*pp, "false", 5)) {
     if (*pp + 5 == endptr ||
-	istokensep(*(*pp + 5))) {
+        istokensep(*(*pp + 5))) {
       *pp += 5;
       return pdf_new_boolean(0);
     }
@@ -400,7 +400,7 @@ parse_pdf_null (const char **pp, const char *endptr)
     dpx_warning("Not a null object.");
     return NULL;
   } else if (*pp + 4 < endptr &&
-	     !istokensep(*(*pp+4))) {
+             !istokensep(*(*pp+4))) {
     dpx_warning("Not a null object.");
     return NULL;
   } else if (!strncmp(*pp, "null", 4)) {
@@ -448,16 +448,16 @@ ps_getescc (const char **pp, const char *endptr)
     break;
   default:
     if (p[0] == '\\' ||
-	p[0] == '('  || p[0] == ')') {
+        p[0] == '('  || p[0] == ')') {
       ch = p[0];
       p++;
     } else if (isodigit(p[0])) {
       ch = 0;
       /* Don't forget isodigit() is a macro. */
       for (i = 0; i < 3 &&
-	     p < endptr && isodigit(p[0]); i++) {
+             p < endptr && isodigit(p[0]); i++) {
         ch = (ch << 3) + (p[0] - '0');
-	p++;
+        p++;
       }
       ch = (ch & 0xff); /* Ignore overflow. */
     } else {
@@ -507,22 +507,22 @@ parse_pdf_literal_string (const char **pp, const char *endptr)
 #ifndef PDF_PARSE_STRICT
     if (parser_state.tainted) {
       if (p + 1 < endptr && (ch & 0x80)) {
-	if (len + 2 >= PDF_STRING_LEN_MAX) {
-	  dpx_warning("PDF string length too long. (limit: %ld)",
-	       PDF_STRING_LEN_MAX);
-	  return NULL;
-	}
-	sbuf[len++] = p[0];
-	sbuf[len++] = p[1];
-	p += 2;
-	continue;
+        if (len + 2 >= PDF_STRING_LEN_MAX) {
+          dpx_warning("PDF string length too long. (limit: %ld)",
+               PDF_STRING_LEN_MAX);
+          return NULL;
+        }
+        sbuf[len++] = p[0];
+        sbuf[len++] = p[1];
+        p += 2;
+        continue;
       }
     }
 #endif /* !PDF_PARSE_STRICT */
 
     if (len + 1 >= PDF_STRING_LEN_MAX) {
       dpx_warning("PDF string length too long. (limit: %ld)",
-	   PDF_STRING_LEN_MAX);
+           PDF_STRING_LEN_MAX);
       return NULL;
     }
 
@@ -530,19 +530,19 @@ parse_pdf_literal_string (const char **pp, const char *endptr)
     case '\\':
       ch = ps_getescc(&p, endptr);
       if (ch >= 0)
-	sbuf[len++] = (ch & 0xff);
+        sbuf[len++] = (ch & 0xff);
       break;
     case '\r':
       p++;
       if (p < endptr && p[0] == '\n')
-	p++;
+        p++;
       sbuf[len++] = '\n';
       break;
     default:
       if (ch == '(')
-	op_count++;
+        op_count++;
       else if (ch == ')')
-	op_count--;
+        op_count--;
       sbuf[len++] = ch;
       p++;
       break;
@@ -632,7 +632,7 @@ parse_pdf_string (const char **pp, const char *endptr)
     if (**pp == '(')
       return parse_pdf_literal_string(pp, endptr);
     else if (**pp == '<' &&
-	     (*(*pp + 1) == '>' || isxdigit((unsigned char)*(*pp + 1)))) {
+             (*(*pp + 1) == '>' || isxdigit((unsigned char)*(*pp + 1)))) {
       return parse_pdf_hex_string(pp, endptr);
     }
   }

--- a/tectonic/dpx-pdfparse.c
+++ b/tectonic/dpx-pdfparse.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -697,7 +697,7 @@ parse_pdf_dict (const char **pp, const char *endptr, pdf_file *pf)
 
     value = parse_pdf_object(&p, endptr, pf);
     if (!value) {
-      pdf_release_obj(key); 
+      pdf_release_obj(key);
       pdf_release_obj(value);
       pdf_release_obj(result);
       dpx_warning("Could not find a value in dictionary object.");
@@ -743,7 +743,7 @@ parse_pdf_array (const char **pp, const char *endptr, pdf_file *pf)
 
     elem = parse_pdf_object(&p, endptr, pf);
     if (!elem) {
-      pdf_release_obj(result); 
+      pdf_release_obj(result);
       dpx_warning("Could not find a valid object in array object.");
       return NULL;
     }
@@ -797,7 +797,7 @@ parse_pdf_stream (const char **pp, const char *endptr, pdf_obj *dict)
     pdf_obj *tmp, *tmp2;
 
     tmp = pdf_lookup_dict(dict, "Length");
- 
+
     if (tmp != NULL) {
       tmp2 = pdf_deref_obj(tmp);
       if (pdf_obj_typeof(tmp2) != PDF_NUMBER)
@@ -812,7 +812,7 @@ parse_pdf_stream (const char **pp, const char *endptr, pdf_obj *dict)
     }
   }
 
-  
+
   if (stream_length < 0 ||
       p + stream_length > endptr)
     return NULL;
@@ -842,7 +842,7 @@ parse_pdf_stream (const char **pp, const char *endptr, pdf_obj *dict)
   {
     /* It is recommended that there be an end-of-line marker
      * after the data and before endstream; this marker is not included
-     * in the stream length. 
+     * in the stream length.
      * [PDF Reference, 6th ed., version 1.7, pp. 61] */
     if (p < endptr && p[0] == '\r')
       p++;
@@ -933,7 +933,7 @@ try_pdf_reference (const char *start, const char *end, const char **endptr, pdf_
   start++;
   if (!PDF_TOKEN_END(start, end))
     return NULL;
-    
+
   if (endptr)
     *endptr = start;
 
@@ -955,7 +955,7 @@ parse_pdf_object (const char **pp, const char *endptr, pdf_file *pf)
 
   switch (**pp) {
 
-  case '<': 
+  case '<':
 
     if (*(*pp + 1) != '<') {
       result = parse_pdf_hex_string(pp, endptr);

--- a/tectonic/dpx-pdfparse.h
+++ b/tectonic/dpx-pdfparse.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pdfresource.c
+++ b/tectonic/dpx-pdfresource.c
@@ -187,7 +187,7 @@ get_category (const char *category)
 
 int
 pdf_defineresource (const char *category,
-		    const char *resname, pdf_obj *object, int flags)
+                    const char *resname, pdf_obj *object, int flags)
 {
   int      res_id;
   struct res_cache *rc;
@@ -207,17 +207,17 @@ pdf_defineresource (const char *category,
     for (res_id = 0; res_id < rc->count; res_id++) {
       res = &rc->resources[res_id];
       if (!strcmp(resname, res->ident)) {
-	dpx_warning("Resource %s (category: %s) already defined...",
-	     resname, category);
-	pdf_flush_resource(res);
-	res->flags    = flags;
-	if (flags & PDF_RES_FLUSH_IMMEDIATE) {
-	  res->reference = pdf_ref_obj(object);
-	  pdf_release_obj(object);
-	} else {
-	  res->object = object;
-	}
-	return (cat_id << 16) | res_id;
+        dpx_warning("Resource %s (category: %s) already defined...",
+             resname, category);
+        pdf_flush_resource(res);
+        res->flags    = flags;
+        if (flags & PDF_RES_FLUSH_IMMEDIATE) {
+          res->reference = pdf_ref_obj(object);
+          pdf_release_obj(object);
+        } else {
+          res->object = object;
+        }
+        return (cat_id << 16) | res_id;
       }
     }
   } else {

--- a/tectonic/dpx-pdfresource.h
+++ b/tectonic/dpx-pdfresource.h
@@ -31,7 +31,7 @@ extern void     pdf_init_resources  (void);
 extern void     pdf_close_resources (void);
 
 extern int      pdf_defineresource (const char *category,
-				    const char *resname,  pdf_obj *object, int flags);
+                                    const char *resname,  pdf_obj *object, int flags);
 extern int      pdf_findresource   (const char *category, const char *resname);
 #if 0
 extern int      pdf_resource_exist (const char *category, const char *resname);

--- a/tectonic/dpx-pdfximage.c
+++ b/tectonic/dpx-pdfximage.c
@@ -211,22 +211,22 @@ source_image_type (rust_input_handle_t handle)
     /* Original check order: jpeg, jp2, png, bmp, pdf, ps */
 
     if (check_for_jpeg(handle))
-	format = IMAGE_TYPE_JPEG;
+        format = IMAGE_TYPE_JPEG;
     /* else if (check_for_jp2(fp))
      *    format = IMAGE_TYPE_JP2; */
 #ifdef HAVE_LIBPNG
     else if (check_for_png(handle))
-	format = IMAGE_TYPE_PNG;
+        format = IMAGE_TYPE_PNG;
 #endif /*HAVE_LIBPNG*/
     else if (check_for_bmp(handle))
-	format = IMAGE_TYPE_BMP;
+        format = IMAGE_TYPE_BMP;
     else if (check_for_pdf(handle))
-	format = IMAGE_TYPE_PDF;
+        format = IMAGE_TYPE_PDF;
     else if (check_for_ps(handle))
         format = IMAGE_TYPE_EPS;
     else {
-	dpx_warning("Tectonic was unable to detect an image's format");
-	format = IMAGE_TYPE_UNKNOWN;
+        dpx_warning("Tectonic was unable to detect an image's format");
+        format = IMAGE_TYPE_UNKNOWN;
     }
 
     ttstub_input_seek(handle, 0, SEEK_SET);
@@ -267,33 +267,33 @@ load_image (const char *ident, const char *fullname, int format, rust_input_hand
         if (_opts.verbose)
             dpx_message("[JPEG]");
         if (jpeg_include_image(I, handle) < 0)
-	    goto error;
+            goto error;
         I->subtype = PDF_XOBJECT_TYPE_IMAGE;
-	break;
+        break;
     case IMAGE_TYPE_JP2:
         if (_opts.verbose)
             dpx_message("[JP2]");
         /*if (jp2_include_image(I, fp) < 0)*/
-	dpx_warning("Tectonic: JP2 not yet supported");
-	goto error;
+        dpx_warning("Tectonic: JP2 not yet supported");
+        goto error;
         /*I->subtype = PDF_XOBJECT_TYPE_IMAGE;
-	  break;*/
+          break;*/
 #ifdef HAVE_LIBPNG
     case IMAGE_TYPE_PNG:
         if (_opts.verbose)
             dpx_message("[PNG]");
         if (png_include_image(I, handle) < 0)
-	    goto error;
+            goto error;
         I->subtype = PDF_XOBJECT_TYPE_IMAGE;
-	break;
+        break;
 #endif
     case IMAGE_TYPE_BMP:
         if (_opts.verbose)
             dpx_message("[BMP]");
         if (bmp_include_image(I, handle) < 0)
-	    goto error;
+            goto error;
         I->subtype = PDF_XOBJECT_TYPE_IMAGE;
-	break;
+        break;
     case IMAGE_TYPE_PDF:
         if (_opts.verbose)
             dpx_message("[PDF]");
@@ -304,14 +304,14 @@ load_image (const char *ident, const char *fullname, int format, rust_input_hand
                 goto error;
         }
         if (_opts.verbose)
-	    dpx_message(",Page:%ld", I->attr.page_no);
-	I->subtype  = PDF_XOBJECT_TYPE_FORM;
+            dpx_message(",Page:%ld", I->attr.page_no);
+        I->subtype  = PDF_XOBJECT_TYPE_FORM;
         break;
     case IMAGE_TYPE_EPS:
         if (_opts.verbose)
             dpx_message("[EPS]");
-	dpx_warning("Tectonic: EPS yet not supported");
-	goto error;
+        dpx_warning("Tectonic: EPS yet not supported");
+        goto error;
     default:
         if (_opts.verbose)
             dpx_message("[UNKNOWN]");
@@ -378,8 +378,8 @@ pdf_ximage_findresource (const char *ident, load_options options)
 
     handle = ttstub_input_open(ident, kpse_pict_format, 0);
     if (handle == NULL) {
-	dpx_warning("Error locating image file \"%s\"", ident);
-	return -1;
+        dpx_warning("Error locating image file \"%s\"", ident);
+        return -1;
     }
 
     if (_opts.verbose)

--- a/tectonic/dpx-pdfximage.h
+++ b/tectonic/dpx-pdfximage.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -44,7 +44,7 @@ typedef struct {
 
 typedef struct {
   int         flags;
-  
+
   pdf_rect    bbox;
   pdf_tmatrix matrix;
 } xform_info;

--- a/tectonic/dpx-pkfont.c
+++ b/tectonic/dpx-pkfont.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pkfont.c
+++ b/tectonic/dpx-pkfont.c
@@ -681,11 +681,11 @@ pdf_font_load_pkfont (pdf_font *font)
 #endif /* ENABLE_GLYPHENC */
     encoding  = pdf_new_dict();
     pdf_add_dict(encoding,
-		 pdf_new_name("Type"), pdf_new_name("Encoding"));
+                 pdf_new_name("Type"), pdf_new_name("Encoding"));
     pdf_add_dict(encoding,
-		 pdf_new_name("Differences"), tmp_array);
+                 pdf_new_name("Differences"), tmp_array);
     pdf_add_dict(fontdict,
-		 pdf_new_name("Encoding"),    pdf_ref_obj(encoding));
+                 pdf_new_name("Encoding"),    pdf_ref_obj(encoding));
     pdf_release_obj(encoding);
   } else
     pdf_release_obj(tmp_array);

--- a/tectonic/dpx-pkfont.h
+++ b/tectonic/dpx-pkfont.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-pngimage.h
+++ b/tectonic/dpx-pngimage.h
@@ -33,7 +33,7 @@
 extern int png_include_image (pdf_ximage *ximage, rust_input_handle_t handle);
 extern int check_for_png     (rust_input_handle_t handle);
 extern int png_get_bbox (rust_input_handle_t handle, uint32_t *width, uint32_t *height,
-			 double *xdensity, double *ydensity);
+                         double *xdensity, double *ydensity);
 
 #endif
 

--- a/tectonic/dpx-pngimage.h
+++ b/tectonic/dpx-pngimage.h
@@ -20,7 +20,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
 
-	
+
 #ifndef _PNGIMAGE_H_
 #define _PNGIMAGE_H_
 

--- a/tectonic/dpx-pst.c
+++ b/tectonic/dpx-pst.c
@@ -85,14 +85,14 @@ pst_parse_comment (unsigned char **inbuf, unsigned char *inbufend)
 
   if (*cur != '%')
     return NULL;
-  
+
   while (cur < inbufend && *cur != '\n' && *cur != '\r')
     cur++;
   len = cur - (*inbuf);
   data = NEW(len+1, unsigned char);
   memcpy(data, *inbuf, len);
   data[len] = '\0';
-     
+
   *inbuf = cur;
   return pst_new_obj(PST_TYPE_UNKNOWN, data);
 }
@@ -152,7 +152,7 @@ pst_get_token (unsigned char **inbuf, unsigned char *inbufend)
       (*inbuf) += 2;
     }
     break;
-  case ']': case '}': 
+  case ']': case '}':
     {
       char *mark;
 

--- a/tectonic/dpx-pst_obj.c
+++ b/tectonic/dpx-pst_obj.c
@@ -171,7 +171,7 @@ pst_length_of (pst_obj *obj)
   case PST_TYPE_STRING:  len = pst_string_length(obj->data);  break;
   case PST_TYPE_NULL:
   case PST_TYPE_MARK:
-    TYPE_ERROR();                     
+    TYPE_ERROR();
     break;
   case PST_TYPE_UNKNOWN:
     len = strlen(obj->data);
@@ -196,8 +196,8 @@ pst_getIV (pst_obj *obj)
   case PST_TYPE_NAME:    iv = pst_name_IV();             break;
   case PST_TYPE_STRING:  iv = pst_string_IV(obj->data);  break;
   case PST_TYPE_NULL:
-  case PST_TYPE_MARK: 
-    TYPE_ERROR(); 
+  case PST_TYPE_MARK:
+    TYPE_ERROR();
     break;
   case PST_TYPE_UNKNOWN:
     _tt_abort("Cannot convert object of type UNKNOWN to integer value.");
@@ -223,7 +223,7 @@ pst_getRV (pst_obj *obj)
   case PST_TYPE_STRING:  rv = pst_string_RV(obj->data);  break;
   case PST_TYPE_NULL:
   case PST_TYPE_MARK:
-    TYPE_ERROR();                  
+    TYPE_ERROR();
     break;
   case PST_TYPE_UNKNOWN:
     _tt_abort("Cannot convert object of type UNKNOWN to real value.");
@@ -250,7 +250,7 @@ pst_getSV (pst_obj *obj)
   case PST_TYPE_STRING:  sv = pst_string_SV(obj->data);  break;
   case PST_TYPE_NULL:
   case PST_TYPE_MARK:
-    TYPE_ERROR(); 
+    TYPE_ERROR();
     break;
   case PST_TYPE_UNKNOWN:
     {
@@ -286,7 +286,7 @@ pst_data_ptr (pst_obj *obj)
   case PST_TYPE_NAME:    p = pst_name_data_ptr(obj->data);    break;
   case PST_TYPE_STRING:  p = pst_string_data_ptr(obj->data);  break;
   case PST_TYPE_NULL:
-  case PST_TYPE_MARK: 
+  case PST_TYPE_MARK:
     TYPE_ERROR();
     break;
   case PST_TYPE_UNKNOWN:
@@ -817,7 +817,7 @@ esctouc (unsigned char **inbuf, unsigned char *inbufend, unsigned char *valid)
     unescaped = escaped;
     (*inbuf)++;
     break;
-    /* Other escaped char */ 
+    /* Other escaped char */
   case 'n': unescaped = '\n'; (*inbuf)++; break;
   case 'r': unescaped = '\r'; (*inbuf)++; break;
   case 't': unescaped = '\t'; (*inbuf)++; break;
@@ -837,7 +837,7 @@ esctouc (unsigned char **inbuf, unsigned char *inbufend, unsigned char *valid)
     *valid    = 0;
     (*inbuf)++;
     break;
-    /* Possibly octal notion */ 
+    /* Possibly octal notion */
   default:
     unescaped = ostrtouc(inbuf, inbufend, valid);
   }
@@ -908,7 +908,7 @@ pst_string_parse_hex (unsigned char **inbuf, unsigned char *inbufend)
     return NULL;
 
   cur++;
-  /* PDF Reference does not specify how to treat invalid char */  
+  /* PDF Reference does not specify how to treat invalid char */
   while (cur < inbufend && len < PST_STRING_LEN_MAX) {
     int    hi, lo;
     skip_white_spaces(&cur, inbufend);

--- a/tectonic/dpx-pst_obj.c
+++ b/tectonic/dpx-pst_obj.c
@@ -258,11 +258,11 @@ pst_getSV (pst_obj *obj)
 
       len = strlen((char *) obj->data);
       if (len > 0) {
-	sv = NEW(len+1, unsigned char);
-	memcpy(sv, obj->data, len);
-	sv[len] = '\0';
+        sv = NEW(len+1, unsigned char);
+        memcpy(sv, obj->data, len);
+        sv[len] = '\0';
       } else {
-	sv = NULL;
+        sv = NULL;
       }
       break;
     }
@@ -373,8 +373,8 @@ pst_parse_boolean (unsigned char **inbuf, unsigned char *inbufend)
     *inbuf += 4;
     return pst_new_obj(PST_TYPE_BOOLEAN, pst_boolean_new(1));
   } else if (*inbuf + 5 <= inbufend &&
-	     memcmp(*inbuf, "false", 5) == 0 &&
-	     PST_TOKEN_END(*inbuf + 5, inbufend)) {
+             memcmp(*inbuf, "false", 5) == 0 &&
+             PST_TOKEN_END(*inbuf + 5, inbufend)) {
     *inbuf += 5;
     return pst_new_obj(PST_TYPE_BOOLEAN, pst_boolean_new(0));
   } else
@@ -550,8 +550,8 @@ pst_parse_number (unsigned char **inbuf, unsigned char *inbufend)
     *inbuf = cur;
     return pst_new_obj(PST_TYPE_INTEGER, pst_integer_new(lval));
   } else if (lval >= 2 && lval <= 36 && *cur == '#' && isalnum(*++cur) &&
-	     /* strtod allows leading "0x" for hex numbers, but we don't */
-	     (lval != 16 || (cur[1] != 'x' && cur[1] != 'X'))) {
+             /* strtod allows leading "0x" for hex numbers, but we don't */
+             (lval != 16 || (cur[1] != 'x' && cur[1] != 'X'))) {
     /* integer with radix */
     /* Can the base have a (plus) sign? I think yes. */
     errno = 0;
@@ -633,7 +633,7 @@ pst_name_encode (const char *name)
   for (i = 0; i < len; i++) {
     c = name[i];
     if (c < '!'  || c > '~' ||
-	c == '#' || is_delim(c) || is_space(c)) {
+        c == '#' || is_delim(c) || is_space(c)) {
       *p++ = '#';
       putxpair(c, &p);
     } else {
@@ -677,15 +677,15 @@ pst_parse_name (unsigned char **inbuf, unsigned char *inbufend) /* / is required
     if (c == '#') {
       int val;
       if (cur + 2 >= inbufend) {
-	dpx_warning("Premature end of input name string.");
-	break;
+        dpx_warning("Premature end of input name string.");
+        break;
       }
       val = getxpair(&cur);
       if (val <= 0) {
-	dpx_warning("Invalid char for name object. (ignored)");
-	continue;
+        dpx_warning("Invalid char for name object. (ignored)");
+        continue;
       } else
-	c = (unsigned char) val;
+        c = (unsigned char) val;
     }
     if (len < PST_NAME_LEN_MAX)
       *p++ = c;
@@ -791,7 +791,7 @@ ostrtouc (unsigned char **inbuf, unsigned char *inbufend, unsigned char *valid)
   unsigned int   val = 0;
 
   while (cur < inbufend && cur < *inbuf + 3 &&
-	 (*cur >= '0' && *cur <= '7')) {
+         (*cur >= '0' && *cur <= '7')) {
     val = (val << 3) | (*cur - '0');
     cur++;
   }
@@ -861,10 +861,10 @@ pst_string_parse_literal (unsigned char **inbuf, unsigned char *inbufend)
     switch (c) {
     case '\\':
       {
-	unsigned char unescaped, valid;
-	unescaped = esctouc(&cur, inbufend, &valid);
-	if (valid)
-	  wbuf[len++] = unescaped;
+        unsigned char unescaped, valid;
+        unescaped = esctouc(&cur, inbufend, &valid);
+        if (valid)
+          wbuf[len++] = unescaped;
       }
       break;
     case '(':
@@ -874,7 +874,7 @@ pst_string_parse_literal (unsigned char **inbuf, unsigned char *inbufend)
     case ')':
       balance--;
       if (balance > 0)
-	wbuf[len++] = ')';
+        wbuf[len++] = ')';
       break;
       /*
        * An end-of-line marker (\n, \r or \r\n), not preceeded by a backslash,
@@ -882,7 +882,7 @@ pst_string_parse_literal (unsigned char **inbuf, unsigned char *inbufend)
        */
     case '\r':
       if (cur < inbufend && *cur == '\n')
-	cur++;
+        cur++;
       wbuf[len++] = '\n';
       break;
     default:

--- a/tectonic/dpx-spc_color.c
+++ b/tectonic/dpx-spc_color.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -102,7 +102,7 @@ spc_handler_background (struct spc_env *spe, struct spc_arg *args)
 #ifndef ISBLANK
 #define ISBLANK(c) ((c) == ' ' || (c) == '\t' || (c) == '\v')
 #endif
-static void 
+static void
 skip_blank (const char **pp, const char *endptr)
 {
   const char  *p = *pp;

--- a/tectonic/dpx-spc_color.c
+++ b/tectonic/dpx-spc_color.c
@@ -136,7 +136,7 @@ spc_color_check_special (const char *buf, int len)
 
 int
 spc_color_setup_handler (struct spc_handler *sph,
-			 struct spc_env *spe, struct spc_arg *ap)
+                         struct spc_env *spe, struct spc_arg *ap)
 {
   const char *p;
   char *q;

--- a/tectonic/dpx-spc_color.h
+++ b/tectonic/dpx-spc_color.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_color.h
+++ b/tectonic/dpx-spc_color.h
@@ -25,6 +25,6 @@
 
 extern int spc_color_check_special (const char *buffer, int size);
 extern int spc_color_setup_handler (struct spc_handler *handle,
-				    struct spc_env *spe, struct spc_arg *args);
+                                    struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_COLOR_H_ */

--- a/tectonic/dpx-spc_dvipdfmx.c
+++ b/tectonic/dpx-spc_dvipdfmx.c
@@ -7,12 +7,12 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_dvipdfmx.c
+++ b/tectonic/dpx-spc_dvipdfmx.c
@@ -64,7 +64,7 @@ spc_dvipdfmx_check_special (const char *buf, int len)
 
 int
 spc_dvipdfmx_setup_handler (struct spc_handler *sph,
-			    struct spc_env *spe, struct spc_arg *ap)
+                            struct spc_env *spe, struct spc_arg *ap)
 {
   int    error = -1, i;
   char  *q;

--- a/tectonic/dpx-spc_dvipdfmx.h
+++ b/tectonic/dpx-spc_dvipdfmx.h
@@ -7,12 +7,12 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_dvipdfmx.h
+++ b/tectonic/dpx-spc_dvipdfmx.h
@@ -25,6 +25,6 @@
 
 extern int spc_dvipdfmx_check_special (const char *buf, int len);
 extern int spc_dvipdfmx_setup_handler (struct spc_handler *sph,
-				       struct spc_env *spe, struct spc_arg *ap);
+                                       struct spc_env *spe, struct spc_arg *ap);
 
 #endif /* _SPC_DVIPDFMX_H_ */

--- a/tectonic/dpx-spc_dvips.c
+++ b/tectonic/dpx-spc_dvips.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -940,7 +940,7 @@ spc_dvips_check_special (const char *buf, int len)
   return  0;
 }
 
-int 
+int
 spc_dvips_setup_handler (struct spc_handler *handle,
 			 struct spc_env *spe, struct spc_arg *args)
 {

--- a/tectonic/dpx-spc_dvips.c
+++ b/tectonic/dpx-spc_dvips.c
@@ -704,49 +704,49 @@ spc_handler_ps_tricks_render (struct spc_env *spe, struct spc_arg *args)
 }
 
 typedef enum {
-  render	= 1 << 0,
-  global_def	= 1 << 1,
-  page_def	= 1 << 2,
-  new_temp	= 1 << 3,
-  add_temp	= 1 << 4,
-  begin_put	= 1 << 5,
-  end_put	= 1 << 6,
-  begin_rotate	= 1 << 7,
-  end_rotate	= 1 << 8,
-  parse		= 1 << 9,
-  req_ref	= 1 << 10,
-  transform	= 1 << 11
+  render       = 1 << 0,
+  global_def   = 1 << 1,
+  page_def     = 1 << 2,
+  new_temp     = 1 << 3,
+  add_temp     = 1 << 4,
+  begin_put    = 1 << 5,
+  end_put      = 1 << 6,
+  begin_rotate = 1 << 7,
+  end_rotate   = 1 << 8,
+  parse        = 1 << 9,
+  req_ref      = 1 << 10,
+  transform    = 1 << 11
 } Operation;
 
-/*	ToDo: all the substring search must be centralized so that	*
- *	keys can be read from external configuration.			*/
+/*    ToDo: all the substring search must be centralized so that        *
+ *    keys can be read from external configuration.                     */
 struct pstricks_key_ {
   const char * key;
   Operation exec;
 } pstricks_key[] = {
   /* The first 5 are hard-coded here. */
-  {"LPut",	add_temp | req_ref},
-  {"HPutPos",	add_temp | req_ref},
-  {"PutBegin",	begin_put},
-  {"RotBegin",	begin_rotate},
-  {"clip",	parse},
+  {"LPut",               add_temp | req_ref},
+  {"HPutPos",            add_temp | req_ref},
+  {"PutBegin",           begin_put},
+  {"RotBegin",           begin_rotate},
+  {"clip",               parse},
   /* The rest can be read from an external source. */
-  {"NewNode",	page_def | req_ref},
-  {"InitNC",	render | new_temp},
-  {"/Glbx",	add_temp},
-  {"NewtonSolving",	add_temp},
-  {"tx@LightThreeDDict",	page_def},
-  {"PutEnd",	end_put},
-  {"RotEnd",	end_rotate},
-  {"mtrxc",	parse},
-  {"stroke",	render},
-  {"fill",	render},
-  {"Fill",	render},
-  {" Glbx", req_ref},
-  {"TextPathShow", parse},
-  {"/rotAngle", page_def},
-  {"NAngle", req_ref},
-  {"TMatrix", transform}
+  {"NewNode",            page_def | req_ref},
+  {"InitNC",             render | new_temp},
+  {"/Glbx",              add_temp},
+  {"NewtonSolving",      add_temp},
+  {"tx@LightThreeDDict", page_def},
+  {"PutEnd",             end_put},
+  {"RotEnd",             end_rotate},
+  {"mtrxc",              parse},
+  {"stroke",             render},
+  {"fill",               render},
+  {"Fill",               render},
+  {" Glbx",              req_ref},
+  {"TextPathShow",       parse},
+  {"/rotAngle",          page_def},
+  {"NAngle",             req_ref},
+  {"TMatrix",            transform}
 };
 
 static int

--- a/tectonic/dpx-spc_dvips.c
+++ b/tectonic/dpx-spc_dvips.c
@@ -204,8 +204,8 @@ spc_handler_ps_plotfile (struct spc_env *spe, struct spc_arg *args)
 #if 0
     /* I don't know how to treat this... */
     pdf_dev_put_image(form_id, &p,
-		      block_pending ? pending_x : spe->x_user,
-		      block_pending ? pending_y : spe->y_user);
+                      block_pending ? pending_x : spe->x_user,
+                      block_pending ? pending_y : spe->y_user);
 #endif
     pdf_dev_put_image(form_id, &p, 0, 0);
   }
@@ -232,7 +232,7 @@ spc_handler_ps_literal (struct spc_env *spe, struct spc_arg *args)
     y_user = pending_y = spe->y_user;
     args->curptr += strlen(":[begin]");
   } else if (args->curptr + strlen(":[end]") <= args->endptr &&
-	     !strncmp(args->curptr, ":[end]", strlen(":[end]"))) {
+             !strncmp(args->curptr, ":[end]", strlen(":[end]"))) {
     if (block_pending <= 0) {
       spc_warn(spe, "No corresponding ::[begin] found.");
       return -1;
@@ -245,7 +245,7 @@ spc_handler_ps_literal (struct spc_env *spe, struct spc_arg *args)
     y_user = pending_y;
     args->curptr += strlen(":[end]");
   } else if (args->curptr < args->endptr &&
-	     args->curptr[0] == ':') {
+             args->curptr[0] == ':') {
     x_user = position_set ? pending_x : spe->x_user;
     y_user = position_set ? pending_y : spe->y_user;
     args->curptr++;
@@ -262,8 +262,8 @@ spc_handler_ps_literal (struct spc_env *spe, struct spc_arg *args)
     gs_depth = pdf_dev_current_depth();
 
     error = mps_exec_inline(&args->curptr,
-			    args->endptr,
-			    x_user, y_user);
+                            args->endptr,
+                            x_user, y_user);
     if (error) {
       spc_warn(spe, "Interpreting PS code failed!!! Output might be broken!!!");
       pdf_dev_grestore_to(gs_depth);
@@ -822,8 +822,8 @@ spc_handler_ps_default (struct spc_env *spe, struct spc_arg *args)
     M.a = M.d = 1.0; M.b = M.c = 0.0; M.e = spe->x_user; M.f = spe->y_user;
     pdf_dev_concat(&M);
   error = mps_exec_inline(&args->curptr,
-			  args->endptr,
-			  spe->x_user, spe->y_user);
+                          args->endptr,
+                          spe->x_user, spe->y_user);
     M.e = -spe->x_user; M.f = -spe->y_user;
     pdf_dev_concat(&M);
   }
@@ -942,7 +942,7 @@ spc_dvips_check_special (const char *buf, int len)
 
 int
 spc_dvips_setup_handler (struct spc_handler *handle,
-			 struct spc_env *spe, struct spc_arg *args)
+                         struct spc_env *spe, struct spc_arg *args)
 {
   const char *key;
   int   i, keylen;
@@ -953,7 +953,7 @@ spc_dvips_setup_handler (struct spc_handler *handle,
 
   key = args->curptr;
   while (args->curptr < args->endptr &&
-	 isalpha((unsigned char)args->curptr[0])) {
+         isalpha((unsigned char)args->curptr[0])) {
     args->curptr++;
   }
   /* Test for "ps:". The "ps::" special is subsumed under this case.  */
@@ -961,7 +961,7 @@ spc_dvips_setup_handler (struct spc_handler *handle,
       args->curptr[0] == ':') {
     args->curptr++;
     if (args->curptr+strlen(" plotfile ") <= args->endptr &&
-	!strncmp(args->curptr, " plotfile ", strlen(" plotfile "))) {
+        !strncmp(args->curptr, " plotfile ", strlen(" plotfile "))) {
       args->curptr += strlen(" plotfile ");
       }
   } else if (args->curptr+1 < args->endptr &&
@@ -978,7 +978,7 @@ spc_dvips_setup_handler (struct spc_handler *handle,
   for (i = 0;
        i < sizeof(dvips_handlers) / sizeof(struct spc_handler); i++) {
     if (keylen == strlen(dvips_handlers[i].key) &&
-	!strncmp(key, dvips_handlers[i].key, keylen)) {
+        !strncmp(key, dvips_handlers[i].key, keylen)) {
 
       skip_white(&args->curptr, args->endptr);
 

--- a/tectonic/dpx-spc_dvips.h
+++ b/tectonic/dpx-spc_dvips.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_dvips.h
+++ b/tectonic/dpx-spc_dvips.h
@@ -32,6 +32,6 @@ extern int spc_dvips_at_end_page       (void);
 
 extern int spc_dvips_check_special (const char *buffer, int size);
 extern int spc_dvips_setup_handler (struct spc_handler *handle,
-				    struct spc_env *spe, struct spc_arg *args);
+                                    struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_DVIPS_H_ */

--- a/tectonic/dpx-spc_html.c
+++ b/tectonic/dpx-spc_html.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -172,7 +172,7 @@ read_html_tag (char *name, pdf_obj *attr, int *type, const char **pp, const char
 #define ISDELIM(c) ((c) == '>' || (c) == '/' || isspace((unsigned char)c))
   for (n = 0; p < endptr && n < HTML_TAG_NAME_MAX && !ISDELIM(*p); n++, p++) {
     name[n] = *p;
-  } 
+  }
   name[n] = '\0';
   if (n == 0 || p == endptr || !ISDELIM(*p)) {
     *pp = p;
@@ -635,7 +635,7 @@ spc_html__img_empty (struct spc_env *spe, pdf_obj *attr)
 
   id = pdf_ximage_findresource(pdf_string_value(src), options);
   if (id < 0) {
-    spc_warn(spe, "Could not find/load image: %s", pdf_string_value(src)); 
+    spc_warn(spe, "Could not find/load image: %s", pdf_string_value(src));
     error = -1;
   } else {
 #if defined(ENABLE_HTML_SVG_TRANSFORM) || defined(ENABLE_HTML_SVG_OPACITY)
@@ -863,7 +863,7 @@ cvt_a_to_tmatrix (pdf_tmatrix *M, const char *ptr, const char **nextptr)
   if (nextptr)
     *nextptr = p;
   return  0;
-}    
+}
 #endif /* ENABLE_HTML_SVG_TRANSFORM */
 
 int

--- a/tectonic/dpx-spc_html.c
+++ b/tectonic/dpx-spc_html.c
@@ -310,9 +310,9 @@ html_open_link (struct spc_env *spe, const char *name, struct spc_html_ *sd)
 
   sd->link_dict = pdf_new_dict();
   pdf_add_dict(sd->link_dict,
-	       pdf_new_name("Type"),    pdf_new_name ("Annot"));
+               pdf_new_name("Type"),    pdf_new_name ("Annot"));
   pdf_add_dict(sd->link_dict,
-	       pdf_new_name("Subtype"), pdf_new_name ("Link"));
+               pdf_new_name("Subtype"), pdf_new_name ("Link"));
 
   color = pdf_new_array ();
   pdf_add_array(color, pdf_new_number(0.0));
@@ -324,22 +324,22 @@ html_open_link (struct spc_env *spe, const char *name, struct spc_html_ *sd)
   if (url[0] == '#') {
     /* url++; causes memory leak in free(url) */
     pdf_add_dict(sd->link_dict,
-		 pdf_new_name("Dest"),
-		 pdf_new_string(url+1, strlen(url+1)));
+                 pdf_new_name("Dest"),
+                 pdf_new_string(url+1, strlen(url+1)));
   } else { /* Assume this is URL */
     pdf_obj  *action = pdf_new_dict();
     pdf_add_dict(action,
-		 pdf_new_name("Type"),
-		 pdf_new_name("Action"));
+                 pdf_new_name("Type"),
+                 pdf_new_name("Action"));
     pdf_add_dict(action,
-		 pdf_new_name("S"),
-		 pdf_new_name("URI"));
+                 pdf_new_name("S"),
+                 pdf_new_name("URI"));
     pdf_add_dict(action,
-		 pdf_new_name("URI"),
-		 pdf_new_string(url, strlen(url)));
+                 pdf_new_name("URI"),
+                 pdf_new_string(url, strlen(url)));
     pdf_add_dict(sd->link_dict,
-		 pdf_new_name("A"),
-		 pdf_link_obj(action));
+                 pdf_new_name("A"),
+                 pdf_link_obj(action));
     pdf_release_obj(action);
   }
   free(url);
@@ -372,8 +372,8 @@ html_open_dest (struct spc_env *spe, const char *name, struct spc_html_ *sd)
   pdf_add_array(array, pdf_new_null());
 
   error = pdf_doc_add_names("Dests",
-			    name, strlen(name),
-			    array);
+                            name, strlen(name),
+                            array);
 
   if (error)
     spc_warn(spe, "Failed to add named destination: %s", name);

--- a/tectonic/dpx-spc_html.h
+++ b/tectonic/dpx-spc_html.h
@@ -32,6 +32,6 @@ extern int spc_html_at_end_document   (void);
 
 extern int spc_html_check_special (const char *buffer, int size);
 extern int spc_html_setup_handler (struct spc_handler *handle,
-				   struct spc_env *spe, struct spc_arg *args);
+                                   struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_HTML_H_ */

--- a/tectonic/dpx-spc_html.h
+++ b/tectonic/dpx-spc_html.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_misc.h
+++ b/tectonic/dpx-spc_misc.h
@@ -27,6 +27,6 @@
 
 extern int spc_misc_check_special (const char *buffer, int size);
 extern int spc_misc_setup_handler (struct spc_handler *handle,
-				   struct spc_env *spe, struct spc_arg *args);
+                                   struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_MISC_H_ */

--- a/tectonic/dpx-spc_misc.h
+++ b/tectonic/dpx-spc_misc.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_pdfm.c
+++ b/tectonic/dpx-spc_pdfm.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -271,7 +271,7 @@ safeputresdict (pdf_obj *kp, pdf_obj *vp, void *dp)
 /* Think what happens if you do
  *
  *  pdf:put @resources << /Font << >> >>
- * 
+ *
  */
 static int
 spc_handler_pdfm_put (struct spc_env *spe, struct spc_arg *ap)
@@ -536,7 +536,7 @@ parse_pdf_dict_with_tounicode (const char **pp, const char *endptr, struct touni
     return  parse_pdf_dict(pp, endptr, NULL);
 
   /* :( */
-  if (cd && cd->unescape_backslash) 
+  if (cd && cd->unescape_backslash)
     dict = parse_pdf_tainted_dict(pp, endptr);
   else {
     dict = parse_pdf_dict(pp, endptr, NULL);
@@ -1883,7 +1883,7 @@ static struct spc_handler pdfm_handlers[] = {
   {"bead",       spc_handler_pdfm_bead},
   {"thread",     spc_handler_pdfm_bead},
 
-  {"destination", spc_handler_pdfm_dest}, 
+  {"destination", spc_handler_pdfm_dest},
   {"dest",        spc_handler_pdfm_dest},
 
 

--- a/tectonic/dpx-spc_pdfm.c
+++ b/tectonic/dpx-spc_pdfm.c
@@ -142,7 +142,7 @@ spc_handler_pdfm__init (void *dp)
   sd->cd.taintkeys = pdf_new_array();
   for (i = 0; default_taintkeys[i] != NULL; i++) {
     pdf_add_array(sd->cd.taintkeys,
-		  pdf_new_name(default_taintkeys[i]));
+                  pdf_new_name(default_taintkeys[i]));
   }
 
   return 0;
@@ -194,7 +194,7 @@ spc_handler_pdfm_bop (struct spc_env *spe, struct spc_arg *args)
 {
   if (args->curptr < args->endptr) {
     pdf_doc_set_bop_content(args->curptr,
-			    (int) (args->endptr - args->curptr));
+                            (int) (args->endptr - args->curptr));
   }
 
   args->curptr = args->endptr;
@@ -207,7 +207,7 @@ spc_handler_pdfm_eop (struct spc_env *spe, struct spc_arg *args)
 {
   if (args->curptr < args->endptr) {
     pdf_doc_set_eop_content(args->curptr,
-			    (int) (args->endptr - args->curptr));
+                            (int) (args->endptr - args->curptr));
   }
 
   args->curptr = args->endptr;
@@ -343,7 +343,7 @@ spc_handler_pdfm_put (struct spc_env *spe, struct spc_arg *ap)
     while (ap->curptr < ap->endptr) {
       pdf_obj *obj3 = parse_pdf_object(&ap->curptr, ap->endptr, NULL);
       if (!obj3)
-	break;
+        break;
       pdf_add_array(obj1, obj3);
       skip_white(&ap->curptr, ap->endptr);
     }
@@ -388,8 +388,8 @@ reencodestring (CMap *cmap, pdf_obj *instring)
   obufleft = WBUF_SIZE - 2;
 
   CMap_decode(cmap,
-	      &inbufcur, &inbufleft,
-	      &obufcur, &obufleft);
+              &inbufcur, &inbufleft,
+              &obufcur, &obufleft);
 
   if (inbufleft > 0) {
     return  -1;
@@ -1298,11 +1298,11 @@ spc_handler_pdfm_literal (struct spc_env *spe, struct spc_arg *args)
   skip_white(&args->curptr, args->endptr);
   while (args->curptr < args->endptr) {
     if (args->curptr + 7 <= args->endptr &&
-	!strncmp(args->curptr, "reverse", 7)) {
+        !strncmp(args->curptr, "reverse", 7)) {
       args->curptr += 7;
       dpx_warning("The special \"pdf:literal reverse ...\" is no longer supported.\nIgnore the \"reverse\" option.");
     } else if (args->curptr + 6 <= args->endptr &&
-	       !strncmp(args->curptr, "direct", 6)) {
+               !strncmp(args->curptr, "direct", 6)) {
       direct      = 1;
       args->curptr += 6;
     } else {
@@ -1437,7 +1437,7 @@ spc_handler_pdfm_stream_with_type (struct spc_env *spe, struct spc_arg *args, in
     }
     fstream = pdf_new_stream(STREAM_COMPRESS);
     while ((nb_read =
-	    fread(work_buffer, sizeof(char), WORK_BUFFER_SIZE, fp)) > 0)
+            fread(work_buffer, sizeof(char), WORK_BUFFER_SIZE, fp)) > 0)
       pdf_add_stream(fstream, work_buffer, nb_read);
     fclose(fp);
     free(fullname);

--- a/tectonic/dpx-spc_pdfm.h
+++ b/tectonic/dpx-spc_pdfm.h
@@ -30,6 +30,6 @@ extern int  spc_pdfm_at_end_document   (void);
 
 extern int  spc_pdfm_check_special (const char *buffer, int size);
 extern int  spc_pdfm_setup_handler (struct spc_handler *handle,
-				    struct spc_env *spe, struct spc_arg *args);
+                                    struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_PDFM_H_ */

--- a/tectonic/dpx-spc_pdfm.h
+++ b/tectonic/dpx-spc_pdfm.h
@@ -2,24 +2,24 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
-	
+
 #ifndef _SPC_PDFM_H_
 #define _SPC_PDFM_H_
 

--- a/tectonic/dpx-spc_tpic.c
+++ b/tectonic/dpx-spc_tpic.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -47,7 +47,7 @@
 
 /*
  * Value for 'sh' command 'g' is interpreted as
- * 
+ *
  *   gray color value 1-g for "solid"
  *   opacity value g for "opacity"
  *   shape value g for "shape"
@@ -92,7 +92,7 @@ static struct spc_tpic_ _tpic_state;
  * since we always draw isolated graphics.
  */
 static void
-tpic__clear (struct spc_tpic_ *tp) 
+tpic__clear (struct spc_tpic_ *tp)
 {
   if (tp->points) {
     free(tp->points);
@@ -297,7 +297,7 @@ tpic__polyline (struct spc_tpic_ *tp,
 /*
  * Accroding to
  * "Tpic: Pic for TEX", Tim Morgan, Original by Brian Kernighan, p.20:
- * 
+ *
  *  A spline is a smooth curve guided by a set of straight lines just
  *  like the line above. It begins at the same place, ends at the same
  *  place, and in between is tangent to the mid-point of each guiding
@@ -695,7 +695,7 @@ spc_handler_tpic_sh (struct spc_env *spe,
     else {
       dpx_warning("Invalid fill color specified: %g\n", g);
       return -1;
-    }      
+    }
   }
 
   return  0;
@@ -750,7 +750,7 @@ spc_handler_tpic__init (struct spc_env *spe, void *dp)
 
 #if  0
   tp->mode.fill  = TPIC_MODE__FILL_SOLID;
-#endif 
+#endif
   tp->pen_size   = 1.0;
   tp->fill_shape = 0;
   tp->fill_color = 0.0;

--- a/tectonic/dpx-spc_tpic.c
+++ b/tectonic/dpx-spc_tpic.c
@@ -203,11 +203,11 @@ set_fillstyle (double g, double a, int f_ais)
 
 static void
 set_styles (struct spc_tpic_ *tp,
-	    const pdf_coord  *c,
-	    int               f_fs,
-	    int               f_vp,
-	    double            pn,
-	    double            da) {
+            const pdf_coord  *c,
+            int               f_fs,
+            int               f_vp,
+            double            pn,
+            double            da) {
   pdf_tmatrix M;
 
   pdf_setmatrix (&M, 1.0, 0.0, 0.0, -1.0, c->x, c->y);

--- a/tectonic/dpx-spc_tpic.h
+++ b/tectonic/dpx-spc_tpic.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_tpic.h
+++ b/tectonic/dpx-spc_tpic.h
@@ -34,6 +34,6 @@ extern int  spc_tpic_at_end_document   (void);
 
 extern int  spc_tpic_check_special (const char *buffer, int size);
 extern int  spc_tpic_setup_handler (struct spc_handler *handle,
-				    struct spc_env *spe, struct spc_arg *args);
+                                    struct spc_env *spe, struct spc_arg *args);
 
 #endif /* _SPC_TPIC_H_ */

--- a/tectonic/dpx-spc_util.c
+++ b/tectonic/dpx-spc_util.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_util.h
+++ b/tectonic/dpx-spc_util.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_xtx.c
+++ b/tectonic/dpx-spc_xtx.c
@@ -8,7 +8,7 @@
 
     This file based on spc_pdfm.c, part of the dvipdfmx project:
 
-    Copyright (C) 2002 by Jin-Hwan Cho and Shunsaku Hirata.    
+    Copyright (C) 2002 by Jin-Hwan Cho and Shunsaku Hirata.
 
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
@@ -16,12 +16,12 @@
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-spc_xtx.h
+++ b/tectonic/dpx-spc_xtx.h
@@ -33,7 +33,7 @@
 
 extern int  spc_xtx_check_special (const char *buffer, int size);
 extern int  spc_xtx_setup_handler (struct spc_handler *handle,
-				    struct spc_env *spe, struct spc_arg *args);
+                                    struct spc_env *spe, struct spc_arg *args);
 extern int spc_handler_xtx_do_transform (double x_user, double y_user, double a, double b, double c, double d, double e, double f);
 extern int spc_handler_xtx_gsave (struct spc_env *spe, struct spc_arg *args);
 extern int spc_handler_xtx_grestore (struct spc_env *spe, struct spc_arg *args);

--- a/tectonic/dpx-spc_xtx.h
+++ b/tectonic/dpx-spc_xtx.h
@@ -8,24 +8,24 @@
 
     Copyright (C) 2002 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
-	
+
 #ifndef _SPC_XTX_H_
 #define _SPC_XTX_H_
 

--- a/tectonic/dpx-specials.c
+++ b/tectonic/dpx-specials.c
@@ -314,10 +314,10 @@ spc_handler_unknown (struct spc_env *spe,
 
 static void
 init_special (struct spc_handler *special,
-	      struct spc_env *spe,
-	      struct spc_arg *args,
-	      const char *p, uint32_t size,
-	      double x_user, double y_user, double mag)
+              struct spc_env *spe,
+              struct spc_arg *args,
+              const char *p, uint32_t size,
+              double x_user, double y_user, double mag)
 {
 
   special->key  = NULL;
@@ -559,7 +559,7 @@ print_error (const char *name, struct spc_env *spe, struct spc_arg *ap)
 
 int
 spc_exec_special (const char *buffer, int32_t size,
-		  double x_user, double y_user, double mag)
+                  double x_user, double y_user, double mag)
 {
   int    error = -1;
   int    i, found;
@@ -578,10 +578,10 @@ spc_exec_special (const char *buffer, int32_t size,
     if (found) {
       error = known_specials[i].setup_func(&special, &spe, &args);
       if (!error) {
-	error = special.exec(&spe, &args);
+        error = special.exec(&spe, &args);
       }
       if (error) {
-	print_error(known_specials[i].key, &spe, &args);
+        print_error(known_specials[i].key, &spe, &args);
       }
       break;
     }

--- a/tectonic/dpx-specials.c
+++ b/tectonic/dpx-specials.c
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -530,7 +530,7 @@ print_error (const char *name, struct spc_env *spe, struct spc_arg *ap)
     else
       break;
   }
-  ebuf[i] = '\0'; 
+  ebuf[i] = '\0';
   if (ap->curptr < ap->endptr) {
     while (i-- > 60)
       ebuf[i] = '.';
@@ -546,7 +546,7 @@ print_error (const char *name, struct spc_env *spe, struct spc_arg *ap)
       else
         break;
     }
-    ebuf[i] = '\0'; 
+    ebuf[i] = '\0';
     if (ap->curptr < ap->endptr) {
       while (i-- > 60)
         ebuf[i] = '.';
@@ -585,7 +585,7 @@ spc_exec_special (const char *buffer, int32_t size,
       }
       break;
     }
-  } 
+  }
 
   check_garbage(&args);
 

--- a/tectonic/dpx-specials.h
+++ b/tectonic/dpx-specials.h
@@ -2,24 +2,24 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
 */
-	
+
 #ifndef _SPECIALS_H_
 #define _SPECIALS_H_
 

--- a/tectonic/dpx-specials.h
+++ b/tectonic/dpx-specials.h
@@ -71,6 +71,6 @@ extern int      spc_exec_at_begin_document (void);
 extern int      spc_exec_at_end_document   (void);
 
 extern int      spc_exec_special (const char *p, int32_t size,
-				  double x_user, double y_user, double mag);
+                                  double x_user, double y_user, double mag);
 
 #endif /* _SPECIALS_H_ */

--- a/tectonic/dpx-subfont.h
+++ b/tectonic/dpx-subfont.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-t1_char.c
+++ b/tectonic/dpx-t1_char.c
@@ -215,7 +215,7 @@ static double ps_arg_stack[PS_ARG_STACK_MAX];
 /*      RESERVED      19 */
 #define cs_put        20
 #define cs_get        21
-#define cs_ifelse     22 
+#define cs_ifelse     22
 #define cs_random     23
 #define cs_mul        24
 /*      RESERVED      25 */
@@ -1375,7 +1375,7 @@ t1char_encode_charpath (t1_chardesc *cd,
   curr = cd->charpath;
 
   RESET_STATE();
-  CLEARSTACK(); 
+  CLEARSTACK();
   /*
    * Advance Width
    */

--- a/tectonic/dpx-t1_char.h
+++ b/tectonic/dpx-t1_char.h
@@ -16,11 +16,11 @@ typedef struct {
 } t1_ginfo;
 
 extern int  t1char_get_metrics (card8 *src, int srclen,
-				cff_index *subrs, t1_ginfo *ginfo);
+                                cff_index *subrs, t1_ginfo *ginfo);
 extern int  t1char_convert_charstring (card8 *dst, int dstlen,
-				       card8 *src, int srclen,
-				       cff_index *subrs,
-				       double default_width, double nominal_width,
-				       t1_ginfo *ginfo);
+                                       card8 *src, int srclen,
+                                       cff_index *subrs,
+                                       double default_width, double nominal_width,
+                                       t1_ginfo *ginfo);
 
 #endif /* _T1_CSTR_H_ */

--- a/tectonic/dpx-t1_load.c
+++ b/tectonic/dpx-t1_load.c
@@ -496,7 +496,7 @@ parse_encoding (char **enc_vec, unsigned char **start, unsigned char *end)
             if (MATCH_OP(tok, "dup")) { /* possibly putinterval type */
                 if (enc_vec == NULL) {
                     dpx_warning("This kind of type1 fonts are not supported as native fonts.\n"
-				"                   They are supported if used with tfm fonts.\n");
+                                "                   They are supported if used with tfm fonts.\n");
                 } else {
                     try_put_or_putinterval(enc_vec, start, end);
                 }
@@ -1196,39 +1196,39 @@ get_pfb_segment_tt (rust_input_handle_t handle, int expected_type, int *length)
         ch = ttstub_input_getc(handle);
         if (ch < 0)
             break;
-	if (ch != 128)
+        if (ch != 128)
             _tt_abort("Not a pfb file?");
 
         ch = ttstub_input_getc(handle);
         if (ch < 0 || ch != expected_type) {
-	    ttstub_input_seek(handle, -2, SEEK_CUR);
+            ttstub_input_seek(handle, -2, SEEK_CUR);
             break;
         }
 
-	slen = 0;
+        slen = 0;
 
-	for (i = 0; i < 4; i++) {
-	    if ((ch = ttstub_input_getc(handle)) < 0) {
-		if (buffer)
-		    free(buffer);
-		return NULL;
-	    }
+        for (i = 0; i < 4; i++) {
+            if ((ch = ttstub_input_getc(handle)) < 0) {
+                if (buffer)
+                    free(buffer);
+                return NULL;
+            }
 
-	    slen = slen + (ch << (8 * i));
-	}
+            slen = slen + (ch << (8 * i));
+        }
 
-	buffer = RENEW(buffer, bytesread + slen, unsigned char);
-	while (slen > 0) {
-	    rlen = ttstub_input_read(handle, buffer + bytesread, slen);
-	    if (rlen < 0) {
-		if (buffer)
-		    free(buffer);
-		return NULL;
-	    }
+        buffer = RENEW(buffer, bytesread + slen, unsigned char);
+        while (slen > 0) {
+            rlen = ttstub_input_read(handle, buffer + bytesread, slen);
+            if (rlen < 0) {
+                if (buffer)
+                    free(buffer);
+                return NULL;
+            }
 
-	    slen -= rlen;
-	    bytesread += rlen;
-	}
+            slen -= rlen;
+            bytesread += rlen;
+        }
     }
 
     if (bytesread == 0)

--- a/tectonic/dpx-t1_load.h
+++ b/tectonic/dpx-t1_load.h
@@ -4,19 +4,19 @@
     the dvipdfmx project team.
 
     Copyright (C) 2012-2015 by Khaled Hosny <khaledhosny@eglug.org>
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tfm.c
+++ b/tectonic/dpx-tfm.c
@@ -181,9 +181,9 @@ lookup_range (const struct range_map *map, int charcode)
   int  idx;
 
   for (idx = map->num_coverages - 1; idx >= 0 &&
-	 charcode >= map->coverages[idx].first_char; idx--) {
+         charcode >= map->coverages[idx].first_char; idx--) {
     if (charcode <=
-	map->coverages[idx].first_char + map->coverages[idx].num_chars)
+        map->coverages[idx].first_char + map->coverages[idx].num_chars)
       return map->indices[CHARACTER_INDEX(idx)];
   }
 
@@ -297,7 +297,7 @@ fread_fwords (fixword *words, int32_t nmemb, rust_input_handle_t handle)
     int i;
 
     for (i = 0; i < nmemb; i++)
-	words[i] = tt_get_signed_quad(handle);
+        words[i] = tt_get_signed_quad(handle);
 
     return nmemb * 4;
 }
@@ -309,7 +309,7 @@ fread_uquads (uint32_t *quads, int32_t nmemb, rust_input_handle_t handle)
     int i;
 
     for (i = 0; i < nmemb; i++)
-	quads[i] = tt_get_unsigned_quad(handle);
+        quads[i] = tt_get_unsigned_quad(handle);
 
     return nmemb * 4;
 }
@@ -327,7 +327,7 @@ tfm_check_size (struct tfm_font *tfm, off_t tfm_file_size)
    *
   if (tfm->wlenfile != tfm_file_size / 4) {
     dpx_warning("TFM file size is %ld bytes but it says it is %ld bytes!",
-	 tfm_file_size, tfm->wlenfile * 4);
+         tfm_file_size, tfm->wlenfile * 4);
     if (tfm_file_size > tfm->wlenfile * 4) {
       dpx_warning("Proceeding nervously...");
     } else {
@@ -352,7 +352,7 @@ tfm_check_size (struct tfm_font *tfm, off_t tfm_file_size)
 
   if (expected_size != tfm->wlenfile) {
     dpx_warning("TFM file size is expected to be %" PRId64 " bytes but it says it is %" PRId64 "bytes!",
-	 (int64_t)expected_size * 4, (int64_t)tfm->wlenfile * 4);
+         (int64_t)expected_size * 4, (int64_t)tfm->wlenfile * 4);
     if ((int64_t)tfm_file_size > (int64_t)expected_size *4) {
       dpx_warning("Proceeding nervously...");
     } else {
@@ -371,7 +371,7 @@ tfm_get_sizes (rust_input_handle_t tfm_handle, off_t tfm_file_size, struct tfm_f
     tfm->bc = tt_get_unsigned_pair(tfm_handle);
     tfm->ec = tt_get_unsigned_pair(tfm_handle);
     if (tfm->ec < tfm->bc)
-	_tt_abort("TFM file error: ec(%u) < bc(%u) ???", tfm->ec, tfm->bc);
+        _tt_abort("TFM file error: ec(%u) < bc(%u) ???", tfm->ec, tfm->bc);
 
     tfm->nwidths  = tt_get_unsigned_pair(tfm_handle);
     tfm->nheights = tt_get_unsigned_pair(tfm_handle);
@@ -448,7 +448,7 @@ tfm_unpack_header (struct font_metric *fm, struct tfm_font *tfm)
       p = fm->codingscheme;
       p += sput_bigendian(p, tfm->header[2], 3);
       for (i = 1; i <= len / 4; i++) {
-	p += sput_bigendian(p, tfm->header[2+i], 4);
+        p += sput_bigendian(p, tfm->header[2+i], 4);
       }
       fm->codingscheme[len] = '\0';
     } else {
@@ -559,7 +559,7 @@ ofm_do_char_info_one (FILE *tfm_file, struct tfm_font *tfm)
     tfm->depth_index  = NEW(num_chars, unsigned char);
     char_infos_read   = 0;
     for (i = 0; i < num_chars &&
-	   char_infos_read < num_char_infos; i++) {
+           char_infos_read < num_char_infos; i++) {
       int repeats, j;
 
       tfm->width_index [i] = get_unsigned_pair(tfm_file);
@@ -570,20 +570,20 @@ ofm_do_char_info_one (FILE *tfm_file, struct tfm_font *tfm)
       repeats = get_unsigned_pair(tfm_file);
       /* Skip params */
       for (j = 0; j < tfm->npc; j++) {
-	get_unsigned_pair(tfm_file);
+        get_unsigned_pair(tfm_file);
       }
       /* Remove word padding if necessary */
       if (ISEVEN(tfm->npc)){
-	get_unsigned_pair(tfm_file);
+        get_unsigned_pair(tfm_file);
       }
       char_infos_read++;
       if (i + repeats > num_chars) {
-	_tt_abort("Repeats causes number of characters to be exceeded.");
+        _tt_abort("Repeats causes number of characters to be exceeded.");
       }
       for (j = 0; j < repeats; j++) {
-	tfm->width_index [i+j+1] = tfm->width_index [i];
-	tfm->height_index[i+j+1] = tfm->height_index[i];
-	tfm->depth_index [i+j+1] = tfm->depth_index [i];
+        tfm->width_index [i+j+1] = tfm->width_index [i];
+        tfm->height_index[i+j+1] = tfm->height_index[i];
+        tfm->depth_index [i+j+1] = tfm->depth_index [i];
       }
       /* Skip ahead because we have already handled repeats */
       i += repeats;
@@ -593,7 +593,7 @@ ofm_do_char_info_one (FILE *tfm_file, struct tfm_font *tfm)
 
 static void
 ofm_unpack_arrays (struct font_metric *fm,
-		   struct tfm_font *tfm, uint32_t num_chars)
+                   struct tfm_font *tfm, uint32_t num_chars)
 {
   int i;
 
@@ -666,28 +666,28 @@ read_tfm (struct font_metric *fm, rust_input_handle_t tfm_handle, off_t tfm_file
     fm->lastchar  = tfm.ec;
 
     if (tfm.wlenheader > 0) {
-	tfm.header = NEW(tfm.wlenheader, fixword);
-	fread_fwords(tfm.header, tfm.wlenheader, tfm_handle);
+        tfm.header = NEW(tfm.wlenheader, fixword);
+        fread_fwords(tfm.header, tfm.wlenheader, tfm_handle);
     }
 
     if (tfm.ec - tfm.bc + 1 > 0) {
-	tfm.char_info = NEW(tfm.ec - tfm.bc + 1, uint32_t);
-	fread_uquads(tfm.char_info, tfm.ec - tfm.bc + 1, tfm_handle);
+        tfm.char_info = NEW(tfm.ec - tfm.bc + 1, uint32_t);
+        fread_uquads(tfm.char_info, tfm.ec - tfm.bc + 1, tfm_handle);
     }
 
     if (tfm.nwidths > 0) {
-	tfm.width = NEW(tfm.nwidths, fixword);
-	fread_fwords(tfm.width, tfm.nwidths, tfm_handle);
+        tfm.width = NEW(tfm.nwidths, fixword);
+        fread_fwords(tfm.width, tfm.nwidths, tfm_handle);
     }
 
     if (tfm.nheights > 0) {
-	tfm.height = NEW(tfm.nheights, fixword);
-	fread_fwords(tfm.height, tfm.nheights, tfm_handle);
+        tfm.height = NEW(tfm.nheights, fixword);
+        fread_fwords(tfm.height, tfm.nheights, tfm_handle);
     }
 
     if (tfm.ndepths > 0) {
-	tfm.depth = NEW(tfm.ndepths, fixword);
-	fread_fwords(tfm.depth, tfm.ndepths, tfm_handle);
+        tfm.depth = NEW(tfm.ndepths, fixword);
+        fread_fwords(tfm.depth, tfm.ndepths, tfm_handle);
     }
 
     tfm_unpack_arrays(fm, &tfm);
@@ -706,8 +706,8 @@ tfm_open (const char *tfm_name, int must_exist)
     char *ofm_name, *suffix;
 
     for (i = 0; i < numfms; i++) {
-	if (!strcmp(tfm_name, fms[i].tex_name))
-	    return i;
+        if (!strcmp(tfm_name, fms[i].tex_name))
+            return i;
     }
 
     /*
@@ -727,51 +727,51 @@ tfm_open (const char *tfm_name, int must_exist)
 
     suffix = strrchr(tfm_name, '.');
     if (!suffix || (strcmp(suffix, ".tfm") != 0 && strcmp(suffix, ".ofm") != 0)) {
-	ofm_name = NEW(strlen(tfm_name) + strlen(".ofm") + 1, char);
-	strcpy(ofm_name, tfm_name);
-	strcat(ofm_name, ".ofm");
+        ofm_name = NEW(strlen(tfm_name) + strlen(".ofm") + 1, char);
+        strcpy(ofm_name, tfm_name);
+        strcat(ofm_name, ".ofm");
     } else {
-	ofm_name = NULL;
+        ofm_name = NULL;
     }
 
     if (ofm_name &&
-	(tfm_handle = ttstub_input_open(ofm_name, kpse_ofm_format, 0)) != NULL) {
-	format = OFM_FORMAT;
+        (tfm_handle = ttstub_input_open(ofm_name, kpse_ofm_format, 0)) != NULL) {
+        format = OFM_FORMAT;
     } else if ((tfm_handle = ttstub_input_open(tfm_name, kpse_tfm_format, 0)) != NULL) {
-	format = TFM_FORMAT;
+        format = TFM_FORMAT;
     } else if ((tfm_handle = ttstub_input_open(tfm_name, kpse_ofm_format, 0)) != NULL) {
-	format = OFM_FORMAT;
+        format = OFM_FORMAT;
     }
 
     if (ofm_name)
-	free(ofm_name);
+        free(ofm_name);
 
     if (tfm_handle == NULL) {
-	if (must_exist)
-	    _tt_abort("Unable to find TFM file \"%s\".", tfm_name);
-	return -1;
+        if (must_exist)
+            _tt_abort("Unable to find TFM file \"%s\".", tfm_name);
+        return -1;
     }
 
     if (verbose) {
-	if (format == TFM_FORMAT)
-	    dpx_message("(TFM:%s", tfm_name);
-	else if (format == OFM_FORMAT)
-	    dpx_message("(OFM:%s", tfm_name);
+        if (format == TFM_FORMAT)
+            dpx_message("(TFM:%s", tfm_name);
+        else if (format == OFM_FORMAT)
+            dpx_message("(OFM:%s", tfm_name);
     }
 
     tfm_file_size = ttstub_input_get_size (tfm_handle);
     if (tfm_file_size > 0x1FFFFFFFF)
-	_tt_abort("TFM/OFM file size exceeds 33-bit");
+        _tt_abort("TFM/OFM file size exceeds 33-bit");
     if (tfm_file_size < 24)
-	_tt_abort("TFM/OFM file too small to be a valid file.");
+        _tt_abort("TFM/OFM file too small to be a valid file.");
 
     fms_need(numfms + 1);
     fm_init(fms + numfms);
 
     if (format == OFM_FORMAT)
-	_tt_abort("TODO: port read_ofm to new I/O"); /*read_ofm(&fms[numfms], tfm_file, tfm_file_size);*/
+        _tt_abort("TODO: port read_ofm to new I/O"); /*read_ofm(&fms[numfms], tfm_file, tfm_file_size);*/
     else
-	read_tfm(&fms[numfms], tfm_handle, tfm_file_size);
+        read_tfm(&fms[numfms], tfm_handle, tfm_file_size);
 
     ttstub_input_close(tfm_handle);
 
@@ -779,7 +779,7 @@ tfm_open (const char *tfm_name, int must_exist)
     strcpy(fms[numfms].tex_name, tfm_name);
 
     if (verbose)
-	dpx_message(")");
+        dpx_message(")");
 
     return numfms++;
 }
@@ -817,12 +817,12 @@ tfm_get_fw_width (int font_id, int32_t ch)
     case MAPTYPE_CHAR:
       idx = lookup_char(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     case MAPTYPE_RANGE:
       idx = lookup_range(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     default:
       idx = ch;
@@ -848,12 +848,12 @@ tfm_get_fw_height (int font_id, int32_t ch)
     case MAPTYPE_CHAR:
       idx = lookup_char(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     case MAPTYPE_RANGE:
       idx = lookup_range(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     default:
       idx = ch;
@@ -879,12 +879,12 @@ tfm_get_fw_depth (int font_id, int32_t ch)
     case MAPTYPE_CHAR:
       idx = lookup_char(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     case MAPTYPE_RANGE:
       idx = lookup_range(fm->charmap.data, ch);
       if (idx < 0)
-	_tt_abort("Invalid char: %ld\n", ch);
+        _tt_abort("Invalid char: %ld\n", ch);
       break;
     default:
       idx = ch;

--- a/tectonic/dpx-tfm.h
+++ b/tectonic/dpx-tfm.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-truetype.h
+++ b/tectonic/dpx-truetype.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tt_aux.c
+++ b/tectonic/dpx-tt_aux.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -40,7 +40,7 @@ void tt_aux_set_verbose(void)
 ULONG ttc_read_offset (sfnt *sfont, int ttc_idx)
 {
   ULONG offset = 0, num_dirs = 0;
-  
+
   if (sfont == NULL || sfont->handle == NULL)
     _tt_abort("file not opened");
 
@@ -64,7 +64,7 @@ ULONG ttc_read_offset (sfnt *sfont, int ttc_idx)
   Build FontDescriptor (except FontName) from TrueType tables:
 
    Most information found in FontDescriptor is used only when automatic
-   font substitution is needed. (in the case of missing/broken font data) 
+   font substitution is needed. (in the case of missing/broken font data)
    Some PDF viewers may ignore embedded TrueType glyph data. Especially,
    any embedded TrueType data for CID-keyed (CIDFontType 2) font is ignored
    by PDF viewers that only support PDF versions 1.2 or earlier.
@@ -170,7 +170,7 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
        with "Preview & Print embedding" setting.
 
        2001/11/22: Changed to allow `Preview & Print' only fonts embedding
-       
+
        2006/04/19: Added support for always_embed option
     */
     if (os2->fsType == 0x0000 || (os2->fsType & 0x0008)) {
@@ -262,7 +262,7 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
   if (type == 0 && os2) { /* cid-keyed font - add panose */
     pdf_obj *styledict = NULL;
     unsigned char panose[12];
-    
+
     panose[0] = os2->sFamilyClass >> 8;
     panose[1] = os2->sFamilyClass & 0xff;
     memcpy(panose+2, os2->panose, 10);

--- a/tectonic/dpx-tt_aux.c
+++ b/tectonic/dpx-tt_aux.c
@@ -155,8 +155,8 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
 
   descriptor = pdf_new_dict();
   pdf_add_dict (descriptor,
-		pdf_new_name ("Type"),
-		pdf_new_name ("FontDescriptor"));
+                pdf_new_name ("Type"),
+                pdf_new_name ("FontDescriptor"));
 
   if (*embed && os2) {
     /*
@@ -196,34 +196,34 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
 
   if (os2) {
     pdf_add_dict (descriptor,
-		  pdf_new_name ("Ascent"),
-		  pdf_new_number (PDFUNIT(os2->sTypoAscender)));
+                  pdf_new_name ("Ascent"),
+                  pdf_new_number (PDFUNIT(os2->sTypoAscender)));
     pdf_add_dict (descriptor,
-		  pdf_new_name ("Descent"),
-		  pdf_new_number (PDFUNIT(os2->sTypoDescender)));
+                  pdf_new_name ("Descent"),
+                  pdf_new_number (PDFUNIT(os2->sTypoDescender)));
     if (stemv < 0) /* if not given by the option '-v' */
       stemv = (os2->usWeightClass/65.)*(os2->usWeightClass/65.)+50;
     pdf_add_dict (descriptor,
-		  pdf_new_name ("StemV"),
-		  pdf_new_number (stemv));
+                  pdf_new_name ("StemV"),
+                  pdf_new_number (stemv));
     if (os2->version == 0x0002) {
       pdf_add_dict (descriptor,
-		    pdf_new_name("CapHeight"),
-		    pdf_new_number(PDFUNIT(os2->sCapHeight)));
+                    pdf_new_name("CapHeight"),
+                    pdf_new_number(PDFUNIT(os2->sCapHeight)));
       /* optional */
       pdf_add_dict (descriptor,
-		    pdf_new_name("XHeight"),
-		    pdf_new_number(PDFUNIT(os2->sxHeight)));
+                    pdf_new_name("XHeight"),
+                    pdf_new_number(PDFUNIT(os2->sxHeight)));
     } else { /* arbitrary */
       pdf_add_dict (descriptor,
-		    pdf_new_name("CapHeight"),
-		    pdf_new_number(PDFUNIT(os2->sTypoAscender)));
+                    pdf_new_name("CapHeight"),
+                    pdf_new_number(PDFUNIT(os2->sTypoAscender)));
     }
     /* optional */
     if (os2->xAvgCharWidth != 0) {
       pdf_add_dict (descriptor,
-		    pdf_new_name ("AvgWidth"),
-		    pdf_new_number (PDFUNIT(os2->xAvgCharWidth)));
+                    pdf_new_name ("AvgWidth"),
+                    pdf_new_number (PDFUNIT(os2->xAvgCharWidth)));
     }
   }
 
@@ -237,8 +237,8 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
 
   /* post */
   pdf_add_dict (descriptor,
-		pdf_new_name ("ItalicAngle"),
-		pdf_new_number(fixed(post->italicAngle)));
+                pdf_new_name ("ItalicAngle"),
+                pdf_new_number(fixed(post->italicAngle)));
 
   /* Flags */
   if (os2) {
@@ -255,8 +255,8 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
   }
 
   pdf_add_dict (descriptor,
-		pdf_new_name ("Flags"),
-		pdf_new_number (flag));
+                pdf_new_name ("Flags"),
+                pdf_new_number (flag));
 
   /* insert panose if you want */
   if (type == 0 && os2) { /* cid-keyed font - add panose */
@@ -269,7 +269,7 @@ pdf_obj *tt_get_fontdesc (sfnt *sfont, int *embed, int stemv, int type, const ch
 
     styledict = pdf_new_dict ();
     pdf_add_dict (styledict, pdf_new_name ("Panose"),
-		  pdf_new_string (panose, 12));
+                  pdf_new_string (panose, 12));
     pdf_add_dict (descriptor, pdf_new_name ("Style"), styledict);
   }
 

--- a/tectonic/dpx-tt_aux.h
+++ b/tectonic/dpx-tt_aux.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tt_cmap.c
+++ b/tectonic/dpx-tt_cmap.c
@@ -1278,7 +1278,7 @@ otf_create_ToUnicode_stream (const char *font_name,
 
     sfnt_close(sfont);
     if (handle)
-	ttstub_input_close(handle);
+        ttstub_input_close(handle);
 
     return cmap_ref;
 }

--- a/tectonic/dpx-tt_cmap.h
+++ b/tectonic/dpx-tt_cmap.h
@@ -72,7 +72,7 @@ extern pdf_obj *otf_create_ToUnicode_stream (const char *map_name,
                                              int cmap_id);
 /* CMap ID */
 extern int      otf_load_Unicode_CMap       (const char *map_name,
-					     int ttc_index,
-					     const char *otl_opts, int wmode);
+                                             int ttc_index,
+                                             const char *otl_opts, int wmode);
 
 #endif /* _TT_CMAP_H_ */

--- a/tectonic/dpx-tt_cmap.h
+++ b/tectonic/dpx-tt_cmap.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tt_glyf.c
+++ b/tectonic/dpx-tt_glyf.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -159,7 +159,7 @@ tt_build_finish (struct tt_glyphs *g)
   }
 }
 
-static inline int 
+static inline int
 glyf_cmp (const void *v1, const void *v2)
 {
   int cmp = 0;
@@ -174,7 +174,7 @@ glyf_cmp (const void *v1, const void *v2)
     cmp = -1;
   else
     cmp = 1;
-    
+
   return cmp;
 }
 

--- a/tectonic/dpx-tt_glyf.c
+++ b/tectonic/dpx-tt_glyf.c
@@ -148,8 +148,8 @@ tt_build_finish (struct tt_glyphs *g)
     if (g->gd) {
       USHORT idx;
       for (idx = 0; idx < g->num_glyphs; idx++) {
-	if (g->gd[idx].data)
-	  free(g->gd[idx].data);
+        if (g->gd[idx].data)
+          free(g->gd[idx].data);
       }
       free(g->gd);
     }
@@ -351,32 +351,32 @@ tt_build_tables (sfnt *sfont, struct tt_glyphs *g)
     if (number_of_contours < 0) {
       USHORT flags, cgid, new_gid; /* flag, gid of a component */
       do {
-	if (p >= endptr)
-	  _tt_abort("Invalid TrueType glyph data (gid %u): %u bytes", gid, len);
-	/*
-	 * Flags and gid of component glyph are both USHORT.
-	 */
-	flags = ((*p) << 8)| *(p+1);
-	p += 2;
-	cgid  = ((*p) << 8)| *(p+1);
-	if (cgid >= maxp->numGlyphs) {
-	  _tt_abort("Invalid gid (%u > %u) in composite glyph %u.", cgid, maxp->numGlyphs, gid);
-	}
-	new_gid = tt_find_glyph(g, cgid);
-	if (new_gid == 0) {
-	  new_gid = tt_add_glyph(g, cgid, find_empty_slot(g));
-	}
-	p += sfnt_put_ushort(p, new_gid);
-	/*
-	 * Just skip remaining part.
-	 */
-	p += (flags & ARG_1_AND_2_ARE_WORDS) ? 4 : 2;
-	if (flags & WE_HAVE_A_SCALE) /* F2Dot14 */
-	  p += 2;
-	else if (flags & WE_HAVE_AN_X_AND_Y_SCALE) /* F2Dot14 x 2 */
-	  p += 4;
-	else if (flags & WE_HAVE_A_TWO_BY_TWO) /* F2Dot14 x 4 */
-	  p += 8;
+        if (p >= endptr)
+          _tt_abort("Invalid TrueType glyph data (gid %u): %u bytes", gid, len);
+        /*
+         * Flags and gid of component glyph are both USHORT.
+         */
+        flags = ((*p) << 8)| *(p+1);
+        p += 2;
+        cgid  = ((*p) << 8)| *(p+1);
+        if (cgid >= maxp->numGlyphs) {
+          _tt_abort("Invalid gid (%u > %u) in composite glyph %u.", cgid, maxp->numGlyphs, gid);
+        }
+        new_gid = tt_find_glyph(g, cgid);
+        if (new_gid == 0) {
+          new_gid = tt_add_glyph(g, cgid, find_empty_slot(g));
+        }
+        p += sfnt_put_ushort(p, new_gid);
+        /*
+         * Just skip remaining part.
+         */
+        p += (flags & ARG_1_AND_2_ARE_WORDS) ? 4 : 2;
+        if (flags & WE_HAVE_A_SCALE) /* F2Dot14 */
+          p += 2;
+        else if (flags & WE_HAVE_AN_X_AND_Y_SCALE) /* F2Dot14 x 2 */
+          p += 4;
+        else if (flags & WE_HAVE_A_TWO_BY_TWO) /* F2Dot14 x 4 */
+          p += 8;
       } while (flags & MORE_COMPONENT);
       /*
        * TrueType instructions comes here:
@@ -396,8 +396,8 @@ tt_build_tables (sfnt *sfont, struct tt_glyphs *g)
     g->dw = g->gd[0].advw;
     for (i = 0; i < g->emsize + 1; i++) {
       if (w_stat[i] > max_count) {
-	max_count = w_stat[i];
-	g->dw = i;
+        max_count = w_stat[i];
+        g->dw = i;
       }
     }
   }
@@ -416,8 +416,8 @@ tt_build_tables (sfnt *sfont, struct tt_glyphs *g)
       padlen = (g->gd[i].length % 4) ? (4 - (g->gd[i].length % 4)) : 0;
       glyf_table_size += g->gd[i].length + padlen;
       if (!num_hm_known && last_advw != g->gd[i].advw) {
-	hhea->numOfLongHorMetrics = g->gd[i].gid + 2;
-	num_hm_known = 1;
+        hhea->numOfLongHorMetrics = g->gd[i].gid + 2;
+        num_hm_known = 1;
       }
     }
     /* All advance widths are same. */
@@ -447,27 +447,27 @@ tt_build_tables (sfnt *sfont, struct tt_glyphs *g)
       int gap, j;
       gap = g->gd[i].gid - prev - 1;
       for (j = 1; j <= gap; j++) {
-	if (prev + j == hhea->numOfLongHorMetrics - 1) {
-	  p += sfnt_put_ushort(p, last_advw);
-	} else if (prev + j < hhea->numOfLongHorMetrics) {
-	  p += sfnt_put_ushort(p, 0);
-	}
-	p += sfnt_put_short (p, 0);
-	if (head->indexToLocFormat == 0) {
-	  q += sfnt_put_ushort(q, (USHORT) (offset/2));
-	} else {
-	  q += sfnt_put_ulong(q, offset);
-	}
+        if (prev + j == hhea->numOfLongHorMetrics - 1) {
+          p += sfnt_put_ushort(p, last_advw);
+        } else if (prev + j < hhea->numOfLongHorMetrics) {
+          p += sfnt_put_ushort(p, 0);
+        }
+        p += sfnt_put_short (p, 0);
+        if (head->indexToLocFormat == 0) {
+          q += sfnt_put_ushort(q, (USHORT) (offset/2));
+        } else {
+          q += sfnt_put_ulong(q, offset);
+        }
       }
       padlen = (g->gd[i].length % 4) ? (4 - (g->gd[i].length % 4)) : 0;
       if (g->gd[i].gid < hhea->numOfLongHorMetrics) {
-	p += sfnt_put_ushort(p, g->gd[i].advw);
+        p += sfnt_put_ushort(p, g->gd[i].advw);
       }
       p += sfnt_put_short (p, g->gd[i].lsb);
       if (head->indexToLocFormat == 0) {
-	q += sfnt_put_ushort(q, (USHORT) (offset/2));
+        q += sfnt_put_ushort(q, (USHORT) (offset/2));
       } else {
-	q += sfnt_put_ulong(q, offset);
+        q += sfnt_put_ulong(q, offset);
       }
       memset(glyf_table_data + offset, 0, g->gd[i].length + padlen);
       memcpy(glyf_table_data + offset, g->gd[i].data, g->gd[i].length);
@@ -643,8 +643,8 @@ tt_get_metrics (sfnt *sfont, struct tt_glyphs *g)
     g->dw = g->gd[0].advw;
     for (i = 0; i < g->emsize + 1; i++) {
       if (w_stat[i] > max_count) {
-	max_count = w_stat[i];
-	g->dw = i;
+        max_count = w_stat[i];
+        g->dw = i;
       }
     }
   }

--- a/tectonic/dpx-tt_glyf.h
+++ b/tectonic/dpx-tt_glyf.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tt_gsub.c
+++ b/tectonic/dpx-tt_gsub.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -55,7 +55,7 @@ struct clt_record
 /* Ranges */
 /* RangeRecord */
 struct clt_range
-{ 
+{
   GlyphID Start; /* First GlyphID in the range */
   GlyphID End;   /* Last GlyphID in the range */
   USHORT  StartCoverageIndex; /* Converage Index of first GID */
@@ -881,7 +881,7 @@ otl_gsub_read_feat (struct otl_gsub_tab *gsub, sfnt *sfont)
       clt_read_script_table(&script_tab, sfont);
 
       if (otl_match_optrule(language, "dflt") &&
-          script_tab.DefaultLangSys != 0) { 
+          script_tab.DefaultLangSys != 0) {
         struct clt_langsys_table langsys_tab;
 
         if(verbose > VERBOSE_LEVEL_MIN) {
@@ -1334,7 +1334,7 @@ otl_gsub_add_feat (otl_gsub *gsub_list,
     free(gsub->language);
     free(gsub->feature);
   }
-  
+
   return retval;
 }
 
@@ -1589,7 +1589,7 @@ otl_gsub_dump_ligature (struct otl_gsub_subtab *subtab)
       if (idx >= 0 && idx < data->LigSetCount) {
         struct otl_gsub_ligset *ligset;
         USHORT  i, j;
-        ligset = &(data->LigatureSet[idx]); 
+        ligset = &(data->LigatureSet[idx]);
         for (j = 0; j < ligset->LigatureCount; j++) {
           fprintf(stdout, "substitute \\%u", (USHORT) gid);
           for (i = 0; i < ligset->Ligature[j].CompCount - 1; i++) {

--- a/tectonic/dpx-tt_gsub.h
+++ b/tectonic/dpx-tt_gsub.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -55,7 +55,7 @@ extern int  otl_gsub_apply_lig (otl_gsub *gsub_list,
                                 USHORT *gid_in, USHORT num_gids,
                                 USHORT *gid_out);
 
-#if  0  
+#if  0
 extern int  otl_gsub_dump      (otl_gsub *gsub_list,
                                 const char *script,
                                 const char *language,

--- a/tectonic/dpx-tt_post.c
+++ b/tectonic/dpx-tt_post.c
@@ -235,7 +235,7 @@ macglyphorder[258] = {
   "section", "bullet", "paragraph", "germandbls", "registered",
   "copyright", "trademark", "acute", "dieresis", "notequal",
   /* 0x0090 */
-  "AE", "Oslash", "infinity", "plusminus", "lessequal",	"greaterequal",
+  "AE", "Oslash", "infinity", "plusminus", "lessequal", "greaterequal",
   "yen", "mu", "partialdiff", "summation", "product", "pi", "integral",
   "ordfeminine", "ordmasculine", "Omega",
   /* 0x00a0 */
@@ -248,7 +248,7 @@ macglyphorder[258] = {
   "Ydieresis", "fraction", "currency", "guilsinglleft", "guilsinglright",
   /* 0x00c0 */
   "fi", "fl", "daggerdbl", "periodcentered", "quotesinglbase",
-  "quotedblbase", "perthousand", "Acircumflex",	 "Ecircumflex", "Aacute",
+  "quotedblbase", "perthousand", "Acircumflex", "Ecircumflex", "Aacute",
   "Edieresis", "Egrave", "Iacute", "Icircumflex", "Idieresis", "Igrave",
   /* 0x00d0 */
   "Oacute", "Ocircumflex", "apple", "Ograve", "Uacute", "Ucircumflex",

--- a/tectonic/dpx-tt_post.c
+++ b/tectonic/dpx-tt_post.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-tt_post.c
+++ b/tectonic/dpx-tt_post.c
@@ -50,14 +50,14 @@ read_v2_post_names (struct tt_post_table *post, sfnt *sfont)
       if (idx > maxidx)
         maxidx = idx;
       if (idx > 32767) {
-	/* Although this is strictly speaking out of spec, it seems to work
-	   and there are real-life fonts that use it.
+        /* Although this is strictly speaking out of spec, it seems to work
+           and there are real-life fonts that use it.
            We show a warning only once, instead of thousands of times */
-	static char warning_issued = 0;
-	if (!warning_issued) {
-	  dpx_warning("TrueType post table name index %u > 32767", idx);
-	  warning_issued = 1;
-	}
+        static char warning_issued = 0;
+        if (!warning_issued) {
+          dpx_warning("TrueType post table name index %u > 32767", idx);
+          warning_issued = 1;
+        }
         /* In a real-life large font, (x)dvipdfmx crashes if we use
            nonvanishing idx in the case of idx > 32767.
            If we set idx = 0, (x)dvipdfmx works fine for the font and
@@ -77,11 +77,11 @@ read_v2_post_names (struct tt_post_table *post, sfnt *sfont)
     for (i = 0; i < post->count; i++) { /* read Pascal strings */
       len = sfnt_get_byte(sfont);
       if (len > 0) {
-	post->names[i] = NEW(len + 1, char);
-	sfnt_read(post->names[i], len, sfont);
-	post->names[i][len] = 0;
+        post->names[i] = NEW(len + 1, char);
+        sfnt_read(post->names[i], len, sfont);
+        post->names[i][len] = 0;
       } else {
-	post->names[i] = NULL;
+        post->names[i] = NULL;
       }
     }
   }
@@ -95,7 +95,7 @@ read_v2_post_names (struct tt_post_table *post, sfnt *sfont)
       post->glyphNamePtr[i] = post->names[idx - 258];
     } else {
       dpx_warning("Invalid glyph name index number: %u (>= %u)",
-	   idx, post->count + 258);
+           idx, post->count + 258);
       free(indices);
       return -1;
     }
@@ -159,7 +159,7 @@ tt_lookup_post_table (struct tt_post_table *post, const char *glyphname)
 
   for (gid = 0; gid < post->count; gid++) {
     if (post->glyphNamePtr[gid] &&
-	!strcmp(glyphname, post->glyphNamePtr[gid])) {
+        !strcmp(glyphname, post->glyphNamePtr[gid])) {
       return  gid;
     }
   }
@@ -187,7 +187,7 @@ tt_release_post_table (struct tt_post_table *post)
   if (post->names) {
     for (i = 0; i < post->count; i++) {
       if (post->names[i])
-	free(post->names[i]);
+        free(post->names[i]);
     }
     free(post->names);
   }

--- a/tectonic/dpx-tt_post.h
+++ b/tectonic/dpx-tt_post.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -33,7 +33,7 @@ struct tt_post_table
   ULONG    minMemType42;
   ULONG    maxMemType42;
   ULONG    minMemType1;
-  ULONG    maxMemType1; 
+  ULONG    maxMemType1;
 
   USHORT   numberOfGlyphs;
 

--- a/tectonic/dpx-tt_table.c
+++ b/tectonic/dpx-tt_table.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -401,7 +401,7 @@ tt_read_os2__table (sfnt *sfont)
       }
     }
   } else {
- 
+
     /* used in add_CIDVMetrics() of cidtype0.c */
     table->sTypoAscender  = 880;
     table->sTypoDescender = -120;
@@ -432,7 +432,7 @@ tt_get_name (sfnt *sfont, char *dest, USHORT destlen,
 
   name_offset = sfnt_locate_table (sfont, "name");
 
-  if (sfnt_get_ushort(sfont)) 
+  if (sfnt_get_ushort(sfont))
     _tt_abort("Expecting zero");
 
   num_names = sfnt_get_ushort(sfont);
@@ -487,7 +487,7 @@ tt_get_ps_fontname (sfnt *sfont, char *dest, USHORT destlen)
     /*
       Finally falling back to Mac Roman name field.
       Warning: Some bad Japanese TTfonts using SJIS encoded string in the
-      Mac Roman name field. 
+      Mac Roman name field.
     */
     namelen = tt_get_name(sfont, dest, destlen, 1, 0, 0, 1);
   }

--- a/tectonic/dpx-tt_table.c
+++ b/tectonic/dpx-tt_table.c
@@ -287,19 +287,19 @@ tt_read_VORG_table (sfnt *sfont)
 
     sfnt_locate_table(sfont, "VORG");
     if (sfnt_get_ushort(sfont) != 1 ||
-	sfnt_get_ushort(sfont) != 0)
+        sfnt_get_ushort(sfont) != 0)
       _tt_abort("Unsupported VORG version.");
 
     vorg->defaultVertOriginY    = sfnt_get_short(sfont);
     vorg->numVertOriginYMetrics = sfnt_get_ushort(sfont);
     vorg->vertOriginYMetrics    = NEW(vorg->numVertOriginYMetrics,
-				      struct tt_vertOriginYMetrics);
+                                      struct tt_vertOriginYMetrics);
     /*
      * The vertOriginYMetrics array must be sorted in increasing
      * glyphIndex order.
      */
     for (i = 0;
-	 i < vorg->numVertOriginYMetrics; i++) {
+         i < vorg->numVertOriginYMetrics; i++) {
       vorg->vertOriginYMetrics[i].glyphIndex  = sfnt_get_ushort(sfont);
       vorg->vertOriginYMetrics[i].vertOriginY = sfnt_get_short(sfont);
     }
@@ -422,8 +422,8 @@ tt_read_os2__table (sfnt *sfont)
 
 static USHORT
 tt_get_name (sfnt *sfont, char *dest, USHORT destlen,
-	     USHORT plat_id, USHORT enco_id,
-	     USHORT lang_id, USHORT name_id)
+             USHORT plat_id, USHORT enco_id,
+             USHORT lang_id, USHORT name_id)
 {
   USHORT length = 0;
   USHORT num_names, string_offset;
@@ -449,10 +449,10 @@ tt_get_name (sfnt *sfont, char *dest, USHORT destlen,
     offset = sfnt_get_ushort(sfont);
     /* language ID value 0xffffu for `accept any language ID' */
     if ((p_id == plat_id) && (e_id == enco_id) &&
-	(lang_id == 0xffffu || l_id == lang_id) && (n_id == name_id)) {
+        (lang_id == 0xffffu || l_id == lang_id) && (n_id == name_id)) {
       if (length > destlen - 1) {
-	dpx_warning("Name string too long (%u), truncating to %u", length, destlen);
-	length = destlen - 1;
+        dpx_warning("Name string too long (%u), truncating to %u", length, destlen);
+        length = destlen - 1;
       }
       sfnt_seek_set (sfont, name_offset+string_offset+offset);
       sfnt_read((unsigned char*)dest, length, sfont);

--- a/tectonic/dpx-tt_table.h
+++ b/tectonic/dpx-tt_table.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2007-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -70,7 +70,7 @@ struct tt_vhea_table
   Fixed  version;
   SHORT  vertTypoAscender;  /* v.1.1 name */
   SHORT  vertTypoDescender; /* v.1.1 name */
-  SHORT  vertTypoLineGap;   /* v.1.1 name */ 
+  SHORT  vertTypoLineGap;   /* v.1.1 name */
   SHORT  advanceHeightMax;
   SHORT  minTopSideBearing;
   SHORT  minBottomSideBearing;
@@ -106,35 +106,35 @@ struct tt_maxp_table
 struct tt_os2__table
 {
   USHORT  version; /* 0x0001 or 0x0002 */
-  SHORT   xAvgCharWidth;  
-  USHORT  usWeightClass;  
-  USHORT  usWidthClass;   
+  SHORT   xAvgCharWidth;
+  USHORT  usWeightClass;
+  USHORT  usWidthClass;
   SHORT   fsType;  /* if (faType & 0x08) editable_embedding */
-  SHORT   ySubscriptXSize;        
-  SHORT   ySubscriptYSize;      
+  SHORT   ySubscriptXSize;
+  SHORT   ySubscriptYSize;
   SHORT   ySubscriptXOffset;
-  SHORT   ySubscriptYOffset;      
-  SHORT   ySuperscriptXSize;      
-  SHORT   ySuperscriptYSize;      
-  SHORT   ySuperscriptXOffset;    
-  SHORT   ySuperscriptYOffset;    
-  SHORT   yStrikeoutSize; 
-  SHORT   yStrikeoutPosition;     
-  SHORT   sFamilyClass;   
+  SHORT   ySubscriptYOffset;
+  SHORT   ySuperscriptXSize;
+  SHORT   ySuperscriptYSize;
+  SHORT   ySuperscriptXOffset;
+  SHORT   ySuperscriptYOffset;
+  SHORT   yStrikeoutSize;
+  SHORT   yStrikeoutPosition;
+  SHORT   sFamilyClass;
   BYTE    panose[10];
   ULONG   ulUnicodeRange1;
   ULONG   ulUnicodeRange2;
   ULONG   ulUnicodeRange3;
   ULONG   ulUnicodeRange4;
-  CHAR    achVendID[4];   
-  USHORT  fsSelection;    
+  CHAR    achVendID[4];
+  USHORT  fsSelection;
   USHORT  usFirstCharIndex;
   USHORT  usLastCharIndex;
   SHORT   sTypoAscender;  /* TTF spec. from MS is wrong */
   SHORT   sTypoDescender; /* TTF spec. from MS is wrong */
   SHORT   sTypoLineGap;   /* TTF spec. from MS is wrong */
-  USHORT  usWinAscent;   
-  USHORT  usWinDescent;    
+  USHORT  usWinAscent;
+  USHORT  usWinDescent;
   ULONG   ulCodePageRange1;
   ULONG   ulCodePageRange2;
   /* version 0x0002 */

--- a/tectonic/dpx-tt_table.h
+++ b/tectonic/dpx-tt_table.h
@@ -183,7 +183,7 @@ extern struct tt_VORG_table *tt_read_VORG_table (sfnt *sfont);
 
 /* hmtx and vmtx */
 extern struct tt_longMetrics *tt_read_longMetrics (sfnt *sfont,
-						   USHORT numGlyphs, USHORT numLongMetrics, USHORT numExSideBearings);
+                                                   USHORT numGlyphs, USHORT numLongMetrics, USHORT numExSideBearings);
 
 /* OS/2 table */
 extern struct tt_os2__table *tt_read_os2__table (sfnt *sfont);

--- a/tectonic/dpx-type0.c
+++ b/tectonic/dpx-type0.c
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
@@ -20,7 +20,7 @@
 
 /*
  * Type0 font support:
- * 
+ *
  * TODO:
  *
  *  Composite font (multiple descendants) - not supported in PDF
@@ -391,7 +391,7 @@ Type0Font_cache_find (const char *map_name, int cmap_id, fontmap_opt *fmap_opt)
 
   /*
    * Encoding is Identity-H or Identity-V according as thier WMode value.
-   * 
+   *
    * We do not use match against the map_name since fonts (TrueType) covers
    * characters across multiple character collection (eg, Adobe-Japan1 and
    * Adobe-Japan2) must be splited into multiple CID-keyed fonts.
@@ -402,7 +402,7 @@ Type0Font_cache_find (const char *map_name, int cmap_id, fontmap_opt *fmap_opt)
 
   cid_id = CIDFont_cache_find(map_name, csi, fmap_opt);
 
-  if (cid_id < 0) 
+  if (cid_id < 0)
     return -1;
 
   /*
@@ -471,7 +471,7 @@ Type0Font_cache_find (const char *map_name, int cmap_id, fontmap_opt *fmap_opt)
   /*
    * PostScript Font name:
    *
-   *  Type0 font's fontname is usually descendant CID-keyed font's font name 
+   *  Type0 font's fontname is usually descendant CID-keyed font's font name
    *  appended by -ENCODING.
    */
   fontname = CIDFont_get_fontname(cidfont);

--- a/tectonic/dpx-type0.h
+++ b/tectonic/dpx-type0.h
@@ -2,17 +2,17 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-type1.c
+++ b/tectonic/dpx-type1.c
@@ -101,12 +101,12 @@ pdf_font_open_type1 (pdf_font *font)
         pdf_font_set_subtype(font, PDF_FONT_FONTTYPE_TYPE1);
         pdf_font_set_flags(font, PDF_FONT_FLAG_NOEMBED|PDF_FONT_FLAG_BASEFONT);
     } else {
-	rust_input_handle_t handle;
+        rust_input_handle_t handle;
 
         handle = ttstub_input_open(ident, kpse_type1_format, 0);
-	/* NOTE: skipping qcheck_filetype() call in dpx_find_type1_file but we
-	 * call is_pfb() in just a second anyway.
-	 */
+        /* NOTE: skipping qcheck_filetype() call in dpx_find_type1_file but we
+         * call is_pfb() in just a second anyway.
+         */
         if (handle == NULL)
             return -1;
 
@@ -114,7 +114,7 @@ pdf_font_open_type1 (pdf_font *font)
         if (!is_pfb(handle) || t1_get_fontname(handle, fontname) < 0)
             _tt_abort("Failed to read Type 1 font \"%s\".", ident);
 
-	ttstub_input_close(handle);
+        ttstub_input_close(handle);
         pdf_font_set_fontname(font, fontname);
         pdf_font_set_subtype (font, PDF_FONT_FONTTYPE_TYPE1);
     }
@@ -668,8 +668,8 @@ pdf_font_load_type1 (pdf_font *font)
                     dpx_message("/%s", glyph);
 
                 /* CharSet is actually string object. */
-		pdf_add_stream(pdfcharset, "/", 1);
-		pdf_add_stream(pdfcharset, glyph, strlen(glyph));
+                pdf_add_stream(pdfcharset, "/", 1);
+                pdf_add_stream(pdfcharset, glyph, strlen(glyph));
             }
         }
 

--- a/tectonic/dpx-type1.h
+++ b/tectonic/dpx-type1.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-vf.c
+++ b/tectonic/dpx-vf.c
@@ -77,8 +77,8 @@ static void
 read_header(rust_input_handle_t vf_handle, int thisfont)
 {
     if (tt_get_unsigned_byte (vf_handle) != PRE || tt_get_unsigned_byte (vf_handle) != VF_ID) {
-	fprintf (stderr, "VF file may be corrupt\n");
-	return;
+        fprintf (stderr, "VF file may be corrupt\n");
+        return;
     }
 
     /* skip comment */
@@ -94,13 +94,13 @@ static void resize_vf_fonts(int size)
 {
     int i;
     if (size > max_vf_fonts) {
-	vf_fonts = RENEW (vf_fonts, size, struct vf);
-	for (i=max_vf_fonts; i<size; i++) {
-	    vf_fonts[i].num_dev_fonts = 0;
-	    vf_fonts[i].max_dev_fonts = 0;
-	    vf_fonts[i].dev_fonts = NULL;
-	}
-	max_vf_fonts = size;
+        vf_fonts = RENEW (vf_fonts, size, struct vf);
+        for (i=max_vf_fonts; i<size; i++) {
+            vf_fonts[i].num_dev_fonts = 0;
+            vf_fonts[i].max_dev_fonts = 0;
+            vf_fonts[i].dev_fonts = NULL;
+        }
+        max_vf_fonts = size;
     }
     return;
 }
@@ -109,14 +109,14 @@ static void resize_one_vf_font (struct vf *a_vf, unsigned size)
 {
     unsigned i;
     if (size > (a_vf->num_chars)) {
-	size = MAX (size, a_vf->num_chars+256);
-	a_vf->ch_pkt = RENEW (a_vf->ch_pkt, size, unsigned char *);
-	a_vf->pkt_len = RENEW (a_vf->pkt_len, size, uint32_t);
-	for (i=a_vf->num_chars; i<size; i++) {
-	    (a_vf->ch_pkt)[i] = NULL;
-	    (a_vf->pkt_len)[i] = 0;
-	}
-	a_vf->num_chars = size;
+        size = MAX (size, a_vf->num_chars+256);
+        a_vf->ch_pkt = RENEW (a_vf->ch_pkt, size, unsigned char *);
+        a_vf->pkt_len = RENEW (a_vf->pkt_len, size, uint32_t);
+        for (i=a_vf->num_chars; i<size; i++) {
+            (a_vf->ch_pkt)[i] = NULL;
+            (a_vf->pkt_len)[i] = 0;
+        }
+        a_vf->num_chars = size;
     }
 }
 
@@ -128,13 +128,13 @@ read_a_char_def(rust_input_handle_t vf_handle, int thisfont, uint32_t pkt_len, u
 
     /* Resize and initialize character arrays if necessary */
     if (ch >= vf_fonts[thisfont].num_chars)
-	resize_one_vf_font (vf_fonts + thisfont, ch + 1);
+        resize_one_vf_font (vf_fonts + thisfont, ch + 1);
 
     if (pkt_len > 0) {
-	pkt = NEW (pkt_len, unsigned char);
-	if (ttstub_input_read (vf_handle, pkt, pkt_len) != pkt_len)
-	    _tt_abort("VF file ended prematurely.");
-	vf_fonts[thisfont].ch_pkt[ch] = pkt;
+        pkt = NEW (pkt_len, unsigned char);
+        if (ttstub_input_read (vf_handle, pkt, pkt_len) != pkt_len)
+            _tt_abort("VF file ended prematurely.");
+        vf_fonts[thisfont].ch_pkt[ch] = pkt;
     }
 
     vf_fonts[thisfont].pkt_len[ch] = pkt_len;
@@ -148,10 +148,10 @@ read_a_font_def(rust_input_handle_t vf_handle, int32_t font_id, int thisfont)
     int dir_length, name_length;
 
     if (vf_fonts[thisfont].num_dev_fonts >= vf_fonts[thisfont].max_dev_fonts) {
-	vf_fonts[thisfont].max_dev_fonts += VF_ALLOC_SIZE;
-	vf_fonts[thisfont].dev_fonts = RENEW (vf_fonts[thisfont].dev_fonts,
-					      vf_fonts[thisfont].max_dev_fonts,
-					      struct font_def);
+        vf_fonts[thisfont].max_dev_fonts += VF_ALLOC_SIZE;
+        vf_fonts[thisfont].dev_fonts = RENEW (vf_fonts[thisfont].dev_fonts,
+                                              vf_fonts[thisfont].max_dev_fonts,
+                                              struct font_def);
     }
 
     dev_font = vf_fonts[thisfont].dev_fonts + vf_fonts[thisfont].num_dev_fonts;
@@ -164,11 +164,11 @@ read_a_font_def(rust_input_handle_t vf_handle, int32_t font_id, int thisfont)
 
     dev_font->directory = NEW (dir_length+1, char);
     if (ttstub_input_read (vf_handle, dev_font->directory, dir_length) != dir_length)
-	_tt_abort("directory read failed");
+        _tt_abort("directory read failed");
 
     dev_font->name = NEW (name_length+1, char);
     if (ttstub_input_read (vf_handle, dev_font->name, name_length) != name_length)
-	_tt_abort("directory read failed");
+        _tt_abort("directory read failed");
 
     dev_font->directory[dir_length] = 0;
     dev_font->name[name_length] = 0;
@@ -176,7 +176,7 @@ read_a_font_def(rust_input_handle_t vf_handle, int32_t font_id, int thisfont)
 
     dev_font->tfm_id = tfm_open (dev_font->name, 1); /* must exist */
     dev_font->dev_id = dvi_locate_font (dev_font->name,
-					sqxfw (vf_fonts[thisfont].ptsize, dev_font->size));
+                                        sqxfw (vf_fonts[thisfont].ptsize, dev_font->size));
 }
 
 
@@ -187,45 +187,45 @@ process_vf_file (rust_input_handle_t vf_handle, int thisfont)
     int32_t font_id;
 
     while (!eof) {
-	code = tt_get_unsigned_byte (vf_handle);
+        code = tt_get_unsigned_byte (vf_handle);
 
-	switch (code) {
-	case FNT_DEF1: case FNT_DEF2: case FNT_DEF3: case FNT_DEF4:
-	    font_id = tt_get_unsigned_num (vf_handle, code - FNT_DEF1);
-	    read_a_font_def (vf_handle, font_id, thisfont);
-	    break;
+        switch (code) {
+        case FNT_DEF1: case FNT_DEF2: case FNT_DEF3: case FNT_DEF4:
+            font_id = tt_get_unsigned_num (vf_handle, code - FNT_DEF1);
+            read_a_font_def (vf_handle, font_id, thisfont);
+            break;
 
-	default:
-	    if (code < 242) {
-		/* For a short packet, code is the pkt_len */
-		uint32_t ch = tt_get_unsigned_byte (vf_handle);
-		/* Skip over TFM width since we already know it */
-		tt_skip_bytes (3, vf_handle);
-		read_a_char_def (vf_handle, thisfont, code, ch);
-		break;
-	    }
+        default:
+            if (code < 242) {
+                /* For a short packet, code is the pkt_len */
+                uint32_t ch = tt_get_unsigned_byte (vf_handle);
+                /* Skip over TFM width since we already know it */
+                tt_skip_bytes (3, vf_handle);
+                read_a_char_def (vf_handle, thisfont, code, ch);
+                break;
+            }
 
-	    if (code == 242) {
-		uint32_t pkt_len = tt_get_positive_quad (vf_handle, "VF", "pkt_len");
-		uint32_t ch = tt_get_unsigned_quad (vf_handle);
-		/* Skip over TFM width since we already know it */
-		tt_skip_bytes (4, vf_handle);
-		if (ch < 0x1000000U)
-		    read_a_char_def (vf_handle, thisfont, pkt_len, ch);
-		else {
-		    fprintf (stderr, "char=%u\n", ch);
-		    _tt_abort("Long character (>24 bits) in VF file.\nI can't handle long characters!\n");
-		}
-		break;
-	    }
-	    if (code == POST) {
-		eof = 1;
-		break;
-	    }
-	    fprintf (stderr, "Quitting on code=%d\n", code);
-	    eof = 1;
-	    break;
-	}
+            if (code == 242) {
+                uint32_t pkt_len = tt_get_positive_quad (vf_handle, "VF", "pkt_len");
+                uint32_t ch = tt_get_unsigned_quad (vf_handle);
+                /* Skip over TFM width since we already know it */
+                tt_skip_bytes (4, vf_handle);
+                if (ch < 0x1000000U)
+                    read_a_char_def (vf_handle, thisfont, pkt_len, ch);
+                else {
+                    fprintf (stderr, "char=%u\n", ch);
+                    _tt_abort("Long character (>24 bits) in VF file.\nI can't handle long characters!\n");
+                }
+                break;
+            }
+            if (code == POST) {
+                eof = 1;
+                break;
+            }
+            fprintf (stderr, "Quitting on code=%d\n", code);
+            eof = 1;
+            break;
+        }
     }
 }
 
@@ -245,26 +245,26 @@ int vf_locate_font (const char *tex_name, spt_t ptsize)
 
     /* Has this name and ptsize already been loaded as a VF? */
     for (i = 0; i < num_vf_fonts; i++) {
-	if (!strcmp (vf_fonts[i].tex_name, tex_name) && vf_fonts[i].ptsize == ptsize)
-	    break;
+        if (!strcmp (vf_fonts[i].tex_name, tex_name) && vf_fonts[i].ptsize == ptsize)
+            break;
     }
 
     if (i != num_vf_fonts)
-	return i;
+        return i;
 
     vf_handle = ttstub_input_open (tex_name, kpse_vf_format, 0);
 
     if (vf_handle == NULL)
-	vf_handle = ttstub_input_open (tex_name, kpse_ovf_format, 0);
+        vf_handle = ttstub_input_open (tex_name, kpse_ovf_format, 0);
 
     if (vf_handle == NULL)
-	return -1;
+        return -1;
 
     if (verbose == 1)
-	fprintf (stderr, "(VF:%s", tex_name);
+        fprintf (stderr, "(VF:%s", tex_name);
 
     if (num_vf_fonts >= max_vf_fonts)
-	resize_vf_fonts (max_vf_fonts + VF_ALLOC_SIZE);
+        resize_vf_fonts (max_vf_fonts + VF_ALLOC_SIZE);
 
     thisfont = num_vf_fonts++;
 
@@ -280,7 +280,7 @@ int vf_locate_font (const char *tex_name, spt_t ptsize)
     process_vf_file (vf_handle, thisfont);
 
     if (verbose)
-	fprintf (stderr, ")");
+        fprintf (stderr, ")");
 
     ttstub_input_close (vf_handle);
     return thisfont;
@@ -292,9 +292,9 @@ static int unsigned_byte (unsigned char **start, unsigned char *end)
 {
     int byte = 0;
     if (*start < end)
-	byte = next_byte();
+        byte = next_byte();
     else
-	_tt_abort("Premature end of DVI byte stream in VF font\n");
+        _tt_abort("Premature end of DVI byte stream in VF font\n");
     return byte;
 }
 
@@ -303,17 +303,17 @@ static int32_t get_pkt_signed_num (unsigned char **start, unsigned char *end,
 {
     int32_t val = 0;
     if (end-*start > num) {
-	val = next_byte();
-	if (val > 0x7f)
-	    val -= 0x100;
-	switch (num) {
-	case 3: val = (val << 8) | next_byte();
-	case 2: val = (val << 8) | next_byte();
-	case 1: val = (val << 8) | next_byte();
-	default: break;
-	}
+        val = next_byte();
+        if (val > 0x7f)
+            val -= 0x100;
+        switch (num) {
+        case 3: val = (val << 8) | next_byte();
+        case 2: val = (val << 8) | next_byte();
+        case 1: val = (val << 8) | next_byte();
+        default: break;
+        }
     } else
-	_tt_abort("Premature end of DVI byte stream in VF font\n");
+        _tt_abort("Premature end of DVI byte stream in VF font\n");
     return val;
 }
 
@@ -322,17 +322,17 @@ static int32_t get_pkt_unsigned_num (unsigned char **start, unsigned char *end,
 {
     int32_t val = 0;
     if (end-*start > num) {
-	val = next_byte();
-	switch (num) {
-	case 3: if (val > 0x7f)
-		val -= 0x100;
+        val = next_byte();
+        switch (num) {
+        case 3: if (val > 0x7f)
+                val -= 0x100;
             val = (val << 8) | next_byte();
-	case 2: val = (val << 8) | next_byte();
-	case 1: val = (val << 8) | next_byte();
-	default: break;
-	}
+        case 2: val = (val << 8) | next_byte();
+        case 1: val = (val << 8) | next_byte();
+        default: break;
+        }
     } else
-	_tt_abort("Premature end of DVI byte stream in VF font\n");
+        _tt_abort("Premature end of DVI byte stream in VF font\n");
     return val;
 }
 
@@ -355,14 +355,14 @@ static void vf_fnt (int32_t font_id, int vf_font)
 {
     int i;
     for (i=0; i<vf_fonts[vf_font].num_dev_fonts; i++) {
-	if (font_id == ((vf_fonts[vf_font].dev_fonts)[i]).font_id) {
-	    break;
-	}
+        if (font_id == ((vf_fonts[vf_font].dev_fonts)[i]).font_id) {
+            break;
+        }
     }
     if (i < vf_fonts[vf_font].num_dev_fonts) { /* Font was found */
-	dvi_set_font ((vf_fonts[vf_font].dev_fonts[i]).dev_id);
+        dvi_set_font ((vf_fonts[vf_font].dev_fonts[i]).dev_id);
     } else {
-	fprintf (stderr, "Font_id: %d not found in VF\n", font_id);
+        fprintf (stderr, "Font_id: %d not found in VF\n", font_id);
     }
 }
 
@@ -370,26 +370,26 @@ static void vf_fnt (int32_t font_id, int vf_font)
 static void vf_xxx (int32_t len, unsigned char **start, unsigned char *end)
 {
     if (*start <= end - len) {
-	unsigned char *buffer = NEW(len+1, unsigned char);
-	memcpy(buffer, *start, len);
-	buffer[len] = '\0';
-	{
-	    unsigned char *p = buffer;
+        unsigned char *buffer = NEW(len+1, unsigned char);
+        memcpy(buffer, *start, len);
+        buffer[len] = '\0';
+        {
+            unsigned char *p = buffer;
 
-	    while (p < buffer+len && *p == ' ') p++;
-	    /*
-	     * Warning message from virtual font.
-	     */
-	    if (!memcmp((char *)p, "Warning:", 8)) {
-		if (verbose)
-		    dpx_warning("VF:%s", p+8);
-	    } else {
-		dvi_do_special(buffer, len);
-	    }
-	}
-	free(buffer);
+            while (p < buffer+len && *p == ' ') p++;
+            /*
+             * Warning message from virtual font.
+             */
+            if (!memcmp((char *)p, "Warning:", 8)) {
+                if (verbose)
+                    dpx_warning("VF:%s", p+8);
+            } else {
+                dvi_do_special(buffer, len);
+            }
+        }
+        free(buffer);
     } else {
-	_tt_abort("Premature end of DVI byte stream in VF font.");
+        _tt_abort("Premature end of DVI byte stream in VF font.");
     }
 
     *start += len;
@@ -403,114 +403,114 @@ void vf_set_char(int32_t ch, int vf_font)
     spt_t ptsize;
     int default_font = -1;
     if (vf_font < num_vf_fonts) {
-	/* Initialize to the first font or -1 if undefined */
-	ptsize = vf_fonts[vf_font].ptsize;
-	if (vf_fonts[vf_font].num_dev_fonts > 0)
-	    default_font = ((vf_fonts[vf_font].dev_fonts)[0]).dev_id;
-	dvi_vf_init (default_font);
-	if (ch >= vf_fonts[vf_font].num_chars ||
-	    !(start = (vf_fonts[vf_font].ch_pkt)[ch])) {
-	    fprintf (stderr, "\nchar=0x%x(%d)\n", ch, ch);
-	    fprintf (stderr, "Tried to set a nonexistent character in a virtual font");
-	    start = end = NULL;
-	} else {
-	    end = start + (vf_fonts[vf_font].pkt_len)[ch];
-	}
-	while (start && start < end) {
-	    opcode = *(start++);
+        /* Initialize to the first font or -1 if undefined */
+        ptsize = vf_fonts[vf_font].ptsize;
+        if (vf_fonts[vf_font].num_dev_fonts > 0)
+            default_font = ((vf_fonts[vf_font].dev_fonts)[0]).dev_id;
+        dvi_vf_init (default_font);
+        if (ch >= vf_fonts[vf_font].num_chars ||
+            !(start = (vf_fonts[vf_font].ch_pkt)[ch])) {
+            fprintf (stderr, "\nchar=0x%x(%d)\n", ch, ch);
+            fprintf (stderr, "Tried to set a nonexistent character in a virtual font");
+            start = end = NULL;
+        } else {
+            end = start + (vf_fonts[vf_font].pkt_len)[ch];
+        }
+        while (start && start < end) {
+            opcode = *(start++);
 #ifdef DEBUG
-	    fprintf (stderr, "VF opcode: %d", opcode);
-	    if (isprint (opcode)) fprintf (stderr, " (\'%c\')\n", opcode);
-	    else fprintf (stderr, "\n");
+            fprintf (stderr, "VF opcode: %d", opcode);
+            if (isprint (opcode)) fprintf (stderr, " (\'%c\')\n", opcode);
+            else fprintf (stderr, "\n");
 #endif
-	    switch (opcode)
-	    {
-	    case SET1: case SET2: case SET3:
-		dvi_set (get_pkt_unsigned_num (&start, end, opcode-SET1));
-		break;
-	    case SET4:
-		_tt_abort("Multibyte (>24 bits) character in VF packet.\nI can't handle this!");
-		break;
-	    case SET_RULE:
-		vf_setrule(&start, end, ptsize);
-		break;
-	    case PUT1: case PUT2: case PUT3:
-		dvi_put (get_pkt_unsigned_num (&start, end, opcode-PUT1));
-		break;
-	    case PUT4:
-		_tt_abort("Multibyte (>24 bits) character in VF packet.\nI can't handle this!");
-		break;
-	    case PUT_RULE:
-		vf_putrule(&start, end, ptsize);
-		break;
-	    case NOP:
-		break;
-	    case PUSH:
-		dvi_push();
-		break;
-	    case POP:
-		dvi_pop();
-		break;
-	    case RIGHT1: case RIGHT2: case RIGHT3: case RIGHT4:
-		dvi_right (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-RIGHT1)));
-		break;
-	    case W0:
-		dvi_w0();
-		break;
-	    case W1: case W2: case W3: case W4:
-		dvi_w (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-W1)));
-		break;
-	    case X0:
-		dvi_x0();
-		break;
-	    case X1: case X2: case X3: case X4:
-		dvi_x (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-X1)));
-		break;
-	    case DOWN1: case DOWN2: case DOWN3: case DOWN4:
-		dvi_down (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-DOWN1)));
-		break;
-	    case Y0:
-		dvi_y0();
-		break;
-	    case Y1: case Y2: case Y3: case Y4:
-		dvi_y (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-Y1)));
-		break;
-	    case Z0:
-		dvi_z0();
-		break;
-	    case Z1: case Z2: case Z3: case Z4:
-		dvi_z (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-Z1)));
-		break;
-	    case FNT1: case FNT2: case FNT3: case FNT4:
-		vf_fnt (get_pkt_signed_num (&start, end, opcode-FNT1), vf_font);
-		break;
-	    case XXX1: case XXX2: case XXX3: case XXX4:
-	    {
-		int32_t len = get_pkt_unsigned_num (&start, end, opcode-XXX1);
-		if (len < 0)
-		    dpx_warning("VF: Special with %d bytes???", len);
-		else
-		    vf_xxx (len, &start, end);
-	    }
-	    break;
-	    case PTEXDIR:
-		dvi_dirchg (unsigned_byte (&start, end));
-		break;
-	    default:
-		if (opcode <= SET_CHAR_127) {
-		    dvi_set (opcode);
-		} else if (opcode >= FNT_NUM_0 && opcode <= FNT_NUM_63) {
-		    vf_fnt (opcode - FNT_NUM_0, vf_font);
-		} else {
-		    fprintf (stderr, "Unexpected opcode: %d\n", opcode);
-		    _tt_abort("Unexpected opcode in vf file\n");
-		}
-	    }
-	}
-	dvi_vf_finish();
+            switch (opcode)
+            {
+            case SET1: case SET2: case SET3:
+                dvi_set (get_pkt_unsigned_num (&start, end, opcode-SET1));
+                break;
+            case SET4:
+                _tt_abort("Multibyte (>24 bits) character in VF packet.\nI can't handle this!");
+                break;
+            case SET_RULE:
+                vf_setrule(&start, end, ptsize);
+                break;
+            case PUT1: case PUT2: case PUT3:
+                dvi_put (get_pkt_unsigned_num (&start, end, opcode-PUT1));
+                break;
+            case PUT4:
+                _tt_abort("Multibyte (>24 bits) character in VF packet.\nI can't handle this!");
+                break;
+            case PUT_RULE:
+                vf_putrule(&start, end, ptsize);
+                break;
+            case NOP:
+                break;
+            case PUSH:
+                dvi_push();
+                break;
+            case POP:
+                dvi_pop();
+                break;
+            case RIGHT1: case RIGHT2: case RIGHT3: case RIGHT4:
+                dvi_right (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-RIGHT1)));
+                break;
+            case W0:
+                dvi_w0();
+                break;
+            case W1: case W2: case W3: case W4:
+                dvi_w (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-W1)));
+                break;
+            case X0:
+                dvi_x0();
+                break;
+            case X1: case X2: case X3: case X4:
+                dvi_x (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-X1)));
+                break;
+            case DOWN1: case DOWN2: case DOWN3: case DOWN4:
+                dvi_down (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-DOWN1)));
+                break;
+            case Y0:
+                dvi_y0();
+                break;
+            case Y1: case Y2: case Y3: case Y4:
+                dvi_y (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-Y1)));
+                break;
+            case Z0:
+                dvi_z0();
+                break;
+            case Z1: case Z2: case Z3: case Z4:
+                dvi_z (sqxfw (ptsize, get_pkt_signed_num (&start, end, opcode-Z1)));
+                break;
+            case FNT1: case FNT2: case FNT3: case FNT4:
+                vf_fnt (get_pkt_signed_num (&start, end, opcode-FNT1), vf_font);
+                break;
+            case XXX1: case XXX2: case XXX3: case XXX4:
+            {
+                int32_t len = get_pkt_unsigned_num (&start, end, opcode-XXX1);
+                if (len < 0)
+                    dpx_warning("VF: Special with %d bytes???", len);
+                else
+                    vf_xxx (len, &start, end);
+            }
+            break;
+            case PTEXDIR:
+                dvi_dirchg (unsigned_byte (&start, end));
+                break;
+            default:
+                if (opcode <= SET_CHAR_127) {
+                    dvi_set (opcode);
+                } else if (opcode >= FNT_NUM_0 && opcode <= FNT_NUM_63) {
+                    vf_fnt (opcode - FNT_NUM_0, vf_font);
+                } else {
+                    fprintf (stderr, "Unexpected opcode: %d\n", opcode);
+                    _tt_abort("Unexpected opcode in vf file\n");
+                }
+            }
+        }
+        dvi_vf_finish();
     } else {
-	fprintf (stderr, "vf_set_char: font: %d", vf_font);
-	_tt_abort("Font not loaded\n");
+        fprintf (stderr, "vf_set_char: font: %d", vf_font);
+        _tt_abort("Font not loaded\n");
     }
     return;
 }
@@ -522,28 +522,28 @@ void vf_close_all_fonts(void)
     int j;
     struct font_def *one_font;
     for (i=0; i<num_vf_fonts; i++) {
-	/* Release the packet for each character */
-	if (vf_fonts[i].ch_pkt) {
-	    for (j=0; j<vf_fonts[i].num_chars; j++) {
-		if ((vf_fonts[i].ch_pkt)[j] != NULL)
-		    free ((vf_fonts[i].ch_pkt)[j]);
-	    }
-	    free (vf_fonts[i].ch_pkt);
-	}
-	if (vf_fonts[i].pkt_len)
-	    free (vf_fonts[i].pkt_len);
-	if (vf_fonts[i].tex_name)
-	    free (vf_fonts[i].tex_name);
-	/* Release each font record */
-	for (j=0; j<vf_fonts[i].num_dev_fonts; j++) {
-	    one_font = &(vf_fonts[i].dev_fonts)[j];
-	    free (one_font -> directory);
-	    free (one_font -> name);
-	}
-	if (vf_fonts[i].dev_fonts != NULL)
-	    free (vf_fonts[i].dev_fonts);
+        /* Release the packet for each character */
+        if (vf_fonts[i].ch_pkt) {
+            for (j=0; j<vf_fonts[i].num_chars; j++) {
+                if ((vf_fonts[i].ch_pkt)[j] != NULL)
+                    free ((vf_fonts[i].ch_pkt)[j]);
+            }
+            free (vf_fonts[i].ch_pkt);
+        }
+        if (vf_fonts[i].pkt_len)
+            free (vf_fonts[i].pkt_len);
+        if (vf_fonts[i].tex_name)
+            free (vf_fonts[i].tex_name);
+        /* Release each font record */
+        for (j=0; j<vf_fonts[i].num_dev_fonts; j++) {
+            one_font = &(vf_fonts[i].dev_fonts)[j];
+            free (one_font -> directory);
+            free (one_font -> name);
+        }
+        if (vf_fonts[i].dev_fonts != NULL)
+            free (vf_fonts[i].dev_fonts);
     }
     if (vf_fonts != NULL)
-	free (vf_fonts);
+        free (vf_fonts);
     return;
 }

--- a/tectonic/dpx-vf.h
+++ b/tectonic/dpx-vf.h
@@ -2,19 +2,19 @@
 
     Copyright (C) 2002-2016 by Jin-Hwan Cho and Shunsaku Hirata,
     the dvipdfmx project team.
-    
+
     Copyright (C) 1998, 1999 by Mark A. Wicks <mwicks@kettering.edu>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.

--- a/tectonic/dpx-xftello.c
+++ b/tectonic/dpx-xftello.c
@@ -32,6 +32,6 @@ xftello (FILE *f, const_string filename)
 	fprintf(stderr, "ftello failed\n");
 	exit(1);
     }
-    
+
     return where;
 }

--- a/tectonic/dpx-xftello.c
+++ b/tectonic/dpx-xftello.c
@@ -29,8 +29,8 @@ xftello (FILE *f, const_string filename)
     off_t where = ftello (f);
 
     if (where < 0) {
-	fprintf(stderr, "ftello failed\n");
-	exit(1);
+        fprintf(stderr, "ftello failed\n");
+        exit(1);
     }
 
     return where;

--- a/tectonic/engine-interface.c
+++ b/tectonic/engine-interface.c
@@ -14,11 +14,11 @@ int
 tt_set_int_variable (char *var_name, int value)
 {
     if (STREQ (var_name, "halt_on_error_p"))
-	halt_on_error_p = value;
+        halt_on_error_p = value;
     else if (STREQ (var_name, "in_initex_mode"))
-	in_initex_mode = (value != 0);
+        in_initex_mode = (value != 0);
     else
-	return 1; /* Uh oh: unrecognized variable */
+        return 1; /* Uh oh: unrecognized variable */
 
     return 0; /* success */
 }
@@ -28,17 +28,17 @@ int
 tt_set_string_variable (char *var_name, char *value)
 {
     if (STREQ (var_name, "output_comment")) {
-	size_t len = strlen (value);
+        size_t len = strlen (value);
 
-	if (len < 256) {
-	    output_comment = xstrdup (value);
-	} else {
-	    output_comment = xmalloc (256);
-	    strncpy (output_comment, value, 255);
-	    output_comment[255] = '\0';
-	}
+        if (len < 256) {
+            output_comment = xstrdup (value);
+        } else {
+            output_comment = xmalloc (256);
+            strncpy (output_comment, value, 255);
+            output_comment[255] = '\0';
+        }
     } else
-	return 1; /* Uh oh: unrecognized variable */
+        return 1; /* Uh oh: unrecognized variable */
 
     return 0; /* success */
 }

--- a/tectonic/errors.c
+++ b/tectonic/errors.c
@@ -28,9 +28,9 @@ pre_error_message (void)
         selector--;
 
     if (file_line_error_style_p)
-	print_file_line();
+        print_file_line();
     else
-	print_nl(S(__/*"! "*/));
+        print_nl(S(__/*"! "*/));
 }
 
 
@@ -39,10 +39,10 @@ static void
 post_error_message(int need_to_print_it)
 {
     if (interaction == ERROR_STOP_MODE)
-	interaction = SCROLL_MODE;
+        interaction = SCROLL_MODE;
 
     if (need_to_print_it && log_opened)
-	error();
+        error();
 
     history = HISTORY_FATAL_ERROR;
     close_files_and_terminate();
@@ -64,7 +64,7 @@ error(void)
     if (halt_on_error_p) {
         history = HISTORY_FATAL_ERROR;
         post_error_message(0);
-	_tt_abort("halted on potentially-recoverable error as specified");
+        _tt_abort("halted on potentially-recoverable error as specified");
     }
 
     /* This used to be where there was a bunch of code if "interaction ==
@@ -76,7 +76,7 @@ error(void)
         print_nl(S(_That_makes_100_errors__plea/*se try again.)*/));
         history = HISTORY_FATAL_ERROR;
         post_error_message(0);
-	_tt_abort("halted after 100 potentially-recoverable errors");
+        _tt_abort("halted after 100 potentially-recoverable errors");
     }
 
     if (interaction > BATCH_MODE)
@@ -136,18 +136,18 @@ confusion(str_number s)
     pre_error_message();
 
     if (history < HISTORY_ERROR_ISSUED) {
-	print(S(This_can_t_happen__));
+        print(S(This_can_t_happen__));
         print(s);
         print_char(41 /*")" */ );
 
-	help_ptr = 1;
-	help_line[0] = S(I_m_broken__Please_show_this/* to someone who can fix can fix*/);
+        help_ptr = 1;
+        help_line[0] = S(I_m_broken__Please_show_this/* to someone who can fix can fix*/);
     } else {
-	print(S(I_can_t_go_on_meeting_you_li/*ke this*/));
+        print(S(I_can_t_go_on_meeting_you_li/*ke this*/));
 
-	help_ptr = 2;
-	help_line[1] = S(One_of_your_faux_pas_seems_t/*o have wounded me deeply...*/);
-	help_line[0] = S(in_fact__I_m_barely_consciou/*s. Please fix it and try again.*/);
+        help_ptr = 2;
+        help_line[1] = S(One_of_your_faux_pas_seems_t/*o have wounded me deeply...*/);
+        help_line[0] = S(in_fact__I_m_barely_consciou/*s. Please fix it and try again.*/);
     }
 
     post_error_message(1);

--- a/tectonic/inimisc.c
+++ b/tectonic/inimisc.c
@@ -854,36 +854,36 @@ prune_page_top(int32_t p, boolean s)
         case HLIST_NODE:
         case VLIST_NODE:
         case RULE_NODE:
-	    q = new_skip_param(GLUE_PAR__split_top_skip);
-	    mem[prev_p].hh.v.RH = q;
-	    mem[q].hh.v.RH = p;
-	    if (mem[temp_ptr + 1].cint > mem[p + 3].cint)
-		mem[temp_ptr + 1].cint = mem[temp_ptr + 1].cint - mem[p + 3].cint;
-	    else
-		mem[temp_ptr + 1].cint = 0;
-	    p = MIN_HALFWORD;
+            q = new_skip_param(GLUE_PAR__split_top_skip);
+            mem[prev_p].hh.v.RH = q;
+            mem[q].hh.v.RH = p;
+            if (mem[temp_ptr + 1].cint > mem[p + 3].cint)
+                mem[temp_ptr + 1].cint = mem[temp_ptr + 1].cint - mem[p + 3].cint;
+            else
+                mem[temp_ptr + 1].cint = 0;
+            p = MIN_HALFWORD;
             break;
         case WHATSIT_NODE:
         case MARK_NODE:
         case INS_NODE:
-	    prev_p = p;
-	    p = mem[prev_p].hh.v.RH;
+            prev_p = p;
+            p = mem[prev_p].hh.v.RH;
             break;
         case GLUE_NODE:
         case KERN_NODE:
         case PENALTY_NODE:
-	    q = p;
-	    p = mem[q].hh.v.RH;
-	    mem[q].hh.v.RH = MIN_HALFWORD;
-	    mem[prev_p].hh.v.RH = p;
-	    if (s) {
-		if (disc_ptr[VSPLIT_CODE] == MIN_HALFWORD)
-		    disc_ptr[VSPLIT_CODE] = q;
-		else
-		    mem[r].hh.v.RH = q;
-		r = q;
-	    } else
-		flush_node_list(q);
+            q = p;
+            p = mem[q].hh.v.RH;
+            mem[q].hh.v.RH = MIN_HALFWORD;
+            mem[prev_p].hh.v.RH = p;
+            if (s) {
+                if (disc_ptr[VSPLIT_CODE] == MIN_HALFWORD)
+                    disc_ptr[VSPLIT_CODE] = q;
+                else
+                    mem[r].hh.v.RH = q;
+                r = q;
+            } else
+                flush_node_list(q);
             break;
         default:
             confusion(S(pruning));
@@ -918,9 +918,9 @@ do_marks(small_number a, small_number l, int32_t q)
             }
         }
 
-	if (mem[q].hh.u.B1 == 0) {
-	    free_node(q, INDEX_NODE_SIZE);
-	    q = MIN_HALFWORD;
+        if (mem[q].hh.u.B1 == 0) {
+            free_node(q, INDEX_NODE_SIZE);
+            q = MIN_HALFWORD;
         }
     } else {
         switch (a) { /*1614: */

--- a/tectonic/io.c
+++ b/tectonic/io.c
@@ -17,7 +17,7 @@
 
 /* Define some variables. */
 /* For "file:line:error" style error messages. */
-string fullnameoffile;          /* Defaults to NULL.  */
+string fullnameoffile; /* Defaults to NULL.  */
 
 
 rust_input_handle_t
@@ -49,7 +49,7 @@ tt_open_input (int filefmt)
    code is based on ConvertUTF.[ch] sample code
    published by the Unicode consortium */
 const uint32_t
-offsetsFromUTF8[6] =    {
+offsetsFromUTF8[6] = {
     0x00000000UL,
     0x00003080UL,
     0x000E2080UL,
@@ -79,8 +79,8 @@ const int halfShift                 = 10;
 const uint32_t halfBase             = 0x0010000UL;
 const uint32_t halfMask             = 0x3FFUL;
 const uint32_t kSurrogateHighStart  = 0xD800UL;
-const uint32_t kSurrogateHighEnd        = 0xDBFFUL;
-const uint32_t kSurrogateLowStart       = 0xDC00UL;
+const uint32_t kSurrogateHighEnd    = 0xDBFFUL;
+const uint32_t kSurrogateLowStart   = 0xDC00UL;
 const uint32_t kSurrogateLowEnd     = 0xDFFFUL;
 const uint32_t byteMask             = 0x000000BFUL;
 const uint32_t byteMark             = 0x00000080UL;

--- a/tectonic/io.c
+++ b/tectonic/io.c
@@ -33,7 +33,7 @@ tt_open_input (int filefmt)
     fname = name_of_file + 1;
     handle = ttstub_input_open (fname, (kpse_file_format_type) filefmt, 0);
     if (handle == NULL)
-	return NULL;
+        return NULL;
 
     fullnameoffile = xstrdup(fname);
     name_length = strlen(fname);
@@ -136,7 +136,7 @@ u_open_in(UFILE **f, integer filefmt, const_string fopen_mode, integer mode, int
 
     handle = tt_open_input (filefmt);
     if (handle == NULL)
-	return 0;
+        return 0;
 
     *f = (UFILE *) xmalloc(sizeof(UFILE));
     (*f)->encodingMode = 0;
@@ -146,30 +146,30 @@ u_open_in(UFILE **f, integer filefmt, const_string fopen_mode, integer mode, int
     (*f)->handle = handle;
 
     if (mode == AUTO) {
-	/* sniff encoding form */
-	B1 = ttstub_input_getc ((*f)->handle);
-	B2 = ttstub_input_getc ((*f)->handle);
+        /* sniff encoding form */
+        B1 = ttstub_input_getc ((*f)->handle);
+        B2 = ttstub_input_getc ((*f)->handle);
 
-	if (B1 == 0xfe && B2 == 0xff)
-	    mode = UTF16BE;
-	else if (B2 == 0xfe && B1 == 0xff)
-	    mode = UTF16LE;
-	else if (B1 == 0 && B2 != 0) {
-	    mode = UTF16BE;
-	    ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
-	} else if (B2 == 0 && B1 != 0) {
-	    mode = UTF16LE;
-	    ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
-	} else if (B1 == 0xEF && B2 == 0xBB) {
-	    int B3 = ttstub_input_getc((*f)->handle);
-	    if (B3 == 0xBF)
-		mode = UTF8;
-	}
+        if (B1 == 0xfe && B2 == 0xff)
+            mode = UTF16BE;
+        else if (B2 == 0xfe && B1 == 0xff)
+            mode = UTF16LE;
+        else if (B1 == 0 && B2 != 0) {
+            mode = UTF16BE;
+            ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
+        } else if (B2 == 0 && B1 != 0) {
+            mode = UTF16LE;
+            ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
+        } else if (B1 == 0xEF && B2 == 0xBB) {
+            int B3 = ttstub_input_getc((*f)->handle);
+            if (B3 == 0xBF)
+                mode = UTF8;
+        }
 
-	if (mode == AUTO) {
-	    ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
-	    mode = UTF8;
-	}
+        if (mode == AUTO) {
+            ttstub_input_seek ((*f)->handle, 0, SEEK_SET);
+            mode = UTF8;
+        }
     }
 
     set_input_file_encoding(*f, mode, encodingData);
@@ -209,7 +209,7 @@ apply_normalization(uint32_t* buf, int len, int norm)
             NATIVE_UTF32, NATIVE_UTF32 | (norm == 1 ? kForm_NFC : kForm_NFD),
             &*normPtr);
         if (status != kStatus_NoError)
-	    _tt_abort ("failed to create normalizer: error code = %d", (int)status);
+            _tt_abort ("failed to create normalizer: error code = %d", (int)status);
     }
 
     status = TECkit_ConvertBuffer(*normPtr, (Byte*)buf, len * sizeof(UInt32), &inUsed,
@@ -229,8 +229,8 @@ input_line(UFILE* f)
     int norm = get_input_normalization_state();
 
     if (f->handle == NULL)
-	/* NULL 'handle' means this: */
-	_tt_abort ("reads from synthetic \"terminal\" file #0 should never happen");
+        /* NULL 'handle' means this: */
+        _tt_abort ("reads from synthetic \"terminal\" file #0 should never happen");
 
     last = first;
 
@@ -360,13 +360,13 @@ void
 u_close(UFILE* f)
 {
     if (f == NULL || f->handle == NULL)
-	/* NULL handle is stdin/terminal file. Shouldn't happen but meh. */
-	return;
+        /* NULL handle is stdin/terminal file. Shouldn't happen but meh. */
+        return;
 
     ttstub_input_close (f->handle);
 
     if (f->encodingMode == ICUMAPPING && f->conversionData != NULL)
-	ucnv_close ((UConverter*) f->conversionData);
+        ucnv_close ((UConverter*) f->conversionData);
 
     free (f);
 }
@@ -390,7 +390,7 @@ get_uni_c(UFILE* f)
             if (rval != EOF) {
                 uint16_t extraBytes = bytesFromUTF8[rval];
                 switch (extraBytes) {
-		/* note: code falls through cases! */
+                /* note: code falls through cases! */
                 case 3:
                     c = ttstub_input_getc(f->handle);
                     if (c < 0x80 || c >= 0xC0)
@@ -415,7 +415,7 @@ get_uni_c(UFILE* f)
                 bad_utf8:
                     if (c != EOF)
                         ttstub_input_ungetc(f->handle, c);
-		case 5:
+                case 5:
                 case 4:
                     bad_utf8_warning();
                     return 0xFFFD; /* return without adjusting by offsetsFromUTF8 */
@@ -468,7 +468,7 @@ get_uni_c(UFILE* f)
             break;
 
         default:
-	    _tt_abort("internal error; file input mode=%d", f->encodingMode);
+            _tt_abort("internal error; file input mode=%d", f->encodingMode);
     }
 
     return rval;
@@ -536,7 +536,7 @@ open_or_close_in(void)
         pack_file_name(cur_name, cur_area, cur_ext);
 
         if (u_open_in(&read_file[n], kpse_tex_format, "rb", STATEINT(xetex_default_input_mode),
-		      STATEINT(xetex_default_input_encoding))) {
+                      STATEINT(xetex_default_input_encoding))) {
             make_utf16_name();
             name_in_progress = true;
             begin_name();

--- a/tectonic/output.c
+++ b/tectonic/output.c
@@ -15,25 +15,25 @@ print_ln(void)
 {
     switch (selector) {
     case SELECTOR_TERM_AND_LOG:
-	ttstub_output_putc(rust_stdout, '\n');
-	ttstub_output_putc(log_file, '\n');
-	term_offset = 0;
-	file_offset = 0;
+        ttstub_output_putc(rust_stdout, '\n');
+        ttstub_output_putc(log_file, '\n');
+        term_offset = 0;
+        file_offset = 0;
         break;
     case SELECTOR_LOG_ONLY:
-	ttstub_output_putc(log_file, '\n');
-	file_offset = 0;
+        ttstub_output_putc(log_file, '\n');
+        file_offset = 0;
         break;
     case SELECTOR_TERM_ONLY:
-	ttstub_output_putc(rust_stdout, '\n');
-	term_offset = 0;
+        ttstub_output_putc(rust_stdout, '\n');
+        term_offset = 0;
         break;
     case SELECTOR_NO_PRINT:
     case SELECTOR_PSEUDO:
     case SELECTOR_NEW_STRING:
         break;
     default:
-	ttstub_output_putc(write_file[selector], '\n');
+        ttstub_output_putc(write_file[selector], '\n');
         break;
     }
 }
@@ -44,34 +44,34 @@ print_raw_char(UTF16_code s, boolean incr_offset)
 {
     switch (selector) {
     case SELECTOR_TERM_AND_LOG:
-	ttstub_output_putc(rust_stdout, s);
-	ttstub_output_putc(log_file, s);
-	if (incr_offset) {
-	    term_offset++;
-	    file_offset++;
-	}
-	if (term_offset == max_print_line) {
-	    ttstub_output_putc(rust_stdout, '\n');
-	    term_offset = 0;
-	}
-	if (file_offset == max_print_line) {
-	    ttstub_output_putc(log_file, '\n');
-	    file_offset = 0;
+        ttstub_output_putc(rust_stdout, s);
+        ttstub_output_putc(log_file, s);
+        if (incr_offset) {
+            term_offset++;
+            file_offset++;
+        }
+        if (term_offset == max_print_line) {
+            ttstub_output_putc(rust_stdout, '\n');
+            term_offset = 0;
+        }
+        if (file_offset == max_print_line) {
+            ttstub_output_putc(log_file, '\n');
+            file_offset = 0;
         }
         break;
     case SELECTOR_LOG_ONLY:
-	ttstub_output_putc(log_file, s);
-	if (incr_offset)
-	    file_offset++;
-	if (file_offset == max_print_line)
-	    print_ln();
+        ttstub_output_putc(log_file, s);
+        if (incr_offset)
+            file_offset++;
+        if (file_offset == max_print_line)
+            print_ln();
         break;
     case SELECTOR_TERM_ONLY:
-	ttstub_output_putc(rust_stdout, s);
-	if (incr_offset)
-	    term_offset++;
-	if (term_offset == max_print_line)
-	    print_ln();
+        ttstub_output_putc(rust_stdout, s);
+        if (incr_offset)
+            term_offset++;
+        if (term_offset == max_print_line)
+            print_ln();
         break;
     case SELECTOR_NO_PRINT:
         break;
@@ -80,13 +80,13 @@ print_raw_char(UTF16_code s, boolean incr_offset)
             trick_buf[tally % error_line] = s;
         break;
     case SELECTOR_NEW_STRING:
-	if (pool_ptr < pool_size) {
-	    str_pool[pool_ptr] = s;
-	    pool_ptr++;
-	}
+        if (pool_ptr < pool_size) {
+            str_pool[pool_ptr] = s;
+            pool_ptr++;
+        }
         break;
     default:
-	ttstub_output_putc(write_file[selector], s);
+        ttstub_output_putc(write_file[selector], s);
         break;
     }
     tally++;
@@ -128,7 +128,7 @@ print_char(integer s)
             print_raw_char(63 /*"?" */ , true);
         } else {
             print_raw_char(s, true);
-	}
+        }
     } else if (s < 160 && !doing_special) {
         print_raw_char(94 /*"^" */ , true);
         print_raw_char(94 /*"^" */ , true);
@@ -227,7 +227,7 @@ print_esc(str_number s)
     integer c = INTPAR(escape_char) /*:251 */ ;
 
     if (c >= 0 && c <= BIGGEST_USV)
-	print_char(c);
+        print_char(c);
     print(s);
 }
 
@@ -468,20 +468,20 @@ print_native_word(int32_t p)
     integer for_end = mem[p + 4].qqqq.u.B2 - 1;
 
     for (i = 0; i <= for_end; i++) {
-	c = get_native_char(p, i);
-	if ((c >= 0xD800) && (c < 0xDC00)) {
-	    if (i < mem[p + 4].qqqq.u.B2 - 1) {
-		cc = get_native_char(p, i + 1);
-		if ((cc >= 0xDC00) && (cc < 0xE000)) {
-		    c = 0x10000 + (c - 0xD800) * 1024 + (cc - 0xDC00);
-		    print_char(c);
-		    i++;
-		} else
-		    print(46 /*"." */ );
-	    } else
-		print(46 /*"." */ );
-	} else
-	    print_char(c);
+        c = get_native_char(p, i);
+        if ((c >= 0xD800) && (c < 0xDC00)) {
+            if (i < mem[p + 4].qqqq.u.B2 - 1) {
+                cc = get_native_char(p, i + 1);
+                if ((cc >= 0xDC00) && (cc < 0xE000)) {
+                    c = 0x10000 + (c - 0xD800) * 1024 + (cc - 0xDC00);
+                    print_char(c);
+                    i++;
+                } else
+                    print(46 /*"." */ );
+            } else
+                print(46 /*"." */ );
+        } else
+            print_char(c);
     }
 }
 

--- a/tectonic/pdfimage.cpp
+++ b/tectonic/pdfimage.cpp
@@ -53,11 +53,11 @@ _rust_to_pdfdoc (rust_input_handle_t file)
 
     unsigned char *buf = new unsigned char[sz];
     if (buf == NULL)
-	return NULL;
+        return NULL;
 
     if (ttstub_input_read (file, buf, sz) != sz) {
-	delete[] buf;
-	return NULL;
+        delete[] buf;
+        return NULL;
     }
 
     /* XXX: are we leaking buf here? Depends on whether MemStream/PDFDoc take

--- a/tectonic/stubs.h
+++ b/tectonic/stubs.h
@@ -17,7 +17,7 @@ typedef enum
 {
     /* The values here are in order, but because we need to map the constants
      * in the Rust code, it's convenient to make them explicit here. */
-    
+
     kpse_gf_format = 0,
     kpse_pk_format = 1,
     kpse_any_glyph_format = 2,

--- a/tectonic/synctex.c
+++ b/tectonic/synctex.c
@@ -125,7 +125,7 @@ get_current_name (void)
      * don't want to have to deal with. */
 
     if (!fullnameoffile)
-	return xstrdup("");
+        return xstrdup("");
 
     return xstrdup(fullnameoffile);
 }

--- a/tectonic/texmfmp.c
+++ b/tectonic/texmfmp.c
@@ -36,7 +36,7 @@ static void
 checkpool_pointer (pool_pointer pool_ptr, size_t len)
 {
     if (pool_ptr + len >= pool_size)
-	_tt_abort ("string pool overflow [%i bytes]", (int) pool_size);
+        _tt_abort ("string pool overflow [%i bytes]", (int) pool_size);
 }
 
 
@@ -203,9 +203,9 @@ convertStringToHexString(const char *in, char *out, int lin)
     j = 0;
 
     for (i = 0; i < lin; i++) {
-	unsigned char c = (unsigned char) in[i];
-	out[j++] = hexchars[(c >> 4) & 0xF];
-	out[j++] = hexchars[c & 0xF];
+        unsigned char c = (unsigned char) in[i];
+        out[j++] = hexchars[(c >> 4) & 0xF];
+        out[j++] = hexchars[c & 0xF];
     }
     out[j] = '\0';
 }
@@ -222,13 +222,13 @@ void getmd5sum(str_number s, boolean file)
     xname = gettexstring (s);
 
     if (file)
-	ret = ttstub_get_file_md5 (xname, digest);
+        ret = ttstub_get_file_md5 (xname, digest);
     else
-	ret = ttstub_get_data_md5 (xname, strlen (xname), digest);
+        ret = ttstub_get_data_md5 (xname, strlen (xname), digest);
 
     xfree (xname);
     if (ret)
-	return;
+        return;
 
     if (pool_ptr + 2 * DIGEST_SIZE >= pool_size) {
         /* error by str_toks that calls str_room(1) */

--- a/tectonic/tidy_kpathutil.c
+++ b/tectonic/tidy_kpathutil.c
@@ -26,8 +26,8 @@ xcalloc (size_t nelem,  size_t elsize)
     void *new_mem = (void*)calloc(nelem ? nelem : 1, elsize ? elsize : 1);
 
     if (new_mem == NULL)
-	_tt_abort ("xcalloc request for %lu elements of size %lu failed",
-		   (unsigned long) nelem, (unsigned long) elsize);
+        _tt_abort ("xcalloc request for %lu elements of size %lu failed",
+                   (unsigned long) nelem, (unsigned long) elsize);
 
     return new_mem;
 }
@@ -39,7 +39,7 @@ xmalloc (size_t size)
     void *new_mem = (void *)malloc(size ? size : 1);
 
     if (new_mem == NULL)
-	_tt_abort ("xmalloc request for %lu bytes failed", (unsigned long) size);
+        _tt_abort ("xmalloc request for %lu bytes failed", (unsigned long) size);
 
     return new_mem;
 }
@@ -55,7 +55,7 @@ xrealloc (void *old_ptr, size_t size)
     } else {
         new_mem = realloc(old_ptr, size ? size : 1);
         if (new_mem == NULL)
-	    _tt_abort("xrealloc() to %lu bytes failed", (unsigned long) size);
+            _tt_abort("xrealloc() to %lu bytes failed", (unsigned long) size);
     }
 
     return new_mem;

--- a/tectonic/xetex0.c
+++ b/tectonic/xetex0.c
@@ -592,7 +592,7 @@ void print_font_and_char(integer p)
 
         if ((mem[p].hh.u.B0 > font_max))
             print_char(42 /*"*" */ );
-        else                    /*279: */
+        else /*279: */
             print_esc(hash[FONT_ID_BASE + mem[p].hh.u.B0].v.RH);
         print_char(32 /*" " */ );
         print(mem[p].hh.u.B1);
@@ -12544,7 +12544,7 @@ int32_t reverse(int32_t this_box, int32_t t, scaled * cur_g, double * cur_glue)
     n = MIN_HALFWORD;
     while (true) {
 
-        while (p != MIN_HALFWORD)        /*1511: */
+        while (p != MIN_HALFWORD) /*1511: */
         reswitch:
             if ((p >= hi_mem_min))
                 do {
@@ -12965,7 +12965,7 @@ void hlist_out(void)
 
     left_edge = cur_h;
     synctex_hlist(this_box);
-    while (p != MIN_HALFWORD)    /*642: */
+    while (p != MIN_HALFWORD) /*642: */
     reswitch:
         if ((p >= hi_mem_min)) {
             if (cur_h != dvi_h) {
@@ -19808,7 +19808,7 @@ found1:
                     mem[mem_top - 4].hh.v.RH = MIN_HALFWORD;
                 }
             }
-            if (hyphen_passed > 0)      /*949: */
+            if (hyphen_passed > 0) /*949: */
                 do {
                     r = get_node(SMALL_NODE_SIZE);
                     mem[r].hh.v.RH = mem[mem_top - 4].hh.v.RH;
@@ -20179,7 +20179,7 @@ int32_t vert_break(int32_t p, scaled h, scaled d)
 
         if (p == MIN_HALFWORD)
             pi = EJECT_PENALTY;
-        else                    /*1008: */
+        else /*1008: */
             switch (mem[p].hh.u.B0) {
             case 0:
             case 1:
@@ -25967,7 +25967,7 @@ reswitch:
                         mem[cur_list.tail].hh.v.RH = new_math(0, cur_chr);
                         cur_list.tail = mem[cur_list.tail].hh.v.RH;
                     }
-                } else          /*:1490 */
+                } else /*:1490 */
                     init_align();
                 break;
             case 239:

--- a/tectonic/xetex0.c
+++ b/tectonic/xetex0.c
@@ -11,7 +11,7 @@ write_to_dvi(integer a, integer b)
     integer n = b - a + 1;
 
     if (ttstub_output_write (dvi_file, (char *) &dvi_buf[a], n) != n)
-	_tt_abort ("failed to write data to XDV file");
+        _tt_abort ("failed to write data to XDV file");
 }
 
 static void
@@ -7602,7 +7602,7 @@ scan_something_internal(small_number level, boolean negative)
                     break;
 
                 case PDF_SHELL_ESCAPE_CODE:
-		    cur_val = 0; /* shellenabledp */
+                    cur_val = 0; /* shellenabledp */
                     break;
 
                 case ETEX_VERSION_CODE:
@@ -9835,7 +9835,7 @@ read_toks(integer n, int32_t r, int32_t j)
         cur_input.name = m + 1;
 
         if (read_open[m] == CLOSED) { /*503:*/
-	    _tt_abort ("terminal input forbidden");
+            _tt_abort ("terminal input forbidden");
         } else if (read_open[m] == JUST_OPEN) { /*504:*/
             if (input_line(read_file[m])) {
                 read_open[m] = NORMAL;
@@ -10670,7 +10670,7 @@ open_log_file(void)
 
     log_file = ttstub_output_open (name_of_file + 1, 0);
     if (log_file == NULL)
-	_tt_abort ("cannot open log file output \"%s\"", name_of_file + 1);
+        _tt_abort ("cannot open log file output \"%s\"", name_of_file + 1);
 
     texmf_log_name = make_name_string();
     selector = SELECTOR_LOG_ONLY;
@@ -10687,7 +10687,7 @@ open_log_file(void)
         l--;
 
     for (k = 1; k <= l; k++)
-	print(buffer[k]);
+        print(buffer[k]);
 
     print_ln();
     selector = old_setting + 2;
@@ -10706,8 +10706,8 @@ start_input(void)
     begin_file_reading();
 
     if (!u_open_in(&input_file[cur_input.index], kpse_tex_format, "rb",
-		  STATEINT(xetex_default_input_mode), STATEINT(xetex_default_input_encoding)))
-	_tt_abort ("failed to open input file \"%s\"", name_of_file + 1);
+                  STATEINT(xetex_default_input_mode), STATEINT(xetex_default_input_encoding)))
+        _tt_abort ("failed to open input file \"%s\"", name_of_file + 1);
 
     make_utf16_name();
     name_in_progress = true;
@@ -10715,7 +10715,7 @@ start_input(void)
     stop_at_space = false;
     k = 0;
     while (k < name_length16 && more_name(name_of_file16[k]))
-	k++;
+        k++;
     stop_at_space = true;
     end_name();
     name_in_progress = false;
@@ -10727,8 +10727,8 @@ start_input(void)
         temp_str = search_string(cur_input.name);
         if (temp_str > 0) {
             cur_input.name = temp_str;
-	    str_ptr--;
-	    pool_ptr = str_start[(str_ptr) - 65536L];
+            str_ptr--;
+            pool_ptr = str_start[(str_ptr) - 65536L];
         }
     }
 
@@ -10754,9 +10754,9 @@ start_input(void)
     input_line(input_file[cur_input.index]);
     cur_input.limit = last;
     if ((INTPAR(end_line_char) < 0) || (INTPAR(end_line_char) > 255))
-	cur_input.limit--;
+        cur_input.limit--;
     else
-	buffer[cur_input.limit] = INTPAR(end_line_char);
+        buffer[cur_input.limit] = INTPAR(end_line_char);
     first = cur_input.limit + 1;
     cur_input.loc = cur_input.start;
 }
@@ -11310,12 +11310,12 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
 
     tfm_file = tt_open_input (kpse_tfm_format);
     if (tfm_file == NULL) {
-	if (!quoted_filename) {
-	    g = load_native_font(u, nom, aire, s);
-	    if (g != FONT_BASE)
-		goto done;
-	}
-	goto bad_tfm;
+        if (!quoted_filename) {
+            g = load_native_font(u, nom, aire, s);
+            if (g != FONT_BASE)
+                goto done;
+        }
+        goto bad_tfm;
     }
 
     file_opened = true; /*:582*/
@@ -11325,11 +11325,11 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
      * used in this one place. */
 
 #define READFIFTEEN(x) do { \
-	x = ttstub_input_getc (tfm_file); \
-	if (x > 127 || x == EOF) \
-	    goto bad_tfm; \
-	x *= 256; \
-	x += ttstub_input_getc (tfm_file);\
+        x = ttstub_input_getc (tfm_file); \
+        if (x > 127 || x == EOF) \
+            goto bad_tfm; \
+        x *= 256; \
+        x += ttstub_input_getc (tfm_file);\
     } while (0)
 
     READFIFTEEN(lf);
@@ -11338,11 +11338,11 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
     READFIFTEEN(ec);
 
     if (bc > ec + 1 || ec > 255)
-	goto bad_tfm;
+        goto bad_tfm;
 
     if (bc > 255) {
-	bc = 1;
-	ec = 0;
+        bc = 1;
+        ec = 0;
     }
 
     READFIFTEEN(nw);
@@ -11355,16 +11355,16 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
     READFIFTEEN(np);
 
     if (lf != 6 + lh + (ec - bc + 1) + nw + nh + nd + ni + nl + nk + ne + np)
-	goto bad_tfm;
+        goto bad_tfm;
     if (nw == 0 || nh == 0 || nd == 0 || ni == 0)
-	goto bad_tfm;
+        goto bad_tfm;
 
     lf = lf - 6 - lh;
     if (np < 7)
-	lf = lf + 7 - np;
+        lf = lf + 7 - np;
 
     if (font_ptr == font_max || fmem_ptr + lf > font_mem_size)
-	_tt_abort("not enough memory to load another font");
+        _tt_abort("not enough memory to load another font");
 
     f = font_ptr + 1;
     char_base[f] = fmem_ptr - bc;
@@ -11378,270 +11378,270 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
     param_base[f] = exten_base[f] + /*:585 */ ne;
 
     if (lh < 2)
-	goto bad_tfm;
+        goto bad_tfm;
 
     qw.u.B0 = a = ttstub_input_getc (tfm_file);
     qw.u.B1 = b = ttstub_input_getc (tfm_file);
     qw.u.B2 = c = ttstub_input_getc (tfm_file);
     qw.u.B3 = d = ttstub_input_getc (tfm_file);
     if (a == EOF || b == EOF || c == EOF || d == EOF)
-	goto bad_tfm;
+        goto bad_tfm;
     font_check[f] = qw;
 
     READFIFTEEN(z);
     z = z * 256 + ttstub_input_getc (tfm_file);
     z = (z * 16) + (ttstub_input_getc (tfm_file) / 16);
     if (z < 65536L)
-	goto bad_tfm;
+        goto bad_tfm;
 
     while (lh > 2) {
-	ttstub_input_getc (tfm_file);
-	ttstub_input_getc (tfm_file);
-	ttstub_input_getc (tfm_file);
-	ttstub_input_getc (tfm_file);
-	lh--;
+        ttstub_input_getc (tfm_file);
+        ttstub_input_getc (tfm_file);
+        ttstub_input_getc (tfm_file);
+        ttstub_input_getc (tfm_file);
+        lh--;
     }
 
     font_dsize[f] = z;
     if (s != -1000) {
-	if (s >= 0)
-	    z = s;
-	else
-	    z = xn_over_d(z, -(integer) s, 1000);
+        if (s >= 0)
+            z = s;
+        else
+            z = xn_over_d(z, -(integer) s, 1000);
     }
 
     font_size[f] = z;
 
     for (k = fmem_ptr; k <= width_base[f] - 1; k++) {
-	qw.u.B0 = a = ttstub_input_getc (tfm_file);
-	qw.u.B1 = b = ttstub_input_getc (tfm_file);
-	qw.u.B2 = c = ttstub_input_getc (tfm_file);
-	qw.u.B3 = d = ttstub_input_getc (tfm_file);
-	if (a == EOF || b == EOF || c == EOF || d == EOF)
-	    goto bad_tfm;
-	font_info[k].qqqq = qw;
+        qw.u.B0 = a = ttstub_input_getc (tfm_file);
+        qw.u.B1 = b = ttstub_input_getc (tfm_file);
+        qw.u.B2 = c = ttstub_input_getc (tfm_file);
+        qw.u.B3 = d = ttstub_input_getc (tfm_file);
+        if (a == EOF || b == EOF || c == EOF || d == EOF)
+            goto bad_tfm;
+        font_info[k].qqqq = qw;
 
-	if (a >= nw || b / 16 >= nh || b % 16 >= nd || c / 4 >= ni)
-	    goto bad_tfm;
+        if (a >= nw || b / 16 >= nh || b % 16 >= nd || c / 4 >= ni)
+            goto bad_tfm;
 
-	switch (c % 4) {
-	case 1:
-	    if (d >= nl)
-		goto bad_tfm;
-	    break;
-	case 3:
-	    if (d >= ne)
-		goto bad_tfm;
-	    break;
-	case 2:
-	    if (d < bc || d > ec)
-		goto bad_tfm;
+        switch (c % 4) {
+        case 1:
+            if (d >= nl)
+                goto bad_tfm;
+            break;
+        case 3:
+            if (d >= ne)
+                goto bad_tfm;
+            break;
+        case 2:
+            if (d < bc || d > ec)
+                goto bad_tfm;
 
-	    while (d < k + bc - fmem_ptr) {
-		qw = font_info[char_base[f] + d].qqqq;
-		if ((qw.u.B2 % 4) != LIST_TAG)
-		    goto not_found;
-		d = qw.u.B3;
-	    }
+            while (d < k + bc - fmem_ptr) {
+                qw = font_info[char_base[f] + d].qqqq;
+                if ((qw.u.B2 % 4) != LIST_TAG)
+                    goto not_found;
+                d = qw.u.B3;
+            }
 
-	    if (d == k + bc - fmem_ptr)
-		goto bad_tfm;
+            if (d == k + bc - fmem_ptr)
+                goto bad_tfm;
 
-	not_found:
-	    break;
-	}
+        not_found:
+            break;
+        }
     }
 
     alpha = 16;
     while (z >= 0x800000) {
-	z = z / 2;
-	alpha = alpha + alpha;
+        z = z / 2;
+        alpha = alpha + alpha;
     }
     beta = 256 / alpha;
     alpha = alpha * z;
 
     for (k = width_base[f]; k <= lig_kern_base[f] - 1; k++) {
-	a = ttstub_input_getc (tfm_file);
-	b = ttstub_input_getc (tfm_file);
-	c = ttstub_input_getc (tfm_file);
-	d = ttstub_input_getc (tfm_file);
-	if (a == EOF || b == EOF || c == EOF || d == EOF)
-	    goto bad_tfm;
-	sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
+        a = ttstub_input_getc (tfm_file);
+        b = ttstub_input_getc (tfm_file);
+        c = ttstub_input_getc (tfm_file);
+        d = ttstub_input_getc (tfm_file);
+        if (a == EOF || b == EOF || c == EOF || d == EOF)
+            goto bad_tfm;
+        sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
 
-	if (a == 0)
-	    font_info[k].cint = sw;
-	else if (a == 255)
-	    font_info[k].cint = sw - alpha;
-	else
-	    goto bad_tfm;
+        if (a == 0)
+            font_info[k].cint = sw;
+        else if (a == 255)
+            font_info[k].cint = sw - alpha;
+        else
+            goto bad_tfm;
     }
 
     if (font_info[width_base[f]].cint != 0)
-	goto bad_tfm;
+        goto bad_tfm;
     if (font_info[height_base[f]].cint != 0)
-	goto bad_tfm;
+        goto bad_tfm;
     if (font_info[depth_base[f]].cint != 0)
-	goto bad_tfm;
+        goto bad_tfm;
     if (font_info[italic_base[f]].cint != 0)
-	goto bad_tfm;
+        goto bad_tfm;
 
     bch_label = 32767;
     bchar = 256;
 
     if (nl > 0) {
-	for (k = lig_kern_base[f]; k <= kern_base[f] + 256 * 128 - 1; k++) {
-	    qw.u.B0 = a = ttstub_input_getc (tfm_file);
-	    qw.u.B1 = b = ttstub_input_getc (tfm_file);
-	    qw.u.B2 = c = ttstub_input_getc (tfm_file);
-	    qw.u.B3 = d = ttstub_input_getc (tfm_file);
-	    if (a == EOF || b == EOF || c == EOF || d == EOF)
-		goto bad_tfm;
-	    font_info[k].qqqq = qw;
+        for (k = lig_kern_base[f]; k <= kern_base[f] + 256 * 128 - 1; k++) {
+            qw.u.B0 = a = ttstub_input_getc (tfm_file);
+            qw.u.B1 = b = ttstub_input_getc (tfm_file);
+            qw.u.B2 = c = ttstub_input_getc (tfm_file);
+            qw.u.B3 = d = ttstub_input_getc (tfm_file);
+            if (a == EOF || b == EOF || c == EOF || d == EOF)
+                goto bad_tfm;
+            font_info[k].qqqq = qw;
 
-	    if (a > 128) {
-		if (256 * c + d >= nl)
-		    goto bad_tfm;
+            if (a > 128) {
+                if (256 * c + d >= nl)
+                    goto bad_tfm;
 
-		if (a == 255 && k == lig_kern_base[f])
-		    bchar = b;
-	    } else {
-		if (b != bchar) {
-		    if ((b < bc) || (b > ec))
-			goto bad_tfm;
+                if (a == 255 && k == lig_kern_base[f])
+                    bchar = b;
+            } else {
+                if (b != bchar) {
+                    if ((b < bc) || (b > ec))
+                        goto bad_tfm;
 
-		    qw = font_info[char_base[f] + b].qqqq;
-		    if (!(qw.u.B0 > 0))
-			goto bad_tfm;
-		}
+                    qw = font_info[char_base[f] + b].qqqq;
+                    if (!(qw.u.B0 > 0))
+                        goto bad_tfm;
+                }
 
-		if (c < 128) {
-		    if ((d < bc) || (d > ec))
-			goto bad_tfm;
-		    qw = font_info[char_base[f] + d].qqqq;
-		    if (!(qw.u.B0 > 0))
-			goto bad_tfm;
-		} else if (256 * (c - 128) + d >= nk)
-		    goto bad_tfm;
+                if (c < 128) {
+                    if ((d < bc) || (d > ec))
+                        goto bad_tfm;
+                    qw = font_info[char_base[f] + d].qqqq;
+                    if (!(qw.u.B0 > 0))
+                        goto bad_tfm;
+                } else if (256 * (c - 128) + d >= nk)
+                    goto bad_tfm;
 
-		if (a < 128 && k - lig_kern_base[f] + a + 1 >= nl)
-		    goto bad_tfm;
-	    }
-	}
+                if (a < 128 && k - lig_kern_base[f] + a + 1 >= nl)
+                    goto bad_tfm;
+            }
+        }
 
-	if (a == 255)
-	    bch_label = 256 * c + d;
+        if (a == 255)
+            bch_label = 256 * c + d;
     }
 
     for (k = kern_base[f] + 256 * 128; k <= exten_base[f] - 1; k++) {
-	a = ttstub_input_getc (tfm_file);
-	b = ttstub_input_getc (tfm_file);
-	c = ttstub_input_getc (tfm_file);
-	d = ttstub_input_getc (tfm_file);
-	if (a == EOF || b == EOF || c == EOF || d == EOF)
-	    goto bad_tfm;
-	sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
+        a = ttstub_input_getc (tfm_file);
+        b = ttstub_input_getc (tfm_file);
+        c = ttstub_input_getc (tfm_file);
+        d = ttstub_input_getc (tfm_file);
+        if (a == EOF || b == EOF || c == EOF || d == EOF)
+            goto bad_tfm;
+        sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
 
-	if (a == 0)
-	    font_info[k].cint = sw;
-	else if (a == 255)
-	    font_info[k].cint = sw - alpha;
-	else
-	    goto bad_tfm;
+        if (a == 0)
+            font_info[k].cint = sw;
+        else if (a == 255)
+            font_info[k].cint = sw - alpha;
+        else
+            goto bad_tfm;
     }
 
     for (k = exten_base[f]; k <= param_base[f] - 1; k++) {
-	qw.u.B0 = a = ttstub_input_getc (tfm_file);
-	qw.u.B1 = b = ttstub_input_getc (tfm_file);
-	qw.u.B2 = c = ttstub_input_getc (tfm_file);
-	qw.u.B3 = d = ttstub_input_getc (tfm_file);
-	if (a == EOF || b == EOF || c == EOF || d == EOF)
-	    goto bad_tfm;
-	font_info[k].qqqq = qw;
+        qw.u.B0 = a = ttstub_input_getc (tfm_file);
+        qw.u.B1 = b = ttstub_input_getc (tfm_file);
+        qw.u.B2 = c = ttstub_input_getc (tfm_file);
+        qw.u.B3 = d = ttstub_input_getc (tfm_file);
+        if (a == EOF || b == EOF || c == EOF || d == EOF)
+            goto bad_tfm;
+        font_info[k].qqqq = qw;
 
-	if (a != 0) {
-	    if ((a < bc) || (a > ec))
-		goto bad_tfm;
-	    qw = font_info[char_base[f] + a].qqqq;
-	    if (!(qw.u.B0 > 0))
-		goto bad_tfm;
-	}
+        if (a != 0) {
+            if ((a < bc) || (a > ec))
+                goto bad_tfm;
+            qw = font_info[char_base[f] + a].qqqq;
+            if (!(qw.u.B0 > 0))
+                goto bad_tfm;
+        }
 
-	if (b != 0) {
-	    if ((b < bc) || (b > ec))
-		goto bad_tfm;
-	    qw = font_info[char_base[f] + b].qqqq;
-	    if (!(qw.u.B0 > 0))
-		goto bad_tfm;
-	}
+        if (b != 0) {
+            if ((b < bc) || (b > ec))
+                goto bad_tfm;
+            qw = font_info[char_base[f] + b].qqqq;
+            if (!(qw.u.B0 > 0))
+                goto bad_tfm;
+        }
 
-	if (c != 0) {
-	    if ((c < bc) || (c > ec))
-		goto bad_tfm;
-	    qw = font_info[char_base[f] + c].qqqq;
-	    if (!(qw.u.B0 > 0))
-		goto bad_tfm;
-	}
+        if (c != 0) {
+            if ((c < bc) || (c > ec))
+                goto bad_tfm;
+            qw = font_info[char_base[f] + c].qqqq;
+            if (!(qw.u.B0 > 0))
+                goto bad_tfm;
+        }
 
-	if ((d < bc) || (d > ec))
-	    goto bad_tfm;
-	qw = font_info[char_base[f] + d].qqqq;
-	if (!(qw.u.B0 > 0))
-	    goto bad_tfm;
+        if ((d < bc) || (d > ec))
+            goto bad_tfm;
+        qw = font_info[char_base[f] + d].qqqq;
+        if (!(qw.u.B0 > 0))
+            goto bad_tfm;
     }
 
     for (k = 1; k <= np; k++) {
-	if (k == 1) {
-	    sw = ttstub_input_getc (tfm_file);
-	    if (sw == EOF)
-		goto bad_tfm;
-	    if (sw > 127)
-		sw = sw - 256;
+        if (k == 1) {
+            sw = ttstub_input_getc (tfm_file);
+            if (sw == EOF)
+                goto bad_tfm;
+            if (sw > 127)
+                sw = sw - 256;
 
-	    sw = sw * 256 + ttstub_input_getc (tfm_file);
-	    sw = sw * 256 + ttstub_input_getc (tfm_file);
-	    font_info[param_base[f]].cint = (sw * 16) + (ttstub_input_getc (tfm_file) / 16);
-	} else {
-	    a = ttstub_input_getc (tfm_file);
-	    b = ttstub_input_getc (tfm_file);
-	    c = ttstub_input_getc (tfm_file);
-	    d = ttstub_input_getc (tfm_file);
-	    if (a == EOF || b == EOF || c == EOF || d == EOF)
-		goto bad_tfm;
-	    sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
+            sw = sw * 256 + ttstub_input_getc (tfm_file);
+            sw = sw * 256 + ttstub_input_getc (tfm_file);
+            font_info[param_base[f]].cint = (sw * 16) + (ttstub_input_getc (tfm_file) / 16);
+        } else {
+            a = ttstub_input_getc (tfm_file);
+            b = ttstub_input_getc (tfm_file);
+            c = ttstub_input_getc (tfm_file);
+            d = ttstub_input_getc (tfm_file);
+            if (a == EOF || b == EOF || c == EOF || d == EOF)
+                goto bad_tfm;
+            sw = (((((d * z) / 256) + c * z) / 256) + b * z) / beta;
 
-	    if (a == 0)
-		font_info[param_base[f] + k - 1].cint = sw;
-	    else if (a == 255)
-		font_info[param_base[f] + k - 1].cint = sw - alpha;
-	    else
-		goto bad_tfm;
-	}
+            if (a == 0)
+                font_info[param_base[f] + k - 1].cint = sw;
+            else if (a == 255)
+                font_info[param_base[f] + k - 1].cint = sw - alpha;
+            else
+                goto bad_tfm;
+        }
     }
 
     for (k = np + 1; k <= 7; k++)
-	font_info[param_base[f] + k - 1].cint = 0;
+        font_info[param_base[f] + k - 1].cint = 0;
 
     if (np >= 7)
-	font_params[f] = np;
+        font_params[f] = np;
     else
-	font_params[f] = 7;
+        font_params[f] = 7;
 
     hyphen_char[f] = INTPAR(default_hyphen_char);
     skew_char[f] = INTPAR(default_skew_char);
     if (bch_label < nl)
-	bchar_label[f] = bch_label + lig_kern_base[f];
+        bchar_label[f] = bch_label + lig_kern_base[f];
     else
-	bchar_label[f] = NON_ADDRESS;
+        bchar_label[f] = NON_ADDRESS;
     font_bchar[f] = bchar;
     font_false_bchar[f] = bchar;
 
     if (bchar <= ec) {
-	if (bchar >= bc) {
-	    qw = font_info[char_base[f] + bchar].qqqq;
-	    if ((qw.u.B0 > 0))
-		font_false_bchar[f] = TOO_BIG_CHAR;
-	}
+        if (bchar >= bc) {
+            qw = font_info[char_base[f] + bchar].qqqq;
+            if ((qw.u.B0 > 0))
+                font_false_bchar[f] = TOO_BIG_CHAR;
+        }
     }
 
     font_name[f] = nom;
@@ -11663,13 +11663,13 @@ read_font_info(int32_t u, str_number nom, str_number aire, scaled s)
 
 bad_tfm:
     if (INTPAR(suppress_fontnotfound_error) == 0) {
-	/* NOTE: must preserve this path to keep passing the TRIP tests */
+        /* NOTE: must preserve this path to keep passing the TRIP tests */
 
-	if (file_line_error_style_p)
-	    print_file_line();
-	else
-	    print_nl(S(__/*"! "*/));
-	print(S(Font_));
+        if (file_line_error_style_p)
+            print_file_line();
+        else
+            print_nl(S(__/*"! "*/));
+        print(S(Font_));
         sprint_cs(u);
         print_char(61 /*"=" */ );
         if (file_name_quote_char != 0)
@@ -11693,12 +11693,12 @@ bad_tfm:
         else
             print(S(_not_loadable__Metric__TFM___Z1/*" not loadable: Metric (TFM) file or installed font not found"*/));
 
-	help_ptr = 5;
-	help_line[4] = S(I_wasn_t_able_to_read_the_si/*ze data for this font,*/);
-	help_line[3] = S(so_I_will_ignore_the_font_sp/*ecification.*/);
-	help_line[2] = S(_Wizards_can_fix_TFM_files_u/*sing TFtoPL/PLtoTF.]*/);
-	help_line[1] = S(You_might_try_inserting_a_di/*fferent font spec;*/);
-	help_line[0] = S(e_g___type__I_font_same_font/* id>=<substitute font name>'.*/);
+        help_ptr = 5;
+        help_line[4] = S(I_wasn_t_able_to_read_the_si/*ze data for this font,*/);
+        help_line[3] = S(so_I_will_ignore_the_font_sp/*ecification.*/);
+        help_line[2] = S(_Wizards_can_fix_TFM_files_u/*sing TFtoPL/PLtoTF.]*/);
+        help_line[1] = S(You_might_try_inserting_a_di/*fferent font spec;*/);
+        help_line[0] = S(e_g___type__I_font_same_font/* id>=<substitute font name>'.*/);
 
         error();
     }
@@ -12478,9 +12478,9 @@ void out_what(int32_t p)
                     if (cur_ext == S())
                         cur_ext = S(_tex);
                     pack_file_name(cur_name, cur_area, cur_ext);
-		    write_file[j] = ttstub_output_open (name_of_file + 1, 0);
-		    if (write_file[j] == NULL)
-			_tt_abort ("cannot open output file \"%s\"", name_of_file + 1);
+                    write_file[j] = ttstub_output_open (name_of_file + 1, 0);
+                    if (write_file[j] == NULL)
+                        _tt_abort ("cannot open output file \"%s\"", name_of_file + 1);
                     write_open[j] = true;
                     if (log_opened) {
                         old_setting = selector;
@@ -13944,7 +13944,7 @@ void ship_out(int32_t p)
         dvi_v = 0;
         cur_h = DIMENPAR(h_offset);
         dvi_f = FONT_BASE;
-	/* 4736287 = round(0xFFFF * 72.27) ; i.e., 1 inch expressed as a scaled */
+        /* 4736287 = round(0xFFFF * 72.27) ; i.e., 1 inch expressed as a scaled */
         cur_h_offset = DIMENPAR(h_offset) + 4736287;
         cur_v_offset = DIMENPAR(v_offset) + 4736287;
         if (DIMENPAR(pdf_page_width) != 0)
@@ -13959,9 +13959,9 @@ void ship_out(int32_t p)
             if (job_name == 0)
                 open_log_file();
             pack_job_name(output_file_extension);
-	    dvi_file = ttstub_output_open (name_of_file + 1, 0);
-	    if (dvi_file == NULL)
-		_tt_abort ("cannot open output file \"%s\"", name_of_file + 1);
+            dvi_file = ttstub_output_open (name_of_file + 1, 0);
+            if (dvi_file == NULL)
+                _tt_abort ("cannot open output file \"%s\"", name_of_file + 1);
             output_file_name = make_name_string();
         }
         if (total_pages == 0) {
@@ -14635,7 +14635,7 @@ common_ending:
 
 exit:
     if ((eqtb[ETEX_STATE_BASE].cint > 0)) {
-	/*1499: */
+        /*1499: */
         if (mem[LR_ptr].hh.v.LH != BEFORE) {
             while (mem[q].hh.v.RH != MIN_HALFWORD)
                 q = mem[q].hh.v.RH;
@@ -27146,10 +27146,10 @@ void close_files_and_terminate(void)
             if (dvi_ptr == dvi_limit)
                 dvi_swap();
         } else {
-	    dvi_buf[dvi_ptr] = EOP;
-	    dvi_ptr++;
-	    if (dvi_ptr == dvi_limit)
-		dvi_swap();
+            dvi_buf[dvi_ptr] = EOP;
+            dvi_ptr++;
+            if (dvi_ptr == dvi_limit)
+                dvi_swap();
             total_pages++;
         }
         cur_s--;
@@ -27158,10 +27158,10 @@ void close_files_and_terminate(void)
     if (total_pages == 0)
         print_nl(S(No_pages_of_output_));
     else if (cur_s != -2) {
-	dvi_buf[dvi_ptr] = POST;
-	dvi_ptr++;
-	if (dvi_ptr == dvi_limit)
-	    dvi_swap();
+        dvi_buf[dvi_ptr] = POST;
+        dvi_ptr++;
+        if (dvi_ptr == dvi_limit)
+            dvi_swap();
         dvi_four(last_bop);
         last_bop = dvi_offset + dvi_ptr - 5;
         dvi_four(25400000L); /* magic values: conversion ratio for sp */
@@ -27218,10 +27218,10 @@ void close_files_and_terminate(void)
         k = 4 + ((dvi_buf_size - dvi_ptr) % 4);
 
         while (k > 0) {
-	    dvi_buf[dvi_ptr] = 223;
-	    dvi_ptr++;
-	    if (dvi_ptr == dvi_limit)
-		dvi_swap();
+            dvi_buf[dvi_ptr] = 223;
+            dvi_ptr++;
+            if (dvi_ptr == dvi_limit)
+                dvi_swap();
             k--;
         }
 
@@ -27264,7 +27264,7 @@ void close_files_and_terminate(void)
 
     synctex_terminate(log_opened);
     if (log_opened) {
-	ttstub_output_putc (log_file, '\n');
+        ttstub_output_putc (log_file, '\n');
         ttstub_output_close (log_file);
         selector = selector - 2;
         if (selector == SELECTOR_TERM_ONLY) {

--- a/tectonic/xetexd.h
+++ b/tectonic/xetexd.h
@@ -20,7 +20,7 @@
 #include <ApplicationServices/ApplicationServices.h>
 #endif
 
-#define odd(x)		((x) & 1)
+#define odd(x) ((x) & 1)
 
 /* Extra stuff used in various change files for various reasons.  */
 
@@ -31,11 +31,11 @@
 
 /* We use this rather than a simple fputs so that the string will end up
    in the .log file, too.  */
-#define print_c_string(STR)        \
+#define print_c_string(STR)      \
   do {                           \
     const_string ch_ptr = (STR); \
     while (*ch_ptr)              \
-      print_char(*(ch_ptr++));    \
+      print_char(*(ch_ptr++));   \
   } while (0)
 
 /* Declarations for the routines we provide ourselves in lib/.  */
@@ -1128,33 +1128,33 @@ void compare_strings(void);
 /* additional declarations we want to slip in for xetex */
 
 #define native_node_text(p) ((unsigned short*) &mem[(p) + NATIVE_NODE_SIZE])
-#define get_native_char(p,i)                      native_node_text(p)[i]
-#define set_native_char(p,i,v)                    native_node_text(p)[i] = v
+#define get_native_char(p,i) native_node_text(p)[i]
+#define set_native_char(p,i,v) native_node_text(p)[i] = v
 #define get_native_usv(p,i) \
   ((native_node_text(p)[i] >= 0xd800 && native_node_text(p)[i] < 0xdc00) ? \
     0x10000 + (native_node_text(p)[i] - 0xd800) * 0x400 + native_node_text(p)[(i)+1] - 0xdc00 : \
     native_node_text(p)[i])
 
 /* p is native_word node; g is XeTeX_use_glyph_metrics flag */
-#define set_native_metrics(p,g)                   measure_native_node(&(mem[p]), g)
-#define set_native_glyph_metrics(p,g)              measure_native_glyph(&(mem[p]), g)
-#define set_justified_native_glyphs(p)             store_justified_native_glyphs(&(mem[p]))
-#define get_native_italic_correction(p)            real_get_native_italic_correction(&(mem[p]))
-#define get_native_glyph_italic_correction(p)       real_get_native_glyph_italic_correction(&(mem[p]))
-#define get_native_glyph(p,i)                     real_get_native_glyph(&(mem[p]), i)
-#define make_xdv_glyph_array_data(p)                makeXDVGlyphArrayData(&(mem[p]))
-#define get_native_word_cp(p,s)                    real_get_native_word_cp(&(mem[p]), s)
+#define set_native_metrics(p,g)               measure_native_node(&(mem[p]), g)
+#define set_native_glyph_metrics(p,g)         measure_native_glyph(&(mem[p]), g)
+#define set_justified_native_glyphs(p)        store_justified_native_glyphs(&(mem[p]))
+#define get_native_italic_correction(p)       real_get_native_italic_correction(&(mem[p]))
+#define get_native_glyph_italic_correction(p) real_get_native_glyph_italic_correction(&(mem[p]))
+#define get_native_glyph(p,i)                 real_get_native_glyph(&(mem[p]), i)
+#define make_xdv_glyph_array_data(p)          makeXDVGlyphArrayData(&(mem[p]))
+#define get_native_word_cp(p,s)               real_get_native_word_cp(&(mem[p]), s)
 
 #define pic_path_byte(p,i) ((unsigned char*) &mem[(p) + PIC_NODE_SIZE])[i]
 
 /* easier to do the bit-twiddling here than in Pascal */
 /* read fields from a 32-bit math code */
-#define math_fam(x)                         (((unsigned)(x) >> 24) & 0xFF)
-#define math_class(x)                       (((unsigned)(x) >> 21) & 0x07)
-#define math_char(x)                        ((unsigned)(x) & 0x1FFFFF)
+#define math_fam(x)   (((unsigned)(x) >> 24) & 0xFF)
+#define math_class(x) (((unsigned)(x) >> 21) & 0x07)
+#define math_char(x)  ((unsigned)(x) & 0x1FFFFF)
 /* calculate pieces to assign to a math code */
-#define set_family(x)                       (((unsigned)(x) & 0xFF) << 24)
-#define set_class(x)                        (((unsigned)(x) & 0x07) << 21)
+#define set_family(x) (((unsigned)(x) & 0xFF) << 24)
+#define set_class(x)  (((unsigned)(x) & 0x07) << 21)
 
 /* Unicode file reading modes */
 #define AUTO       0 /* default: will become one of 1..3 at file open time, after sniffing */

--- a/tectonic/xetexini.c
+++ b/tectonic/xetexini.c
@@ -68,7 +68,7 @@ swap_items (char *p, int nitems, int size)
     case 1:
         break; /* Nothing to do. */
     default:
-	_tt_abort("can't swap a %d-byte item for (un)dumping", size);
+        _tt_abort("can't swap a %d-byte item for (un)dumping", size);
     }
 }
 #else  /* not WORDS_BIGENDIAN */
@@ -244,12 +244,12 @@ primitive(str_number s, uint16_t c, int32_t o)
         if (first + l > buf_size + 1)
             overflow(S(buffer_size), buf_size);
 
-	for (j = 0; j <= l - 1; j++)
-	    buffer[first + j] = str_pool[k + j];
+        for (j = 0; j <= l - 1; j++)
+            buffer[first + j] = str_pool[k + j];
 
         cur_val = id_lookup(first, l);
-	str_ptr--;
-	pool_ptr = str_start[str_ptr - 65536L];
+        str_ptr--;
+        pool_ptr = str_start[str_ptr - 65536L];
         hash[cur_val].v.RH = s;
         prim_val = prim_lookup(s);
     }
@@ -1808,24 +1808,24 @@ store_fmt_file(void)
     rust_output_handle_t fmt_out;
 
     if (save_ptr != 0) {
-	if (file_line_error_style_p)
-	    print_file_line();
-	else
-	    print_nl(S(__/*"! "*/));
+        if (file_line_error_style_p)
+            print_file_line();
+        else
+            print_nl(S(__/*"! "*/));
 
-	print(S(You_can_t_dump_inside_a_grou/*p*/));
-	help_ptr = 1;
-	help_line[0] = S(______dump___is_a_no_no_/*`{...\\dump}' is a no-no.*/);
+        print(S(You_can_t_dump_inside_a_grou/*p*/));
+        help_ptr = 1;
+        help_line[0] = S(______dump___is_a_no_no_/*`{...\\dump}' is a no-no.*/);
 
-	if (interaction == ERROR_STOP_MODE)
-	    interaction = SCROLL_MODE;
-	if (log_opened)
-	    error();
+        if (interaction == ERROR_STOP_MODE)
+            interaction = SCROLL_MODE;
+        if (log_opened)
+            error();
 
-	history = HISTORY_FATAL_ERROR;
-	close_files_and_terminate();
-	ttstub_output_flush (rust_stdout);
-	_tt_abort("\\dump inside a group");
+        history = HISTORY_FATAL_ERROR;
+        close_files_and_terminate();
+        ttstub_output_flush (rust_stdout);
+        _tt_abort("\\dump inside a group");
     }
 
     selector = SELECTOR_NEW_STRING;
@@ -1852,7 +1852,7 @@ store_fmt_file(void)
 
     fmt_out = ttstub_output_open (name_of_file + 1, 1);
     if (fmt_out == NULL)
-	_tt_abort ("cannot open format output file \"%s\"", name_of_file + 1);
+        _tt_abort ("cannot open format output file \"%s\"", name_of_file + 1);
 
     print_nl(S(Beginning_to_dump_on_file_));
     print(make_name_string());
@@ -2211,56 +2211,56 @@ pack_buffered_name(small_number n, integer a, integer b)
     k = 0;
 
     for (j = 1; j <= n; j++) {
-	/* This junk is append_to_name(), inlined, and with UTF-8 decoding, I
-	 * think. */
-	c = TEX_format_default[j];
-	k++;
-	if (k <= INTEGER_MAX) {
-	    if (c < 128) {
-		name_of_file[k] = c;
-	    } else if (c < 2048) {
-		name_of_file[k++] = 192 + c / 64;
-		name_of_file[k] = 128 + c % 64;
-	    } else {
-		name_of_file[k++] = 224 + c / 4096;
-		name_of_file[k++] = 128 + (c % 4096) / 64;
-		name_of_file[k] = 128 + (c % 4096) % 64;
-	    }
-	}
+        /* This junk is append_to_name(), inlined, and with UTF-8 decoding, I
+         * think. */
+        c = TEX_format_default[j];
+        k++;
+        if (k <= INTEGER_MAX) {
+            if (c < 128) {
+                name_of_file[k] = c;
+            } else if (c < 2048) {
+                name_of_file[k++] = 192 + c / 64;
+                name_of_file[k] = 128 + c % 64;
+            } else {
+                name_of_file[k++] = 224 + c / 4096;
+                name_of_file[k++] = 128 + (c % 4096) / 64;
+                name_of_file[k] = 128 + (c % 4096) % 64;
+            }
+        }
     }
 
     for (j = a; j <= b; j++) {
-	c = buffer[j];
-	k++;
-	if (k <= INTEGER_MAX) {
-	    if (c < 128) {
-		name_of_file[k] = c;
-	    } else if (c < 2048) {
-		name_of_file[k++] = 192 + c / 64;
-		name_of_file[k] = 128 + c % 64;
-	    } else {
-		name_of_file[k++] = 224 + c / 4096;
-		name_of_file[k++] = 128 + (c % 4096) / 64;
-		name_of_file[k] = 128 + (c % 4096) % 64;
-	    }
-	}
+        c = buffer[j];
+        k++;
+        if (k <= INTEGER_MAX) {
+            if (c < 128) {
+                name_of_file[k] = c;
+            } else if (c < 2048) {
+                name_of_file[k++] = 192 + c / 64;
+                name_of_file[k] = 128 + c % 64;
+            } else {
+                name_of_file[k++] = 224 + c / 4096;
+                name_of_file[k++] = 128 + (c % 4096) / 64;
+                name_of_file[k] = 128 + (c % 4096) % 64;
+            }
+        }
     }
 
     for (j = format_default_length - 3; j <= format_default_length; j++) {
-	c = TEX_format_default[j];
-	k++;
-	if (k <= INTEGER_MAX) {
-	    if (c < 128) {
-		name_of_file[k] = c;
-	    } else if (c < 2048) {
-		name_of_file[k++] = 192 + c / 64;
-		name_of_file[k] = 128 + c % 64;
-	    } else {
-		name_of_file[k++] = 224 + c / 4096;
-		name_of_file[k++] = 128 + (c % 4096) / 64;
-		name_of_file[k] = 128 + (c % 4096) % 64;
-	    }
-	}
+        c = TEX_format_default[j];
+        k++;
+        if (k <= INTEGER_MAX) {
+            if (c < 128) {
+                name_of_file[k] = c;
+            } else if (c < 2048) {
+                name_of_file[k++] = 192 + c / 64;
+                name_of_file[k] = 128 + c % 64;
+            } else {
+                name_of_file[k++] = 224 + c / 4096;
+                name_of_file[k++] = 128 + (c % 4096) / 64;
+                name_of_file[k] = 128 + (c % 4096) % 64;
+            }
+        }
     }
 
     if (k <= INTEGER_MAX)
@@ -2292,7 +2292,7 @@ load_fmt_file(void)
 
     fmt_in = ttstub_input_open(name_of_file + 1, kpse_fmt_format, 1);
     if (fmt_in == NULL)
-	_tt_abort ("cannot open the format file \"%s\"", TEX_format_default + 1);
+        _tt_abort ("cannot open the format file \"%s\"", TEX_format_default + 1);
 
     cur_input.loc = j;
 
@@ -2932,19 +2932,19 @@ init_io(string input_file_name)
     k = first;
 
     while ((rval = *(ptr++)) != 0) {
-	UInt16 extraBytes = bytesFromUTF8[rval];
+        UInt16 extraBytes = bytesFromUTF8[rval];
 
-	switch (extraBytes) { /* note: code falls through cases! */
-	case 5: rval <<= 6; if (*ptr) rval += *(ptr++);
-	case 4: rval <<= 6; if (*ptr) rval += *(ptr++);
-	case 3: rval <<= 6; if (*ptr) rval += *(ptr++);
-	case 2: rval <<= 6; if (*ptr) rval += *(ptr++);
-	case 1: rval <<= 6; if (*ptr) rval += *(ptr++);
-	case 0: ;
-	}
+        switch (extraBytes) { /* note: code falls through cases! */
+        case 5: rval <<= 6; if (*ptr) rval += *(ptr++);
+        case 4: rval <<= 6; if (*ptr) rval += *(ptr++);
+        case 3: rval <<= 6; if (*ptr) rval += *(ptr++);
+        case 2: rval <<= 6; if (*ptr) rval += *(ptr++);
+        case 1: rval <<= 6; if (*ptr) rval += *(ptr++);
+        case 0: ;
+        }
 
-	rval -= offsetsFromUTF8[extraBytes];
-	buffer[k++] = rval;
+        rval -= offsetsFromUTF8[extraBytes];
+        buffer[k++] = rval;
     }
 
     buffer[k] = ' ';
@@ -3753,7 +3753,7 @@ get_strings_started(void)
     str_ptr = TOO_BIG_CHAR;
 
     if (load_pool_strings(pool_size - string_vacancies) == 0)
-	_tt_abort ("must increase pool_size");
+        _tt_abort ("must increase pool_size");
 }
 /*:1001*/
 
@@ -3785,7 +3785,7 @@ tt_misc_initialize(char *dump_name)
     synctex_options = INT_MAX;
 
     if (file_line_error_style_p < 0)
-	file_line_error_style_p = 0;
+        file_line_error_style_p = 0;
 
     /* Make this something invariant so that we can use XDV files to test
      * reproducibility of the engine output. */
@@ -3830,8 +3830,8 @@ tt_run_engine(char *input_file_name)
     /* Before anything else ... setjmp handling of super-fatal errors */
 
     if (setjmp (jump_buffer)) {
-	history = HISTORY_FATAL_ERROR;
-	return history;
+        history = HISTORY_FATAL_ERROR;
+        return history;
     }
 
     /* These various parameters were configurable in web2c TeX. We don't
@@ -3945,7 +3945,7 @@ tt_run_engine(char *input_file_name)
         bad = 41;
 
     if (bad > 0)
-	_tt_abort ("failed internal consistency check #%d", bad);
+        _tt_abort ("failed internal consistency check #%d", bad);
 
     /* OK, ready to keep on initializing. */
 
@@ -3998,180 +3998,180 @@ tt_run_engine(char *input_file_name)
     init_io(input_file_name);
 
     if (in_initex_mode) {
-	no_new_control_sequence = false;
+        no_new_control_sequence = false;
 
-	primitive(S(XeTeXpicfile), EXTENSION, PIC_FILE_CODE);
-	primitive(S(XeTeXpdffile), EXTENSION, PDF_FILE_CODE);
-	primitive(S(XeTeXglyph), EXTENSION, GLYPH_CODE);
-	primitive(S(XeTeXlinebreaklocale), EXTENSION, XETEX_LINEBREAK_LOCALE_EXTENSION_CODE);
-	primitive(S(XeTeXinterchartoks), ASSIGN_TOKS, LOCAL_BASE + LOCAL__xetex_inter_char);
-	primitive(S(pdfsavepos), EXTENSION, PDFTEX_FIRST_EXTENSION_CODE + 0);
+        primitive(S(XeTeXpicfile), EXTENSION, PIC_FILE_CODE);
+        primitive(S(XeTeXpdffile), EXTENSION, PDF_FILE_CODE);
+        primitive(S(XeTeXglyph), EXTENSION, GLYPH_CODE);
+        primitive(S(XeTeXlinebreaklocale), EXTENSION, XETEX_LINEBREAK_LOCALE_EXTENSION_CODE);
+        primitive(S(XeTeXinterchartoks), ASSIGN_TOKS, LOCAL_BASE + LOCAL__xetex_inter_char);
+        primitive(S(pdfsavepos), EXTENSION, PDFTEX_FIRST_EXTENSION_CODE + 0);
 
-	primitive(S(lastnodetype), LAST_ITEM, LAST_NODE_TYPE_CODE);
-	primitive(S(eTeXversion), LAST_ITEM, ETEX_VERSION_CODE);
+        primitive(S(lastnodetype), LAST_ITEM, LAST_NODE_TYPE_CODE);
+        primitive(S(eTeXversion), LAST_ITEM, ETEX_VERSION_CODE);
 
-	primitive(S(eTeXrevision), CONVERT, ETEX_REVISION_CODE);
+        primitive(S(eTeXrevision), CONVERT, ETEX_REVISION_CODE);
 
-	primitive(S(XeTeXversion), LAST_ITEM, XETEX_VERSION_CODE);
+        primitive(S(XeTeXversion), LAST_ITEM, XETEX_VERSION_CODE);
 
-	primitive(S(XeTeXrevision), CONVERT, XETEX_REVISION_CODE);
+        primitive(S(XeTeXrevision), CONVERT, XETEX_REVISION_CODE);
 
-	primitive(S(XeTeXcountglyphs), LAST_ITEM, XETEX_COUNT_GLYPHS_CODE);
-	primitive(S(XeTeXcountvariations), LAST_ITEM, XETEX_COUNT_VARIATIONS_CODE);
-	primitive(S(XeTeXvariation), LAST_ITEM, XETEX_VARIATION_CODE);
-	primitive(S(XeTeXfindvariationbyname), LAST_ITEM, XETEX_FIND_VARIATION_BY_NAME_CODE);
-	primitive(S(XeTeXvariationmin), LAST_ITEM, XETEX_VARIATION_MIN_CODE);
-	primitive(S(XeTeXvariationmax), LAST_ITEM, XETEX_VARIATION_MAX_CODE);
-	primitive(S(XeTeXvariationdefault), LAST_ITEM, XETEX_VARIATION_DEFAULT_CODE);
-	primitive(S(XeTeXcountfeatures), LAST_ITEM, XETEX_COUNT_FEATURES_CODE);
-	primitive(S(XeTeXfeaturecode), LAST_ITEM, XETEX_FEATURE_CODE_CODE);
-	primitive(S(XeTeXfindfeaturebyname), LAST_ITEM, XETEX_FIND_FEATURE_BY_NAME_CODE);
-	primitive(S(XeTeXisexclusivefeature), LAST_ITEM, XETEX_IS_EXCLUSIVE_FEATURE_CODE);
-	primitive(S(XeTeXcountselectors), LAST_ITEM, XETEX_COUNT_SELECTORS_CODE);
-	primitive(S(XeTeXselectorcode), LAST_ITEM, XETEX_SELECTOR_CODE_CODE);
-	primitive(S(XeTeXfindselectorbyname), LAST_ITEM, XETEX_FIND_SELECTOR_BY_NAME_CODE);
-	primitive(S(XeTeXisdefaultselector), LAST_ITEM, XETEX_IS_DEFAULT_SELECTOR_CODE);
+        primitive(S(XeTeXcountglyphs), LAST_ITEM, XETEX_COUNT_GLYPHS_CODE);
+        primitive(S(XeTeXcountvariations), LAST_ITEM, XETEX_COUNT_VARIATIONS_CODE);
+        primitive(S(XeTeXvariation), LAST_ITEM, XETEX_VARIATION_CODE);
+        primitive(S(XeTeXfindvariationbyname), LAST_ITEM, XETEX_FIND_VARIATION_BY_NAME_CODE);
+        primitive(S(XeTeXvariationmin), LAST_ITEM, XETEX_VARIATION_MIN_CODE);
+        primitive(S(XeTeXvariationmax), LAST_ITEM, XETEX_VARIATION_MAX_CODE);
+        primitive(S(XeTeXvariationdefault), LAST_ITEM, XETEX_VARIATION_DEFAULT_CODE);
+        primitive(S(XeTeXcountfeatures), LAST_ITEM, XETEX_COUNT_FEATURES_CODE);
+        primitive(S(XeTeXfeaturecode), LAST_ITEM, XETEX_FEATURE_CODE_CODE);
+        primitive(S(XeTeXfindfeaturebyname), LAST_ITEM, XETEX_FIND_FEATURE_BY_NAME_CODE);
+        primitive(S(XeTeXisexclusivefeature), LAST_ITEM, XETEX_IS_EXCLUSIVE_FEATURE_CODE);
+        primitive(S(XeTeXcountselectors), LAST_ITEM, XETEX_COUNT_SELECTORS_CODE);
+        primitive(S(XeTeXselectorcode), LAST_ITEM, XETEX_SELECTOR_CODE_CODE);
+        primitive(S(XeTeXfindselectorbyname), LAST_ITEM, XETEX_FIND_SELECTOR_BY_NAME_CODE);
+        primitive(S(XeTeXisdefaultselector), LAST_ITEM, XETEX_IS_DEFAULT_SELECTOR_CODE);
 
-	primitive(S(XeTeXvariationname), CONVERT, XETEX_VARIATION_NAME_CODE);
-	primitive(S(XeTeXfeaturename), CONVERT, XeTeX_feature_name);
-	primitive(S(XeTeXselectorname), CONVERT, XeTeX_selector_name);
+        primitive(S(XeTeXvariationname), CONVERT, XETEX_VARIATION_NAME_CODE);
+        primitive(S(XeTeXfeaturename), CONVERT, XeTeX_feature_name);
+        primitive(S(XeTeXselectorname), CONVERT, XeTeX_selector_name);
 
-	primitive(S(XeTeXOTcountscripts), LAST_ITEM, XETEX_OT_COUNT_SCRIPTS_CODE);
-	primitive(S(XeTeXOTcountlanguages), LAST_ITEM, XETEX_OT_COUNT_LANGUAGES_CODE);
-	primitive(S(XeTeXOTcountfeatures), LAST_ITEM, XETEX_OT_COUNT_FEATURES_CODE);
-	primitive(S(XeTeXOTscripttag), LAST_ITEM, XETEX_OT_SCRIPT_CODE);
-	primitive(S(XeTeXOTlanguagetag), LAST_ITEM, XETEX_OT_LANGUAGE_CODE);
-	primitive(S(XeTeXOTfeaturetag), LAST_ITEM, XETEX_OT_FEATURE_CODE);
-	primitive(S(XeTeXcharglyph), LAST_ITEM, XETEX_MAP_CHAR_TO_GLYPH_CODE);
-	primitive(S(XeTeXglyphindex), LAST_ITEM, XETEX_GLYPH_INDEX_CODE);
-	primitive(S(XeTeXglyphbounds), LAST_ITEM, XETEX_GLYPH_BOUNDS_CODE);
+        primitive(S(XeTeXOTcountscripts), LAST_ITEM, XETEX_OT_COUNT_SCRIPTS_CODE);
+        primitive(S(XeTeXOTcountlanguages), LAST_ITEM, XETEX_OT_COUNT_LANGUAGES_CODE);
+        primitive(S(XeTeXOTcountfeatures), LAST_ITEM, XETEX_OT_COUNT_FEATURES_CODE);
+        primitive(S(XeTeXOTscripttag), LAST_ITEM, XETEX_OT_SCRIPT_CODE);
+        primitive(S(XeTeXOTlanguagetag), LAST_ITEM, XETEX_OT_LANGUAGE_CODE);
+        primitive(S(XeTeXOTfeaturetag), LAST_ITEM, XETEX_OT_FEATURE_CODE);
+        primitive(S(XeTeXcharglyph), LAST_ITEM, XETEX_MAP_CHAR_TO_GLYPH_CODE);
+        primitive(S(XeTeXglyphindex), LAST_ITEM, XETEX_GLYPH_INDEX_CODE);
+        primitive(S(XeTeXglyphbounds), LAST_ITEM, XETEX_GLYPH_BOUNDS_CODE);
 
-	primitive(S(XeTeXglyphname), CONVERT, XETEX_GLYPH_NAME_CODE);
+        primitive(S(XeTeXglyphname), CONVERT, XETEX_GLYPH_NAME_CODE);
 
-	primitive(S(XeTeXfonttype), LAST_ITEM, XETEX_FONT_TYPE_CODE);
-	primitive(S(XeTeXfirstfontchar), LAST_ITEM, XETEX_FIRST_CHAR_CODE);
-	primitive(S(XeTeXlastfontchar), LAST_ITEM, XETEX_LAST_CHAR_CODE);
-	primitive(S(pdflastxpos), LAST_ITEM, PDF_LAST_X_POS_CODE);
-	primitive(S(pdflastypos), LAST_ITEM, PDF_LAST_Y_POS_CODE);
+        primitive(S(XeTeXfonttype), LAST_ITEM, XETEX_FONT_TYPE_CODE);
+        primitive(S(XeTeXfirstfontchar), LAST_ITEM, XETEX_FIRST_CHAR_CODE);
+        primitive(S(XeTeXlastfontchar), LAST_ITEM, XETEX_LAST_CHAR_CODE);
+        primitive(S(pdflastxpos), LAST_ITEM, PDF_LAST_X_POS_CODE);
+        primitive(S(pdflastypos), LAST_ITEM, PDF_LAST_Y_POS_CODE);
 
-	primitive(S(strcmp), CONVERT, PDF_STRCMP_CODE);
-	primitive(S(mdfivesum), CONVERT, PDF_MDFIVE_SUM_CODE);
+        primitive(S(strcmp), CONVERT, PDF_STRCMP_CODE);
+        primitive(S(mdfivesum), CONVERT, PDF_MDFIVE_SUM_CODE);
 
-	primitive(S(shellescape), LAST_ITEM, PDF_SHELL_ESCAPE_CODE);
-	primitive(S(XeTeXpdfpagecount), LAST_ITEM, XETEX_PDF_PAGE_COUNT_CODE);
+        primitive(S(shellescape), LAST_ITEM, PDF_SHELL_ESCAPE_CODE);
+        primitive(S(XeTeXpdfpagecount), LAST_ITEM, XETEX_PDF_PAGE_COUNT_CODE);
 
-	primitive(S(everyeof), ASSIGN_TOKS, LOCAL_BASE + LOCAL__every_eof);
+        primitive(S(everyeof), ASSIGN_TOKS, LOCAL_BASE + LOCAL__every_eof);
 
-	primitive(S(tracingassigns), ASSIGN_INT, INT_BASE + INT_PAR__tracing_assigns);
-	primitive(S(tracinggroups), ASSIGN_INT, INT_BASE + INT_PAR__tracing_groups);
-	primitive(S(tracingifs), ASSIGN_INT, INT_BASE + INT_PAR__tracing_ifs);
-	primitive(S(tracingscantokens), ASSIGN_INT, INT_BASE + INT_PAR__tracing_scan_tokens);
-	primitive(S(tracingnesting), ASSIGN_INT, INT_BASE + INT_PAR__tracing_nesting);
-	primitive(S(predisplaydirection), ASSIGN_INT, INT_BASE + INT_PAR__pre_display_correction);
-	primitive(S(lastlinefit), ASSIGN_INT, INT_BASE + INT_PAR__last_line_fit);
-	primitive(S(savingvdiscards), ASSIGN_INT, INT_BASE + INT_PAR__saving_vdiscards);
-	primitive(S(savinghyphcodes), ASSIGN_INT, INT_BASE + INT_PAR__saving_hyphs);
+        primitive(S(tracingassigns), ASSIGN_INT, INT_BASE + INT_PAR__tracing_assigns);
+        primitive(S(tracinggroups), ASSIGN_INT, INT_BASE + INT_PAR__tracing_groups);
+        primitive(S(tracingifs), ASSIGN_INT, INT_BASE + INT_PAR__tracing_ifs);
+        primitive(S(tracingscantokens), ASSIGN_INT, INT_BASE + INT_PAR__tracing_scan_tokens);
+        primitive(S(tracingnesting), ASSIGN_INT, INT_BASE + INT_PAR__tracing_nesting);
+        primitive(S(predisplaydirection), ASSIGN_INT, INT_BASE + INT_PAR__pre_display_correction);
+        primitive(S(lastlinefit), ASSIGN_INT, INT_BASE + INT_PAR__last_line_fit);
+        primitive(S(savingvdiscards), ASSIGN_INT, INT_BASE + INT_PAR__saving_vdiscards);
+        primitive(S(savinghyphcodes), ASSIGN_INT, INT_BASE + INT_PAR__saving_hyphs);
 
-	primitive(S(currentgrouplevel), LAST_ITEM, CURRENT_GROUP_LEVEL_CODE);
-	primitive(S(currentgrouptype), LAST_ITEM, CURRENT_GROUP_TYPE_CODE);
-	primitive(S(currentiflevel), LAST_ITEM, CURRENT_IF_LEVEL_CODE);
-	primitive(S(currentiftype), LAST_ITEM, CURRENT_IF_TYPE_CODE);
-	primitive(S(currentifbranch), LAST_ITEM, CURRENT_IF_BRANCH_CODE);
-	primitive(S(fontcharwd), LAST_ITEM, FONT_CHAR_WD_CODE);
-	primitive(S(fontcharht), LAST_ITEM, FONT_CHAR_HT_CODE);
-	primitive(S(fontchardp), LAST_ITEM, FONT_CHAR_DP_CODE);
-	primitive(S(fontcharic), LAST_ITEM, FONT_CHAR_IC_CODE);
-	primitive(S(parshapelength), LAST_ITEM, PAR_SHAPE_LENGTH_CODE);
-	primitive(S(parshapeindent), LAST_ITEM, PAR_SHAPE_INDENT_CODE);
-	primitive(S(parshapedimen), LAST_ITEM, PAR_SHAPE_DIMEN_CODE);
+        primitive(S(currentgrouplevel), LAST_ITEM, CURRENT_GROUP_LEVEL_CODE);
+        primitive(S(currentgrouptype), LAST_ITEM, CURRENT_GROUP_TYPE_CODE);
+        primitive(S(currentiflevel), LAST_ITEM, CURRENT_IF_LEVEL_CODE);
+        primitive(S(currentiftype), LAST_ITEM, CURRENT_IF_TYPE_CODE);
+        primitive(S(currentifbranch), LAST_ITEM, CURRENT_IF_BRANCH_CODE);
+        primitive(S(fontcharwd), LAST_ITEM, FONT_CHAR_WD_CODE);
+        primitive(S(fontcharht), LAST_ITEM, FONT_CHAR_HT_CODE);
+        primitive(S(fontchardp), LAST_ITEM, FONT_CHAR_DP_CODE);
+        primitive(S(fontcharic), LAST_ITEM, FONT_CHAR_IC_CODE);
+        primitive(S(parshapelength), LAST_ITEM, PAR_SHAPE_LENGTH_CODE);
+        primitive(S(parshapeindent), LAST_ITEM, PAR_SHAPE_INDENT_CODE);
+        primitive(S(parshapedimen), LAST_ITEM, PAR_SHAPE_DIMEN_CODE);
 
-	primitive(S(showgroups), XRAY, SHOW_GROUPS);
-	primitive(S(showtokens), XRAY, SHOW_TOKENS);
+        primitive(S(showgroups), XRAY, SHOW_GROUPS);
+        primitive(S(showtokens), XRAY, SHOW_TOKENS);
 
-	primitive(S(unexpanded), THE, 1);
-	primitive(S(detokenize), THE, SHOW_TOKENS);
+        primitive(S(unexpanded), THE, 1);
+        primitive(S(detokenize), THE, SHOW_TOKENS);
 
-	primitive(S(showifs), XRAY, SHOW_IFS);
+        primitive(S(showifs), XRAY, SHOW_IFS);
 
-	primitive(S(interactionmode), SET_PAGE_INT, 2);
+        primitive(S(interactionmode), SET_PAGE_INT, 2);
 
-	primitive(S(middle), LEFT_RIGHT, 1);
+        primitive(S(middle), LEFT_RIGHT, 1);
 
-	primitive(S(suppressfontnotfounderror), ASSIGN_INT, INT_BASE + INT_PAR__suppress_fontnotfound_error);
+        primitive(S(suppressfontnotfounderror), ASSIGN_INT, INT_BASE + INT_PAR__suppress_fontnotfound_error);
 
-	primitive(S(TeXXeTstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__texxet);
-	primitive(S(XeTeXupwardsmode), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_upwards);
-	primitive(S(XeTeXuseglyphmetrics), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_use_glyph_metrics);
-	primitive(S(XeTeXinterchartokenstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_inter_char_tokens);
-	primitive(S(XeTeXdashbreakstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_dash_break);
-	primitive(S(XeTeXinputnormalization), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_input_normalization);
-	primitive(S(XeTeXtracingfonts), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_tracing_fonts);
-	primitive(S(XeTeXinterwordspaceshaping), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_interword_space_shaping);
-	primitive(S(XeTeXgenerateactualtext), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_generate_actual_text);
-	primitive(S(XeTeXhyphenatablelength), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_hyphenatable_length);
+        primitive(S(TeXXeTstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__texxet);
+        primitive(S(XeTeXupwardsmode), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_upwards);
+        primitive(S(XeTeXuseglyphmetrics), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_use_glyph_metrics);
+        primitive(S(XeTeXinterchartokenstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_inter_char_tokens);
+        primitive(S(XeTeXdashbreakstate), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_dash_break);
+        primitive(S(XeTeXinputnormalization), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_input_normalization);
+        primitive(S(XeTeXtracingfonts), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_tracing_fonts);
+        primitive(S(XeTeXinterwordspaceshaping), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_interword_space_shaping);
+        primitive(S(XeTeXgenerateactualtext), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_generate_actual_text);
+        primitive(S(XeTeXhyphenatablelength), ASSIGN_INT, ETEX_STATE_BASE + STATE_INT__xetex_hyphenatable_length);
 
-	primitive(S(XeTeXinputencoding), EXTENSION, XETEX_INPUT_ENCODING_EXTENSION_CODE);
-	primitive(S(XeTeXdefaultencoding), EXTENSION, XETEX_DEFAULT_ENCODING_EXTENSION_CODE);
+        primitive(S(XeTeXinputencoding), EXTENSION, XETEX_INPUT_ENCODING_EXTENSION_CODE);
+        primitive(S(XeTeXdefaultencoding), EXTENSION, XETEX_DEFAULT_ENCODING_EXTENSION_CODE);
 
-	primitive(S(beginL), VALIGN, BEGIN_L_CODE);
-	primitive(S(endL), VALIGN, END_L_CODE);
-	primitive(S(beginR), VALIGN, BEGIN_R_CODE);
-	primitive(S(endR), VALIGN, END_R_CODE);
+        primitive(S(beginL), VALIGN, BEGIN_L_CODE);
+        primitive(S(endL), VALIGN, END_L_CODE);
+        primitive(S(beginR), VALIGN, BEGIN_R_CODE);
+        primitive(S(endR), VALIGN, END_R_CODE);
 
-	primitive(S(scantokens), INPUT, 2);
-	primitive(S(readline), READ_TO_CS, 1);
-	primitive(S(unless), EXPAND_AFTER, 1);
+        primitive(S(scantokens), INPUT, 2);
+        primitive(S(readline), READ_TO_CS, 1);
+        primitive(S(unless), EXPAND_AFTER, 1);
 
-	primitive(S(ifdefined), IF_TEST, IF_DEF_CODE);
-	primitive(S(ifcsname), IF_TEST, IF_CS_CODE);
-	primitive(S(iffontchar), IF_TEST, IF_FONT_CHAR_CODE);
-	primitive(S(ifincsname), IF_TEST, IF_IN_CSNAME_CODE);
+        primitive(S(ifdefined), IF_TEST, IF_DEF_CODE);
+        primitive(S(ifcsname), IF_TEST, IF_CS_CODE);
+        primitive(S(iffontchar), IF_TEST, IF_FONT_CHAR_CODE);
+        primitive(S(ifincsname), IF_TEST, IF_IN_CSNAME_CODE);
 
-	primitive(S(protected), PREFIX, 8);
+        primitive(S(protected), PREFIX, 8);
 
-	primitive(S(numexpr), LAST_ITEM, ETEX_EXPR + 0);
-	primitive(S(dimexpr), LAST_ITEM, ETEX_EXPR + 1);
-	primitive(S(glueexpr), LAST_ITEM, ETEX_EXPR + 2);
-	primitive(S(muexpr), LAST_ITEM, ETEX_EXPR + 3);
-	primitive(S(gluestretchorder), LAST_ITEM, GLUE_STRETCH_ORDER_CODE);
-	primitive(S(glueshrinkorder), LAST_ITEM, GLUE_SHRINK_ORDER_CODE);
-	primitive(S(gluestretch), LAST_ITEM, GLUE_STRETCH_CODE);
-	primitive(S(glueshrink), LAST_ITEM, GLUE_SHRINK_CODE);
-	primitive(S(mutoglue), LAST_ITEM, MU_TO_GLUE_CODE);
-	primitive(S(gluetomu), LAST_ITEM, GLUE_TO_MU_CODE);
+        primitive(S(numexpr), LAST_ITEM, ETEX_EXPR + 0);
+        primitive(S(dimexpr), LAST_ITEM, ETEX_EXPR + 1);
+        primitive(S(glueexpr), LAST_ITEM, ETEX_EXPR + 2);
+        primitive(S(muexpr), LAST_ITEM, ETEX_EXPR + 3);
+        primitive(S(gluestretchorder), LAST_ITEM, GLUE_STRETCH_ORDER_CODE);
+        primitive(S(glueshrinkorder), LAST_ITEM, GLUE_SHRINK_ORDER_CODE);
+        primitive(S(gluestretch), LAST_ITEM, GLUE_STRETCH_CODE);
+        primitive(S(glueshrink), LAST_ITEM, GLUE_SHRINK_CODE);
+        primitive(S(mutoglue), LAST_ITEM, MU_TO_GLUE_CODE);
+        primitive(S(gluetomu), LAST_ITEM, GLUE_TO_MU_CODE);
 
-	primitive(S(marks), MARK, 5);
-	primitive(S(topmarks), TOP_BOT_MARK, TOP_MARK_CODE + 5);
-	primitive(S(firstmarks), TOP_BOT_MARK, FIRST_MARK_CODE + 5);
-	primitive(S(botmarks), TOP_BOT_MARK, BOT_MARK_CODE + 5);
-	primitive(S(splitfirstmarks), TOP_BOT_MARK, SPLIT_FIRST_MARK_CODE + 5);
-	primitive(S(splitbotmarks), TOP_BOT_MARK, SPLIT_BOT_MARK_CODE + 5);
+        primitive(S(marks), MARK, 5);
+        primitive(S(topmarks), TOP_BOT_MARK, TOP_MARK_CODE + 5);
+        primitive(S(firstmarks), TOP_BOT_MARK, FIRST_MARK_CODE + 5);
+        primitive(S(botmarks), TOP_BOT_MARK, BOT_MARK_CODE + 5);
+        primitive(S(splitfirstmarks), TOP_BOT_MARK, SPLIT_FIRST_MARK_CODE + 5);
+        primitive(S(splitbotmarks), TOP_BOT_MARK, SPLIT_BOT_MARK_CODE + 5);
 
-	primitive(S(pagediscards), UN_VBOX, LAST_BOX_CODE);
-	primitive(S(splitdiscards), UN_VBOX, VSPLIT_CODE);
+        primitive(S(pagediscards), UN_VBOX, LAST_BOX_CODE);
+        primitive(S(splitdiscards), UN_VBOX, VSPLIT_CODE);
 
-	primitive(S(interlinepenalties), SET_SHAPE, INTER_LINE_PENALTIES_LOC);
-	primitive(S(clubpenalties), SET_SHAPE, CLUB_PENALTIES_LOC);
-	primitive(S(widowpenalties), SET_SHAPE, WIDOW_PENALTIES_LOC);
-	primitive(S(displaywidowpenalties), SET_SHAPE, DISPLAY_WIDOW_PENALTIES_LOC);
+        primitive(S(interlinepenalties), SET_SHAPE, INTER_LINE_PENALTIES_LOC);
+        primitive(S(clubpenalties), SET_SHAPE, CLUB_PENALTIES_LOC);
+        primitive(S(widowpenalties), SET_SHAPE, WIDOW_PENALTIES_LOC);
+        primitive(S(displaywidowpenalties), SET_SHAPE, DISPLAY_WIDOW_PENALTIES_LOC);
 
-	max_reg_num = 32767;
-	max_reg_help_line = S(A_register_number_must_be_be_Z1);
+        max_reg_num = 32767;
+        max_reg_help_line = S(A_register_number_must_be_be_Z1);
     }
 
     no_new_control_sequence = true;
 
     if (!in_initex_mode) {
-	if (!load_fmt_file())
-	    return history;
+        if (!load_fmt_file())
+            return history;
     }
 
     eqtb = the_eqtb;
 
     if (INTPAR(end_line_char) < 0 || INTPAR(end_line_char) > BIGGEST_CHAR)
-	cur_input.limit--;
+        cur_input.limit--;
     else
-	buffer[cur_input.limit] = INTPAR(end_line_char);
+        buffer[cur_input.limit] = INTPAR(end_line_char);
 
     if (in_initex_mode) {
         /* TeX initializes with the real date and time, but for format file
@@ -4188,88 +4188,88 @@ tt_run_engine(char *input_file_name)
     }
 
     if (trie_not_ready) {
-	trie_trl = xmalloc_array(trie_pointer, trie_size);
-	trie_tro = xmalloc_array(trie_pointer, trie_size);
-	trie_trc = xmalloc_array(uint16_t, trie_size);
-	trie_c = xmalloc_array(packed_UTF16_code, trie_size);
-	trie_o = xmalloc_array(trie_opcode, trie_size);
-	trie_l = xmalloc_array(trie_pointer, trie_size);
-	trie_r = xmalloc_array(trie_pointer, trie_size);
-	trie_hash = xmalloc_array(trie_pointer, trie_size);
-	trie_taken = xmalloc_array(boolean, trie_size);
-	trie_l[0] = 0;
-	trie_c[0] = 0;
-	trie_ptr = 0;
-	trie_r[0] = 0;
-	hyph_start = 0;
-	font_mapping = xmalloc_array(void *, font_max);
-	font_layout_engine = xmalloc_array(void *, font_max);
-	font_flags = xmalloc_array(char, font_max);
-	font_letter_space = xmalloc_array(scaled, font_max);
-	font_check = xmalloc_array(four_quarters, font_max);
-	font_size = xmalloc_array(scaled, font_max);
-	font_dsize = xmalloc_array(scaled, font_max);
-	font_params = xmalloc_array(font_index, font_max);
-	font_name = xmalloc_array(str_number, font_max);
-	font_area = xmalloc_array(str_number, font_max);
-	font_bc = xmalloc_array(UTF16_code, font_max);
-	font_ec = xmalloc_array(UTF16_code, font_max);
-	font_glue = xmalloc_array(int32_t, font_max);
-	hyphen_char = xmalloc_array(integer, font_max);
-	skew_char = xmalloc_array(integer, font_max);
-	bchar_label = xmalloc_array(font_index, font_max);
-	font_bchar = xmalloc_array(nine_bits, font_max);
-	font_false_bchar = xmalloc_array(nine_bits, font_max);
-	char_base = xmalloc_array(integer, font_max);
-	width_base = xmalloc_array(integer, font_max);
-	height_base = xmalloc_array(integer, font_max);
-	depth_base = xmalloc_array(integer, font_max);
-	italic_base = xmalloc_array(integer, font_max);
-	lig_kern_base = xmalloc_array(integer, font_max);
-	kern_base = xmalloc_array(integer, font_max);
-	exten_base = xmalloc_array(integer, font_max);
-	param_base = xmalloc_array(integer, font_max);
-	font_ptr = FONT_BASE;
-	fmem_ptr = 7;
-	font_name[FONT_BASE] = S(nullfont);
-	font_area[FONT_BASE] = S();
-	hyphen_char[FONT_BASE] = 45 /*"-" */;
-	skew_char[FONT_BASE] = -1;
-	bchar_label[FONT_BASE] = NON_ADDRESS;
-	font_bchar[FONT_BASE] = TOO_BIG_CHAR;
-	font_false_bchar[FONT_BASE] = TOO_BIG_CHAR;
-	font_bc[FONT_BASE] = 1;
-	font_ec[FONT_BASE] = 0;
-	font_size[FONT_BASE] = 0;
-	font_dsize[FONT_BASE] = 0;
-	char_base[FONT_BASE] = 0;
-	width_base[FONT_BASE] = 0;
-	height_base[FONT_BASE] = 0;
-	depth_base[FONT_BASE] = 0;
-	italic_base[FONT_BASE] = 0;
-	lig_kern_base[FONT_BASE] = 0;
-	kern_base[FONT_BASE] = 0;
-	exten_base[FONT_BASE] = 0;
-	font_glue[FONT_BASE] = MIN_HALFWORD;
-	font_params[FONT_BASE] = 7;
-	font_mapping[FONT_BASE] = 0;
-	param_base[FONT_BASE] = -1;
+        trie_trl = xmalloc_array(trie_pointer, trie_size);
+        trie_tro = xmalloc_array(trie_pointer, trie_size);
+        trie_trc = xmalloc_array(uint16_t, trie_size);
+        trie_c = xmalloc_array(packed_UTF16_code, trie_size);
+        trie_o = xmalloc_array(trie_opcode, trie_size);
+        trie_l = xmalloc_array(trie_pointer, trie_size);
+        trie_r = xmalloc_array(trie_pointer, trie_size);
+        trie_hash = xmalloc_array(trie_pointer, trie_size);
+        trie_taken = xmalloc_array(boolean, trie_size);
+        trie_l[0] = 0;
+        trie_c[0] = 0;
+        trie_ptr = 0;
+        trie_r[0] = 0;
+        hyph_start = 0;
+        font_mapping = xmalloc_array(void *, font_max);
+        font_layout_engine = xmalloc_array(void *, font_max);
+        font_flags = xmalloc_array(char, font_max);
+        font_letter_space = xmalloc_array(scaled, font_max);
+        font_check = xmalloc_array(four_quarters, font_max);
+        font_size = xmalloc_array(scaled, font_max);
+        font_dsize = xmalloc_array(scaled, font_max);
+        font_params = xmalloc_array(font_index, font_max);
+        font_name = xmalloc_array(str_number, font_max);
+        font_area = xmalloc_array(str_number, font_max);
+        font_bc = xmalloc_array(UTF16_code, font_max);
+        font_ec = xmalloc_array(UTF16_code, font_max);
+        font_glue = xmalloc_array(int32_t, font_max);
+        hyphen_char = xmalloc_array(integer, font_max);
+        skew_char = xmalloc_array(integer, font_max);
+        bchar_label = xmalloc_array(font_index, font_max);
+        font_bchar = xmalloc_array(nine_bits, font_max);
+        font_false_bchar = xmalloc_array(nine_bits, font_max);
+        char_base = xmalloc_array(integer, font_max);
+        width_base = xmalloc_array(integer, font_max);
+        height_base = xmalloc_array(integer, font_max);
+        depth_base = xmalloc_array(integer, font_max);
+        italic_base = xmalloc_array(integer, font_max);
+        lig_kern_base = xmalloc_array(integer, font_max);
+        kern_base = xmalloc_array(integer, font_max);
+        exten_base = xmalloc_array(integer, font_max);
+        param_base = xmalloc_array(integer, font_max);
+        font_ptr = FONT_BASE;
+        fmem_ptr = 7;
+        font_name[FONT_BASE] = S(nullfont);
+        font_area[FONT_BASE] = S();
+        hyphen_char[FONT_BASE] = 45 /*"-" */;
+        skew_char[FONT_BASE] = -1;
+        bchar_label[FONT_BASE] = NON_ADDRESS;
+        font_bchar[FONT_BASE] = TOO_BIG_CHAR;
+        font_false_bchar[FONT_BASE] = TOO_BIG_CHAR;
+        font_bc[FONT_BASE] = 1;
+        font_ec[FONT_BASE] = 0;
+        font_size[FONT_BASE] = 0;
+        font_dsize[FONT_BASE] = 0;
+        char_base[FONT_BASE] = 0;
+        width_base[FONT_BASE] = 0;
+        height_base[FONT_BASE] = 0;
+        depth_base[FONT_BASE] = 0;
+        italic_base[FONT_BASE] = 0;
+        lig_kern_base[FONT_BASE] = 0;
+        kern_base[FONT_BASE] = 0;
+        exten_base[FONT_BASE] = 0;
+        font_glue[FONT_BASE] = MIN_HALFWORD;
+        font_params[FONT_BASE] = 7;
+        font_mapping[FONT_BASE] = 0;
+        param_base[FONT_BASE] = -1;
 
-	for (font_k = 0; font_k <= 6; font_k++)
-	    font_info[font_k].cint = 0;
+        for (font_k = 0; font_k <= 6; font_k++)
+            font_info[font_k].cint = 0;
     }
 
     font_used = xmalloc_array(boolean, font_max);
     for (font_k = 0; font_k <= font_max; font_k++)
-	font_used[font_k] = false;
+        font_used[font_k] = false;
 
     /* This is only used in mlist_to_hlist() and I don't even want to know why. */
     magic_offset = str_start[MATH_SPACING - 65536L] - 9 * ORD_NOAD/*:794*/;
 
     if (interaction == BATCH_MODE)
-	selector = SELECTOR_NO_PRINT;
+        selector = SELECTOR_NO_PRINT;
     else
-	selector = SELECTOR_TERM_ONLY; /*:79*/
+        selector = SELECTOR_TERM_ONLY; /*:79*/
 
     /* OK, we are finally ready to go! We have synthesized a "first line" in
      * cur_input that has the file name. Calling start_input() essentially
@@ -4300,7 +4300,7 @@ dvipdfmx_simple_main(char *dviname, char *pdfname)
     char *argv[] = { "dvipdfmx", "-o", pdfname, dviname };
 
     if (setjmp (jump_buffer))
-	return 99;
+        return 99;
 
     return dvipdfmx_main(4, argv);
 }

--- a/tectonic/xetexini.c
+++ b/tectonic/xetexini.c
@@ -71,7 +71,7 @@ swap_items (char *p, int nitems, int size)
         _tt_abort("can't swap a %d-byte item for (un)dumping", size);
     }
 }
-#else  /* not WORDS_BIGENDIAN */
+#else /* not WORDS_BIGENDIAN */
 #define swap_items(a,b,c) do {} while(0)
 #endif
 
@@ -108,9 +108,9 @@ do_undump (char *p, int item_size, int nitems, rust_input_handle_t in_file)
 }
 
 
-#define	dump_things(base, len)                                          \
+#define dump_things(base, len) \
     do_dump ((char *) &(base), sizeof (base), (int) (len), fmt_out)
-#define	undump_things(base, len)                                        \
+#define undump_things(base, len) \
     do_undump ((char *) &(base), sizeof (base), (int) (len), fmt_in)
 
 /* Like do_undump, but check each value against LOW and HIGH.  The
@@ -118,7 +118,7 @@ do_undump (char *p, int item_size, int nitems, rust_input_handle_t in_file)
    detecting incompatible format files.  In fact, Knuth himself noted
    this problem with Web2c some years ago, so it seems worth fixing.  We
    can't make this a subroutine because then we lose the type of BASE.  */
-#define undump_checked_things(low, high, base, len)			\
+#define undump_checked_things(low, high, base, len)                     \
     do {                                                                \
         unsigned i;                                                     \
         undump_things (base, len);                                      \
@@ -140,7 +140,7 @@ do_undump (char *p, int item_size, int nitems, rust_input_handle_t in_file)
         unsigned i;                                                     \
         undump_things (base, len);                                      \
         for (i = 0; i < (len); i++) {                                   \
-            if ((&(base))[i] > (high)) {              			\
+            if ((&(base))[i] > (high)) {                                \
                 _tt_abort ("Item %u (=%" PRIdPTR ") of .fmt array at %" PRIxPTR \
                            " >%" PRIdPTR,                               \
                            i, (uintptr_t) (&(base))[i], (uintptr_t) &(base), \
@@ -156,17 +156,17 @@ do_undump (char *p, int item_size, int nitems, rust_input_handle_t in_file)
 #define dump_qqqq(x) dump_things(x, 1)
 #define undump_wd(x) undump_things(x, 1)
 #define undump_hh(x) undump_things(x, 1)
-#define	undump_qqqq(x) undump_things(x, 1)
+#define undump_qqqq(x) undump_things(x, 1)
 
 /* `dump_int' is called with constant integers, so we put them into a
    variable first.  */
-#define dump_int(x)                             \
-    do {                                        \
-        integer x_val = (x);                    \
-        dump_things(x_val, 1);                  \
+#define dump_int(x)            \
+    do {                       \
+        integer x_val = (x);   \
+        dump_things(x_val, 1); \
     } while (0)
 
-#define	undump_int(x) undump_things(x, 1)
+#define undump_int(x) undump_things(x, 1)
 
 
 #define hash_offset 514


### PR DESCRIPTION
Hey,
while strolling through the codebase I noticed some inconsistencies in indentation.
I wrote a little script to fix the mixed indentation and remove trailing whitespace.
I guess [elastic tabstops](http://nickgravgaard.com/elastic-tabstops/) aren't a thing yet so this might be the best compromise.

-   There are still some inconsistencies left to fix
    (`Engine.*`, `TECkit_*` and the data table files are left untouched)
- [x] The changes should probably be split up into commits of different importance
- [x] The changes to Engine{.cpp,.h} are mostly opinionated and should probably not be included
- [x] ~Try not to overshadow `git-blame`~ TIL: `git blame -w`