### PR TITLE
Handle filenames with spaces

### DIFF
--- a/tectonic/xetexini.c
+++ b/tectonic/xetexini.c
@@ -2865,6 +2865,8 @@ init_io(string input_file_name)
     buffer[first] = 0;
     k = first;
 
+    buffer[k++] = '"'; /* Quote filename so xetex accepts spaces */
+
     while ((rval = *(ptr++)) != 0) {
         UInt16 extraBytes = bytesFromUTF8[rval];
 
@@ -2881,7 +2883,8 @@ init_io(string input_file_name)
         buffer[k++] = rval;
     }
 
-    buffer[k] = ' ';
+    buffer[k++] = '"'; /* Quote filename so xetex accepts spaces */
+    buffer[k] = ' ';   /* Unquoted space terminates filename for xetex engine */
     last = k;
     cur_input.loc = first;
     cur_input.limit = last;


### PR DESCRIPTION
- This breaks all tests, because expected filenames no longer match the ones that are actually written. @pkgw I would appreciate your input on how to fix this, or what should be done about it.
- There was originally a test added in this PR for the behavior, but it failed even after the change was made (and not for the quoting reason.) I don't know what was wrong with it, but a better test should be written instead.

For my notes while developing this, see my comments in #36.