### PR TITLE
Support amsrefs

### DIFF
--- a/src/cli_driver.rs
+++ b/src/cli_driver.rs
@@ -548,8 +548,8 @@ impl ProcessingSession {
 
             let use_bibtex = {
                 if let Some(auxdata) = self.io.mem.files.borrow().get(self.aux_path.as_os_str()) {
-                    let cite_aut = AcAutomaton::new(vec!["\\citation", "\\bibcite"]);
-                    cite_aut.find(auxdata).count() > 0
+                    let cite_aut = AcAutomaton::new(vec!["\\bibdata"]);
+                    cite_aut.find(auxdata).next().is_some()
                 } else {
                     false
                 }


### PR DESCRIPTION
This commit changes the condition that decides whether bibtex is run to
finding `\bibdata` in the aux file (was `\citation` and `\bibcite`).
Since bibtex exits with an error if it does not find `\bibdata` anyway,
this avoids running bibtex unecessarily when for instance amsrefs is
used to process the bibliography.

I also replaced `find(...).count() > 0` by `find(...).next().is_some()`: no need to go through the whole file, stop at the first match.