### PR TITLE
Make cached bundle files readonly

### DIFF
--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -307,6 +307,8 @@ impl<B: IoProvider> LocalCache<B> {
         }
 
         // Make the file readonly once it's at its final path.
+        // XXX: It would be better to set these using the already-open file handle owned by the
+        // tempfile, but mkstemp doesn't give us access.
         let mut perms = match fs::metadata(&final_path) {
             Ok(p) => p,
             Err(e) => return OpenResult::Err(e.into()),


### PR DESCRIPTION
- After moving new cache files to their final destination, set their
  permissions to have `readonly` set `true`.
- This uses `fs::set_permissions` rather than the suggested
  ``fs::File::set_permissions`, because the latter would require the final
  file to be open. We cannot change the permissions on the tempfile in
  this way, because `mkstemp::TempFile` doesn't have the same
  `set_permissions` method.

Close #14