### PR TITLE
Rerun build.rs only on changes in the tectonic/ dir

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -274,4 +274,10 @@ fn main() {
 
     ccfg.compile("libtectonic_c.a");
     cppcfg.compile("libtectonic_cpp.a");
+
+    // Tell cargo to rerun build.rs only if files in the tectonic/ directory have changed.
+    for file in PathBuf::from("tectonic").read_dir().unwrap() {
+        let file = file.unwrap();
+        println!("cargo:rerun-if-changed={}", file.path().display());
+    }
 }


### PR DESCRIPTION
This is really only a convenience for developers: there is not need to recompile the C/C++ code on every unrelated change in the repo.