### PR TITLE
Deploy releases to AUR automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
     - rust: nightly
 
 before_install:
-  - openssl aes-256-cbc -K $encrypted_bc40b17e21fa_key -iv $encrypted_bc40b17e21fa_iv
-    -in dist/deploy_key.enc -out dist/deploy_key -d
   - brew update
 
 install:
@@ -40,3 +38,16 @@ script:
   - |
     cargo build --verbose &&
     cargo test
+
+before_deploy:
+  - openssl aes-256-cbc -K $encrypted_bc40b17e21fa_key -iv $encrypted_bc40b17e21fa_iv
+    -in dist/deploy_key.enc -out /tmp/deploy_key -d
+  - eval "$(ssh-agent -s)"
+  - chmod 600 /tmp/deploy_key
+  - ssh-add /tmp/deploy_key
+
+deploy:
+  provider: script
+  script: dist/arch/deploy.sh
+  on:
+    tags: true

--- a/dist/arch/deploy.sh
+++ b/dist/arch/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/env bash
+cd "$TRAVIS_BUILD_DIR/dist/arch"
+
+# Obtain mksrcinfo
+wget https://www.archlinux.org/packages/community/any/pkgbuild-introspection/download/ -O pkgbuild-introspection.tar.xz
+tar -Jxf pkgbuild-introspection.tar.xz usr/bin/mksrcinfo
+PATH="$PATH:$(pwd)/usr/bin"
+
+# Prepare directory for deploy
+git clone ssh://aur@aur.archlinux.org/tectonic.git aur
+cp PKGBUILD aur
+cd aur
+mksrcinfo
+
+git add PKGBUILD .SRCINFO
+git config user.email "tectonic-deploy@example.com"
+git config user.name "tectonic-deploy"
+git commit -m "Release $TRAVIS_TAG"
+
+# Deploy to AUR
+git push origin master


### PR DESCRIPTION
This uses Travis’s automatic deploy feature. Everytime a new version is tagged, the PKGBUILD file along with updated metadata will be uploaded to AUR.

Decrypting the private key was moved to the `before_deploy` stage, to limit the possibility of the key leaking.

Closes: #54