### PR TITLE
.travis.yml: new encryption stuff cannot run on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - brew update
 
 install:
+  - false
   - brew install graphite2
   - brew install harfbuzz --with-graphite2
   - brew install --force openssl


### PR DESCRIPTION
For security reasons, random PRs don't get access to our encrypted files and variables, so the `openssl` invocation that decrypts the SSH key has to be gated on whether the Travis run is *not* associated with a PR.