### PR TITLE
Fix #50: Normalize paths in MemoryIo

### DIFF
--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use errors::Result;
 use status::StatusBackend;
 use super::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle,
-            try_normalize_path};
+            normalize_tex_path};
 
 
 // MemoryIo is an IoProvider that stores "files" in in-memory buffers.
@@ -118,7 +118,7 @@ impl IoProvider for MemoryIo {
     fn output_open_name(&mut self, name: &OsStr) -> OpenResult<OutputHandle> {
         assert!(name.len() > 0, "name must be non-empty");
 
-        let name = try_normalize_path(name);
+        let name = normalize_tex_path(name);
 
         OpenResult::Ok(OutputHandle::new(&name, MemoryIoItem::new(&self.files, &name, true)))
     }
@@ -134,7 +134,7 @@ impl IoProvider for MemoryIo {
     fn input_open_name(&mut self, name: &OsStr, _status: &mut StatusBackend) -> OpenResult<InputHandle> {
         assert!(name.len() > 0, "name must be non-empty");
 
-        let name = try_normalize_path(name);
+        let name = normalize_tex_path(name);
 
         if self.files.borrow().contains_key(&*name) {
             OpenResult::Ok(InputHandle::new(&name,

--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -10,7 +10,8 @@ use std::rc::Rc;
 
 use errors::Result;
 use status::StatusBackend;
-use super::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle};
+use super::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle,
+            try_normalize_path};
 
 
 // MemoryIo is an IoProvider that stores "files" in in-memory buffers.
@@ -116,7 +117,10 @@ impl MemoryIo {
 impl IoProvider for MemoryIo {
     fn output_open_name(&mut self, name: &OsStr) -> OpenResult<OutputHandle> {
         assert!(name.len() > 0, "name must be non-empty");
-        OpenResult::Ok(OutputHandle::new(name, MemoryIoItem::new(&self.files, name, true)))
+
+        let name = try_normalize_path(name);
+
+        OpenResult::Ok(OutputHandle::new(&name, MemoryIoItem::new(&self.files, &name, true)))
     }
 
     fn output_open_stdout(&mut self) -> OpenResult<OutputHandle> {
@@ -130,8 +134,12 @@ impl IoProvider for MemoryIo {
     fn input_open_name(&mut self, name: &OsStr, _status: &mut StatusBackend) -> OpenResult<InputHandle> {
         assert!(name.len() > 0, "name must be non-empty");
 
-        if self.files.borrow().contains_key(name) {
-            OpenResult::Ok(InputHandle::new(name, MemoryIoItem::new(&self.files, name, false), InputOrigin::Other))
+        let name = try_normalize_path(name);
+
+        if self.files.borrow().contains_key(&*name) {
+            OpenResult::Ok(InputHandle::new(&name,
+                                            MemoryIoItem::new(&self.files, &name, false),
+                                            InputOrigin::Other))
         } else {
             OpenResult::NotAvailable
         }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 use flate2::read::GzDecoder;
+use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
@@ -359,6 +360,74 @@ pub fn try_open_file(path: &Path) -> OpenResult<File> {
     }
 }
 
+/// Normalize a path in a system independent™ way by stripping any `.`, `..`,
+/// or extra separators '/' so that it is of the form
+///
+/// ```text
+/// path/to/my/file.txt
+/// ../../path/to/parent/dir/file.txt
+/// /absolute/path/to/file.txt
+/// ```
+///
+/// Does not strip whitespace.
+///
+/// Returns `None` if the path refers to a parent of the root.
+fn normalize_path(path: &str) -> Option<String> {
+    use std::iter::repeat;
+    if path.is_empty() {
+        return Some("".into());
+    }
+    let mut r = Vec::new();
+    let mut parent_level = 0;
+    let mut has_root = false;
+
+    // TODO: We need to handle a prefix on Windows (i.e. "C:").
+
+    for (i, c) in path.split('/').enumerate() {
+        match c {
+            "" if i == 0 => {
+                has_root = true;
+                r.push("");
+            }
+            "" | "." => {}
+            ".." => {
+                match r.pop() {
+                    // about to pop the root
+                    Some("") => return None,
+                    None => parent_level += 1,
+                    _ => {}
+                }
+            }
+            _ => r.push(c),
+        }
+    }
+
+    let r = repeat("..")
+        .take(parent_level)
+        .chain(r.into_iter())
+        // No `join` on `Iterator`.
+        .collect::<Vec<_>>()
+        .join("/");
+
+    if r.is_empty() {
+        if has_root {
+            Some("/".into())
+        } else {
+            Some(".".into())
+        }
+    } else {
+        Some(r)
+    }
+}
+
+/// Normalize a path using `normalize_path` if possible, otherwise return the original path.
+fn try_normalize_path(path: &OsStr) -> Cow<OsStr> {
+    if let Some(t) = path.to_str().and_then(normalize_path).map(OsString::from) {
+        Cow::Owned(t)
+    } else {
+        Cow::Borrowed(path)
+    }
+}
 
 // Helper for testing. FIXME: I want this to be conditionally compiled with
 // #[cfg(test)] but things break if I do that.
@@ -401,5 +470,41 @@ pub mod testing {
                 OpenResult::NotAvailable
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path() {
+        // edge cases
+        assert_eq!(normalize_path(""), Some("".into()));
+        assert_eq!(normalize_path("/"), Some("/".into()));
+        assert_eq!(normalize_path("."), Some(".".into()));
+        assert_eq!(normalize_path("./"), Some(".".into()));
+        assert_eq!(normalize_path(".."), Some("..".into()));
+        assert_eq!(normalize_path("./././"), Some(".".into()));
+        assert_eq!(normalize_path("/././."), Some("/".into()));
+
+        assert_eq!(normalize_path("my/path/file.txt"),
+                   Some("my/path/file.txt".into()));
+        // preserve spaces
+        assert_eq!(normalize_path("  my/pa  th/file .txt "),
+                   Some("  my/pa  th/file .txt ".into()));
+        assert_eq!(normalize_path("/my/path/file.txt"),
+                   Some("/my/path/file.txt".into()));
+        assert_eq!(normalize_path("./my/path/././file.txt"),
+                   Some("my/path/file.txt".into()));
+        assert_eq!(normalize_path("./../my/../../../file.txt"),
+                   Some("../../../file.txt".into()));
+        assert_eq!(normalize_path("././my/../path/../here/file.txt"),
+                   Some("here/file.txt".into()));
+        assert_eq!(normalize_path("./my/../path/../../here/file.txt"),
+                   Some("../here/file.txt".into()));
+
+        assert_eq!(normalize_path("/my/../../file.txt"), None);
+        assert_eq!(normalize_path("/my/./../path/../../file.txt"), None);
     }
 }


### PR DESCRIPTION
  - Only paths that are valid UTF8 are normalized.
  - `std::path::{Path,PathBuf}` are not used to normalize in a system
    independent way on Unix/Windows.
  - LaTeX identifies OS by testing if `./texsys.aux` exists. This file
    is created as `texsys.aux`. Without normalization, OS is
    misidentified and filename parsing in LaTeX code then produces wrong
    results. (See #50). This fixes the behavior (cache needs to be
    rebuilt).

Note: Normalization currently does not handle path prefix on Windows, but this can be added later (paths on Windows are hard, need to explore what is reasonable).