### PR TITLE
tests: write executable and regression testing suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,5 +64,8 @@ zip = "^0.2"
 # harfbuzz-sys = "^0.1"
 # libz-sys = "^1.0"
 
+[dev-dependencies]
+tempdir = "^0.3"
+
 [package.metadata.docs.rs]
 dependencies = ["libfontconfig1-dev", "libgraphite2-dev", "libharfbuzz-dev", "zlib1g-dev"]

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -1,0 +1,87 @@
+// Copyright 2016-2017 the Tectonic Project
+// Licensed under the MIT License.
+
+extern crate tempdir;
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::str;
+use tempdir::TempDir;
+
+fn run_tectonic(cwd: &Path, args: &[&str]) -> Output {
+    let tectonic = env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tectonic")
+        .with_extension(env::consts::EXE_EXTENSION);
+
+    match fs::metadata(&tectonic) {
+        Ok(_) => {}
+        Err(_) => {
+            panic!("tectonic binary not found at {:?}. Do you need to run `cargo build`?",
+                   tectonic)
+        }
+    }
+    println!("using tectonic binary at {:?}", tectonic);
+    println!("using cwd {:?}", cwd);
+
+    let mut command = Command::new(tectonic);
+    command.args(args);
+    command.current_dir(cwd);
+    println!("running {:?}", command);
+
+    return command.output().expect("tectonic failed to start");
+}
+
+fn setup_and_copy_files(files: &[&str]) -> TempDir {
+    let tempdir = TempDir::new("tectonic_executable_test").unwrap();
+
+    let exe = env::current_exe().unwrap();
+    let root = exe.parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let executable_test_dir = root.join("tests/executable");
+
+    for file in files {
+        fs::copy(executable_test_dir.join(file), tempdir.path().join(file)).unwrap();
+    }
+
+    return tempdir;
+}
+
+fn write_output(output: &Output) {
+    println!("status: {}", output.status);
+    println!("stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+}
+
+/* Keep tests alphabetized */
+
+#[test]
+fn help_flag() {
+    let tempdir = setup_and_copy_files(&[]);
+
+    let output = run_tectonic(tempdir.path(), &["-h"]);
+    write_output(&output); /* only printed on failure */
+    assert!(output.status.success());
+}
+
+// Regression #36
+#[test]
+fn test_space() {
+    let tempdir = setup_and_copy_files(&["test space.tex"]);
+
+    let output = run_tectonic(tempdir.path(), &["test space.tex"]);
+    write_output(&output); /* only printed on failure */
+    assert!(output.status.success());
+}

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -81,7 +81,7 @@ fn help_flag() {
 fn test_space() {
     let tempdir = setup_and_copy_files(&["test space.tex"]);
 
-    let output = run_tectonic(tempdir.path(), &["test space.tex"]);
+    let output = run_tectonic(tempdir.path(), &["--format=plain.fmt.gz", "test space.tex"]);
     write_output(&output); /* only printed on failure */
     assert!(output.status.success());
 }

--- a/tests/executable/test space.tex
+++ b/tests/executable/test space.tex
@@ -1,4 +1,3 @@
-\documentclass{article}
-\begin{document}
 This file has a name which contains spaces.
-\end{document}
+
+\bye

--- a/tests/executable/test space.tex
+++ b/tests/executable/test space.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\begin{document}
+This file has a name which contains spaces.
+\end{document}


### PR DESCRIPTION
The `tests/executable.rs` module includes tools for running the built
executable on a temporary directory, and for copying resources into the
temporary directory easily.

This will more easily let us reproduce reported issues, and test for
them automatically to prevent regressions.

This includes a regression test for #36