### PR TITLE
Reproduce #31

### DIFF
--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -95,7 +95,7 @@ fn help_flag() {
 }
 
 #[test]
-#[should_panic(expected = "failed to open input file \"content/1.tex\"")] // FIXME: GitHub #31
+#[ignore] // FIXME: GitHub #31
 fn relative_include() {
     let tempdir = setup_and_copy_files(&["subdirectory/relative_include.tex",
                                          "subdirectory/content/1.tex"]);

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -39,6 +39,13 @@ fn setup_and_copy_files(files: &[&str]) -> TempDir {
         .join("tests/executable");
 
     for file in files {
+        // Create parent directories, if the file is not at the root of `tests/executable/`
+        let file_path = PathBuf::from(file);
+        let parent_dir = file_path.parent().unwrap();
+        let mut dirbuilder = fs::DirBuilder::new();
+        dirbuilder.recursive(true);
+        dirbuilder.create(tempdir.path().join(parent_dir)).unwrap();
+
         fs::copy(executable_test_dir.join(file), tempdir.path().join(file)).unwrap();
     }
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -94,6 +94,17 @@ fn help_flag() {
     success_or_panic(output);
 }
 
+#[test]
+#[should_panic(expected = "failed to open input file \"content/1.tex\"")] // FIXME: GitHub #31
+fn relative_include() {
+    let tempdir = setup_and_copy_files(&["subdirectory/relative_include.tex",
+                                         "subdirectory/content/1.tex"]);
+
+    let output = run_tectonic(tempdir.path(),
+                              &["--format=plain.fmt.gz", "subdirectory/relative_include.tex"]);
+    success_or_panic(output);
+}
+
 // Regression #36
 #[test]
 fn test_space() {

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -71,10 +71,17 @@ pub fn cargo_dir() -> PathBuf {
         .unwrap_or_else(|| panic!("CARGO_BIN_PATH wasn't set. Cannot continue running test"))
 }
 
-fn write_output(output: &Output) {
-    println!("status: {}", output.status);
-    println!("stdout:\n{}", String::from_utf8_lossy(&output.stdout));
-    println!("stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+fn success_or_panic(output: Output) {
+    if output.status.success() {
+        println!("status: {}", output.status);
+        println!("stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+        println!("stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    } else {
+        panic!("Command exited badly:\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+               output.status,
+               String::from_utf8_lossy(&output.stdout),
+               String::from_utf8_lossy(&output.stderr));
+    }
 }
 
 /* Keep tests alphabetized */
@@ -84,8 +91,7 @@ fn help_flag() {
     let tempdir = setup_and_copy_files(&[]);
 
     let output = run_tectonic(tempdir.path(), &["-h"]);
-    write_output(&output); /* only printed on failure */
-    assert!(output.status.success());
+    success_or_panic(output);
 }
 
 // Regression #36
@@ -94,6 +100,5 @@ fn test_space() {
     let tempdir = setup_and_copy_files(&["test space.tex"]);
 
     let output = run_tectonic(tempdir.path(), &["--format=plain.fmt.gz", "test space.tex"]);
-    write_output(&output); /* only printed on failure */
-    assert!(output.status.success());
+    success_or_panic(output);
 }

--- a/tests/executable/subdirectory/content/1.tex
+++ b/tests/executable/subdirectory/content/1.tex
@@ -1,0 +1,3 @@
+This is content/1.tex
+
+\bye

--- a/tests/executable/subdirectory/relative_include.tex
+++ b/tests/executable/subdirectory/relative_include.tex
@@ -1,0 +1,5 @@
+This is the main document.
+
+\input content/1.tex
+
+\bye


### PR DESCRIPTION
This PR adds a failing test case for issue #31. The test case is prefixed with a reasonably specific `should_panic` decorator, and is noted with a `// FIXME` referring to issue #31. When that issue is fixed, this test case will begin to fail (because it will no longer panic) and the directive can be removed.

I would prefer that this test didn't simply succeed, but gave an "expected failure"-type annotation in the results, like PyTest does. I don't know that this behavior is possible in the current state of Cargo testing.