### PR TITLE
update: Update MAX_STRINGS value

### DIFF
--- a/tectonic/bibtex.c
+++ b/tectonic/bibtex.c
@@ -137,7 +137,7 @@ static jmp_buf error_jmpbuf, recover_jmpbuf;
 #define aux_stack_size 20
 #define MAX_BIB_FILES 20
 #define POOL_SIZE 65000L
-#define MAX_STRINGS 4000
+#define MAX_STRINGS 15000
 #define MAX_CITES 750
 #define WIZ_FN_SPACE 3000
 #define SINGLE_FN_SPACE 50


### PR DESCRIPTION
* Set the value of MAX_STRINGS to 15000. It turns out 10000 was not
  enough to cleanly build the example mentioned in #81 using
  (https://github.com/cryptobib/export_crossref/blob/118d812c4e1e8c462d3b1f226c02b9b1c6e4b505/abbrev0.bib).

* Fixes #79

Signed-off-by: mr.Shu <mr@shu.io>