### PR TITLE
Fix #63: do not panic into C

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -602,7 +602,7 @@ fn input_get_size<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle
     es.input_get_size(rhandle)
 }
 
-fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, offset: libc::ssize_t, whence: libc::c_int) -> libc::size_t {
+fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, offset: libc::ssize_t, whence: libc::c_int, internal_error: *mut libc::c_int) -> libc::size_t {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
 
@@ -611,9 +611,11 @@ fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *m
         libc::SEEK_CUR => SeekFrom::Current(offset as i64),
         libc::SEEK_END => SeekFrom::End(offset as i64),
         _ => {
-                // TODO: Handle the error better. This indicates a bug in the engine.
                 tt_error!(es.status, "serious internal bug: unexpected \"whence\" parameter to fseek() wrapper: {}",
                             whence);
+                unsafe {
+                    *internal_error = 1;
+                }
                 return 0;
         }
     };

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -468,21 +468,21 @@ extern {
 
 // Entry points for the C/C++ API functions.
 
-fn issue_warning<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, text: *const libc::c_char) {
+extern fn issue_warning<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, text: *const libc::c_char) {
     let es = unsafe { &mut *es };
     let rtext = unsafe { CStr::from_ptr(text) };
 
     tt_warning!(es.status, "{}", rtext.to_string_lossy());
 }
 
-fn issue_error<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, text: *const libc::c_char) {
+extern fn issue_error<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, text: *const libc::c_char) {
     let es = unsafe { &mut *es };
     let rtext = unsafe { CStr::from_ptr(text) };
 
     tt_error!(es.status, "{}", rtext.to_string_lossy());
 }
 
-fn get_file_md5<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, path: *const libc::c_char, digest: *mut u8) -> libc::c_int {
+extern fn get_file_md5<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, path: *const libc::c_char, digest: *mut u8) -> libc::c_int {
     let es = unsafe { &mut *es };
     let rpath = osstr_from_cstr(unsafe { CStr::from_ptr(path) });
     let rdest = unsafe { slice::from_raw_parts_mut(digest, 16) };
@@ -494,7 +494,7 @@ fn get_file_md5<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, path: *c
     }
 }
 
-fn get_data_md5<'a, I: 'a + IoProvider>(_es: *mut ExecutionState<'a, I>, data: *const u8, len: libc::size_t, digest: *mut u8) -> libc::c_int {
+extern fn get_data_md5<'a, I: 'a + IoProvider>(_es: *mut ExecutionState<'a, I>, data: *const u8, len: libc::size_t, digest: *mut u8) -> libc::c_int {
     //let es = unsafe { &mut *es };
     let rdata = unsafe { slice::from_raw_parts(data, len) };
     let rdest = unsafe { slice::from_raw_parts_mut(digest, 16) };
@@ -507,7 +507,7 @@ fn get_data_md5<'a, I: 'a + IoProvider>(_es: *mut ExecutionState<'a, I>, data: *
     0
 }
 
-fn output_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *const libc::c_char, is_gz: libc::c_int) -> *const libc::c_void {
+extern fn output_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *const libc::c_char, is_gz: libc::c_int) -> *const libc::c_void {
     let es = unsafe { &mut *es };
     let rname = osstr_from_cstr(&unsafe { CStr::from_ptr(name) });
     let ris_gz = is_gz != 0;
@@ -515,13 +515,13 @@ fn output_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *co
     es.output_open(&rname, ris_gz) as *const _
 }
 
-fn output_open_stdout<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, ) -> *const libc::c_void {
+extern fn output_open_stdout<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, ) -> *const libc::c_void {
     let es = unsafe { &mut *es };
 
     es.output_open_stdout() as *const _
 }
 
-fn output_putc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, c: libc::c_int) -> libc::c_int {
+extern fn output_putc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, c: libc::c_int) -> libc::c_int {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut OutputHandle;
     let rc = c as u8;
@@ -533,7 +533,7 @@ fn output_putc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *
     }
 }
 
-fn output_write<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, data: *const u8, len: libc::size_t) -> libc::size_t {
+extern fn output_write<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, data: *const u8, len: libc::size_t) -> libc::size_t {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut OutputHandle;
     let rdata = unsafe { slice::from_raw_parts(data, len) };
@@ -547,7 +547,7 @@ fn output_write<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: 
     }
 }
 
-fn output_flush<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
+extern fn output_flush<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut OutputHandle;
 
@@ -558,7 +558,7 @@ fn output_flush<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: 
     }
 }
 
-fn output_close<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
+extern fn output_close<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
     let es = unsafe { &mut *es };
 
     if handle == 0 as *mut _ {
@@ -575,7 +575,7 @@ fn output_close<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: 
 }
 
 
-fn input_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *const libc::c_char, format: libc::c_int, is_gz: libc::c_int) -> *const libc::c_void {
+extern fn input_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *const libc::c_char, format: libc::c_int, is_gz: libc::c_int) -> *const libc::c_void {
     let es = unsafe { &mut *es };
     let rname = osstr_from_cstr(unsafe { CStr::from_ptr(name) });
     let rformat = c_format_to_rust(format);
@@ -589,20 +589,20 @@ fn input_open<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, name: *con
     }
 }
 
-fn input_open_primary<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>) -> *const libc::c_void {
+extern fn input_open_primary<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>) -> *const libc::c_void {
     let es = unsafe { &mut *es };
 
     es.input_open_primary() as *const _
 }
 
-fn input_get_size<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::size_t {
+extern fn input_get_size<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::size_t {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
 
     es.input_get_size(rhandle)
 }
 
-fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, offset: libc::ssize_t, whence: libc::c_int, internal_error: *mut libc::c_int) -> libc::size_t {
+extern fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, offset: libc::ssize_t, whence: libc::c_int, internal_error: *mut libc::c_int) -> libc::size_t {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
 
@@ -630,7 +630,7 @@ fn input_seek<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *m
     }
 }
 
-fn input_getc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
+extern fn input_getc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
 
@@ -647,7 +647,7 @@ fn input_getc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *m
     }
 }
 
-fn input_ungetc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, ch: libc::c_int) -> libc::c_int {
+extern fn input_ungetc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, ch: libc::c_int) -> libc::c_int {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
 
@@ -660,7 +660,7 @@ fn input_ungetc<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: 
     }
 }
 
-fn input_read<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, data: *mut u8, len: libc::size_t) -> libc::ssize_t {
+extern fn input_read<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void, data: *mut u8, len: libc::size_t) -> libc::ssize_t {
     let es = unsafe { &mut *es };
     let rhandle = handle as *mut InputHandle;
     let rdata = unsafe { slice::from_raw_parts_mut(data, len) };
@@ -674,7 +674,7 @@ fn input_read<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *m
     }
 }
 
-fn input_close<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
+extern fn input_close<'a, I: 'a + IoProvider>(es: *mut ExecutionState<'a, I>, handle: *mut libc::c_void) -> libc::c_int {
     let es = unsafe { &mut *es };
 
     if handle == 0 as *mut _ {

--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -244,5 +244,9 @@ ttstub_input_ungetc(rust_input_handle_t handle, int ch)
 int
 ttstub_input_close(rust_input_handle_t handle)
 {
-    return TGB->input_close(TGB->context, handle);
+    if (TGB->input_close(TGB->context, handle)) {
+        // Nonzero return value indicates a serious internal error.
+        longjmp(jump_buffer, 1);
+    }
+    return 0;
 }

--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -220,7 +220,13 @@ ttstub_input_get_size(rust_input_handle_t handle)
 size_t
 ttstub_input_seek(rust_input_handle_t handle, ssize_t offset, int whence)
 {
-    return TGB->input_seek(TGB->context, handle, offset, whence);
+    int internal_error = 0;
+    size_t rv = TGB->input_seek(TGB->context, handle, offset, whence, &internal_error);
+    if (internal_error) {
+        // Nonzero indicates a serious internal error.
+        longjmp(jump_buffer, 1);
+    }
+    return rv;
 }
 
 ssize_t

--- a/tectonic/core-bridge.h
+++ b/tectonic/core-bridge.h
@@ -68,7 +68,7 @@ typedef struct tt_bridge_api_t {
     rust_input_handle_t (*input_open)(void *context, char const *path, tt_input_format_type format, int is_gz);
     rust_input_handle_t (*input_open_primary)(void *context);
     size_t (*input_get_size)(void *context, rust_input_handle_t handle);
-    size_t (*input_seek)(void *context, rust_input_handle_t handle, ssize_t offset, int whence);
+    size_t (*input_seek)(void *context, rust_input_handle_t handle, ssize_t offset, int whence, int* internal_error);
     ssize_t (*input_read)(void *context, rust_input_handle_t handle, char *data, size_t len);
     int (*input_getc)(void *context, rust_input_handle_t handle);
     int (*input_ungetc)(void *context, rust_input_handle_t handle, int ch);


### PR DESCRIPTION
Instead of panicking on failure, add a warning and return an error value
(if possible).

Closes #63.

However, these kinds of problems should probably result in a failure since they indicate an internal engine error.