### PR TITLE
Remove an unused global NSAutoreleasePool

### DIFF
--- a/tectonic/XeTeXFontMgr_Mac.mm
+++ b/tectonic/XeTeXFontMgr_Mac.mm
@@ -207,6 +207,8 @@ NSAutoreleasePool* pool = NULL;
 void
 XeTeXFontMgr_Mac::initialize()
 {
+    // An NSAutoreleasePool is needed to deallocate "autorelease" objects
+    // created and returned by Cocoa calls.
     pool = [[NSAutoreleasePool alloc] init];
 }
 
@@ -215,6 +217,7 @@ XeTeXFontMgr_Mac::terminate()
 {
     if (pool != NULL) {
         [pool release];
+        pool = NULL;
     }
 }
 


### PR DESCRIPTION
The problem was a double free after all.

  - The global `pool` was initialized only once, but freed multiple times (on every
    engine run). Never used...

  - Closes #47.