### PR TITLE
Redirection heuristic for #113

### DIFF
--- a/src/io/hyper_seekable.rs
+++ b/src/io/hyper_seekable.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::str;
 
+use super::create_hyper_client;
 use errors::{ErrorKind, Result};
 
 // Of course, we are not actually caching because nothing ever gets expired
@@ -33,9 +34,7 @@ pub struct SeekableHttpFile {
 
 impl SeekableHttpFile {
     pub fn new(url: &str) -> Result<SeekableHttpFile> {
-        let ssl = NativeTlsClient::new().unwrap();
-        let connector = HttpsConnector::new(ssl);
-        let client = Client::with_connector(connector);
+        let client = create_hyper_client();
 
         let len = {
             let req = client.head(url);

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,6 +3,9 @@
 // Licensed under the MIT License.
 
 use flate2::read::GzDecoder;
+use hyper_native_tls::NativeTlsClient;
+use hyper::net::HttpsConnector;
+use hyper::Client;
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
@@ -442,6 +445,13 @@ fn normalize_tex_path(path: &OsStr) -> Cow<OsStr> {
     } else {
         Cow::Borrowed(path)
     }
+}
+
+// Creates an hyper client capable of HTTPS-connections.
+pub fn create_hyper_client() -> Client {
+    let ssl = NativeTlsClient::new().unwrap();
+    let connector = HttpsConnector::new(ssl);
+    Client::with_connector(connector)
 }
 
 // Helper for testing. FIXME: I want this to be conditionally compiled with


### PR DESCRIPTION
I've tried to keep the heuristic general and avoid false-negatives as it only interferes if the last segment of the URL doesn't contain a `.`
(This will separates hash-like URLs from ones that contain a file extension)

Closes #113