### PR TITLE
build.rs: add -std=c++14 to have char16_t and similar defined

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -357,6 +357,7 @@ fn main() {
         .include(&out_dir);
 
     let cppflags = [
+        "-std=c++14",
         "-Wall",
         "-Wdate-time",
         "-Wendif-labels",


### PR DESCRIPTION
unicode headers used in the C++ code use such types.

See #125 