### PR TITLE
Add Linux in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,53 @@
 # Licensed under the MIT License.
 
 language: rust
-sudo: false
 
 cache: cargo
-
-os: osx
-osx_image: xcode8.2
-
-rust:
-  - stable
-  - beta
-  - nightly
+sudo: false
 
 matrix:
+  include:
+    - os: linux
+      dist: trusty
+      rust: stable
+    - os: linux
+      dist: trusty
+      rust: beta
+    - os: linux
+      dist: trusty
+      rust: nightly
+    - os: osx
+      osx_image: xcode8.2
+      rust: stable
   allow_failures:
     - rust: nightly
 
+addons:
+  apt:
+    packages:
+      - libgraphite2-dev
+      - libharfbuzz-dev
+      - libfontconfig1-dev
+      - libicu-dev
+      - zlib1g-dev
+      - openssl
+
 before_install:
-  - brew update
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                            ; fi
 
 install:
-  - brew install graphite2
-  - brew install harfbuzz --with-graphite2
-  - brew install --force openssl
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphite2                 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install harfbuzz --with-graphite2 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --force openssl           ; fi
 
 before_script:
   - |
-    export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include &&
-    export OPENSSL_LIB_DIR=$(brew --prefix openssl)/lib &&
-    export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include &&
-    export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include &&
+      export OPENSSL_LIB_DIR=$(brew --prefix openssl)/lib &&
+      export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include &&
+      export PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+    fi
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,15 @@ addons:
       - openssl
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                            ; fi
+  - '[[ "$TRAVIS_OS_NAME" != "osx" ]] || brew update'
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphite2                 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install harfbuzz --with-graphite2 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install --force openssl           ; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew install graphite2 &&
+      brew install harfbuzz --with-graphite2 &&
+      brew install --force openssl
+    fi
 
 before_script:
   - |

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ use sha2::Digest;
 const LIBS: &'static str = "harfbuzz harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
 
 #[cfg(target_os = "macos")]
-fn c_platform_specifics(cfg: &mut gcc::Config) {
+fn c_platform_specifics(cfg: &mut gcc::Build) {
     cfg.define("XETEX_MAC", Some("1"));
     cfg.file("tectonic/XeTeX_mac.c");
 
@@ -35,7 +35,7 @@ fn c_platform_specifics(cfg: &mut gcc::Config) {
 }
 
 #[cfg(target_os = "macos")]
-fn cpp_platform_specifics(cfg: &mut gcc::Config) {
+fn cpp_platform_specifics(cfg: &mut gcc::Build) {
     cfg.define("XETEX_MAC", Some("1"));
     cfg.file("tectonic/XeTeXFontInst_Mac.cpp");
     cfg.file("tectonic/XeTeXFontMgr_Mac.mm");
@@ -285,7 +285,7 @@ fn main() {
         .file("tectonic/XeTeX_ext.c")
         .file("tectonic/xetexini.c")
         .file("tectonic/XeTeX_pic.c")
-        .define("HAVE_TM_GMTOFF", "1")
+        // .define("HAVE_TM_GMTOFF", "1")
         .define("HAVE_ZLIB", "1")
         .define("HAVE_ZLIB_COMPRESS2", "1")
         .define("ZLIB_CONST", "1")

--- a/build.rs
+++ b/build.rs
@@ -285,7 +285,6 @@ fn main() {
         .file("tectonic/XeTeX_ext.c")
         .file("tectonic/xetexini.c")
         .file("tectonic/XeTeX_pic.c")
-        // .define("HAVE_TM_GMTOFF", "1")
         .define("HAVE_ZLIB", "1")
         .define("HAVE_ZLIB_COMPRESS2", "1")
         .define("ZLIB_CONST", "1")

--- a/build.rs
+++ b/build.rs
@@ -190,6 +190,7 @@ fn main() {
         "-Wno-unused-parameter",
         "-Wno-implicit-fallthrough",
         "-Wno-sign-compare",
+        "-std=c11"
     ];
 
     for flag in &cflags {


### PR DESCRIPTION
It looks like the Linux CI builds are a lot faster (7 minutes with crates cached) so I've moved the builds on Rust nightly and beta to Linux.
In the future it might be interesting to explore different `gcc`/`clang` builds.

This resolves #128.