### PR TITLE
Target GNU C dialect

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -190,7 +190,7 @@ fn main() {
         "-Wno-unused-parameter",
         "-Wno-implicit-fallthrough",
         "-Wno-sign-compare",
-        "-std=c11"
+        "-std=gnu11"
     ];
 
     for flag in &cflags {


### PR DESCRIPTION
A bunch of functions like `strcasecmp` are only available in `glibc`.
This is the major source of warnings (about implicit function declarations).