### PR TITLE
Set up CI to test and run Tectonic on a big-endian architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+# Copyright 2018 the Tectonic Project
+# Licensed under the MIT License
+
+# This CI workflow builds and tests Tectonic on a synthetic PowerPC CPU to
+# verify that we work on big-endian systems. It's not included in the Travis
+# suite because the workflow is so different from our standard one, and Circle
+# has a longer build time limit, which is important in this laughably
+# inefficient approach that we're taking.
+
+jobs:
+  build:
+    machine:
+      image: circleci/classic:201711-01
+    steps:
+      # Print a notice aimed at confused pull-requesters:
+      - run: echo "Testing Tectonic on a synthetic big-endian CPU; this will take a while ..."
+      - checkout
+      - run:
+          command: sudo bash .circleci/outer-build.sh $CIRCLE_WORKING_DIRECTORY
+          no_output_timeout: 1800

--- a/.circleci/inner-build.sh
+++ b/.circleci/inner-build.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+# Copyright 2018 the Tectonic Project
+# Licensed under the MIT License.
+
+set -e -x
+
+work="$1"
+cd "$work"
+
+# Validate that we're actually running in big-endian land! I spent a while
+# working on ARM emulation before I noticed that Ubuntu ARM builds are
+# little-endian ...
+
+cat <<'EOF' >check-bigendian.rs
+#[cfg(not(target_endian = "big"))]
+fn error_if_not_big() { this_platform_should_be_bigendian_but_apparently_is_not(); }
+fn main() {}
+EOF
+
+rustc --crate-type=bin -o check-bigendian check-bigendian.rs
+
+# We have to build and test in --release mode because currently (1.24.0)
+# PowerPC Rust has a crashing bug in debuginfo generation:
+# https://github.com/rust-lang/rust/issues/41253 .
+
+cargo build --release
+cargo test --release

--- a/build.rs
+++ b/build.rs
@@ -260,6 +260,11 @@ fn main() {
     c_platform_specifics(&mut ccfg);
     cpp_platform_specifics(&mut cppcfg);
 
+    if cfg!(target_endian = "big") {
+        ccfg.define("WORDS_BIGENDIAN", "1");
+        cppcfg.define("WORDS_BIGENDIAN", "1");
+    }
+
     ccfg.compile("libtectonic_c.a");
     cppcfg.compile("libtectonic_cpp.a");
 


### PR DESCRIPTION
This is kind of ludicrous, but as far as I can tell the only free way to do this is to use QEMU to run the build inside a synthetic PowerPC CPU. It took a long time to make this work, which was probably not the best use of my time, but here we are!