### PR TITLE
Store format file uncompressed

### DIFF
--- a/src/cli_driver.rs
+++ b/src/cli_driver.rs
@@ -833,7 +833,7 @@ impl ProcessingSession {
             TexEngine::new()
                     .halt_on_error_mode(true)
                     .initex_mode(true)
-                    .process(&mut stack, &mut self.events, status, "UNUSED.fmt.gz", "texput")
+                    .process(&mut stack, &mut self.events, status, "UNUSED.fmt", "texput")
         };
 
         match result {
@@ -871,7 +871,7 @@ impl ProcessingSession {
 
             let sname = name.to_string_lossy();
 
-            if !sname.ends_with(".fmt.gz") {
+            if !sname.ends_with(".fmt") {
                 continue;
             }
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -736,7 +736,7 @@ fn format_to_extension (format: FileFormat) -> Vec<&'static str> {
         FileFormat::Bst => vec!["bst"],
         FileFormat::Cmap => vec!["cmap"], /* XXX: kpathsea doesn't define any suffixes for this */
         FileFormat::Enc => vec!["enc"],
-        FileFormat::Format => vec!["fmt.gz"],
+        FileFormat::Format => vec!["fmt"],
         FileFormat::FontMap => vec!["map"],
         FileFormat::MiscFonts => vec!["miscfonts"], /* XXX: no kpathsea suffixes */
         FileFormat::Ofm => vec!["ofm"],

--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -356,7 +356,7 @@ impl<B: IoProvider> LocalCache<B> {
         };
 
         let mut p = self.formats_base.clone();
-        p.push(format!("{}-{}-{}.fmt.gz", self.cached_digest.to_string(), stem, ::FORMAT_SERIAL));
+        p.push(format!("{}-{}-{}.fmt", self.cached_digest.to_string(), stem, ::FORMAT_SERIAL));
         Ok(p)
     }
 }

--- a/tectonic/xetexini.c
+++ b/tectonic/xetexini.c
@@ -2249,9 +2249,9 @@ store_fmt_file(void)
         overflow("pool size", pool_size - init_pool_ptr);
 
     format_ident = make_string();
-    pack_job_name(".fmt.gz");
+    pack_job_name(".fmt");
 
-    fmt_out = ttstub_output_open ((const char *) name_of_file + 1, 1);
+    fmt_out = ttstub_output_open ((const char *) name_of_file + 1, 0);
     if (fmt_out == NULL)
         _tt_abort ("cannot open format output file \"%s\"", name_of_file + 1);
 
@@ -2667,7 +2667,7 @@ load_fmt_file(void)
 
     pack_buffered_name(format_default_length - 4, 1, 0);
 
-    fmt_in = ttstub_input_open((const char *) name_of_file + 1, TTIF_FORMAT, 1);
+    fmt_in = ttstub_input_open((const char *) name_of_file + 1, TTIF_FORMAT, 0);
     if (fmt_in == NULL)
         _tt_abort("cannot open the format file \"%s\"", (char *) name_of_file + 1);
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -143,7 +143,7 @@ fn relative_include() {
                                          "subdirectory/content/1.tex"]);
 
     let output = run_tectonic(tempdir.path(),
-                              &["--format=plain.fmt.gz", "subdirectory/relative_include.tex"]);
+                              &["--format=plain.fmt", "subdirectory/relative_include.tex"]);
     success_or_panic(output);
     check_file(&tempdir, "subdirectory/relative_include.pdf");
 }
@@ -169,7 +169,7 @@ fn test_space() {
 
     let tempdir = setup_and_copy_files(&["test space.tex"]);
 
-    let output = run_tectonic(tempdir.path(), &["--format=plain.fmt.gz", "test space.tex"]);
+    let output = run_tectonic(tempdir.path(), &["--format=plain.fmt", "test space.tex"]);
     success_or_panic(output);
 }
 
@@ -180,7 +180,7 @@ fn test_outdir() {
     let tempdir = setup_and_copy_files(&["subdirectory/content/1.tex"]);
 
     let output = run_tectonic(tempdir.path(),
-                              &["--format=plain.fmt.gz", "subdirectory/content/1.tex", "--outdir=subdirectory"]);
+                              &["--format=plain.fmt", "subdirectory/content/1.tex", "--outdir=subdirectory"]);
     success_or_panic(output);
     check_file(&tempdir, "subdirectory/1.pdf");
 }
@@ -193,7 +193,7 @@ fn test_bad_outdir() {
     let tempdir = setup_and_copy_files(&["subdirectory/content/1.tex"]);
 
     let output = run_tectonic(tempdir.path(),
-                              &["--format=plain.fmt.gz", "subdirectory/content/1.tex", "--outdir=subdirectory/non_existent"]);
+                              &["--format=plain.fmt", "subdirectory/content/1.tex", "--outdir=subdirectory/non_existent"]);
     success_or_panic(output);
 }
 
@@ -205,7 +205,7 @@ fn test_outdir_is_file() {
     let tempdir = setup_and_copy_files(&["test space.tex", "subdirectory/content/1.tex"]);
 
     let output = run_tectonic(tempdir.path(),
-                              &["--format=plain.fmt.gz", "subdirectory/content/1.tex", "--outdir=test space.tex"]);
+                              &["--format=plain.fmt", "subdirectory/content/1.tex", "--outdir=test space.tex"]);
     success_or_panic(output);
 }
 

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -117,7 +117,7 @@ fn test_format_generation(texname: &str, fmtname: &str, sha256: &str) {
         TexEngine::new()
             .initex_mode(true)
             .process(&mut io, &mut events,
-                     &mut NoopStatusBackend::new(), "unused.fmt.gz", texname).unwrap();
+                     &mut NoopStatusBackend::new(), "unused.fmt", texname).unwrap();
     }
 
     // Did we get what we expected?
@@ -129,7 +129,7 @@ fn test_format_generation(texname: &str, fmtname: &str, sha256: &str) {
             let observed = info.write_digest.unwrap();
 
             if observed != want_digest {
-                println!("expected uncompressed {} to have SHA256 = {}", fmtname, want_digest.to_string());
+                println!("expected {} to have SHA256 = {}", fmtname, want_digest.to_string());
                 println!("instead, got {}", observed.to_string());
                 panic!();
             }
@@ -144,7 +144,7 @@ fn test_format_generation(texname: &str, fmtname: &str, sha256: &str) {
 fn plain_format() {
     test_format_generation(
         "plain.tex",
-        "plain.fmt.gz",
-        "0a096fc88e7b8732ed56beca4319e57e7526a484a5b4f15b5413be7b7cae34ae",
+        "plain.fmt",
+        "83684a4992274fdae8de1b142146f85b0bf1a4f3489c54a04e12739d578dd863",
     )
 }

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -31,7 +31,7 @@ lazy_static! {
 
 fn set_up_format_file(tests_dir: &Path) -> Result<SingleInputFileIo> {
     let mut fmt_path = tests_dir.to_owned();
-    fmt_path.push("plain.fmt.gz");
+    fmt_path.push("plain.fmt");
 
     if try_open_file(&fmt_path).is_not_available() {
         // Well, we need to regenerate the format file. Not too difficult.
@@ -56,11 +56,11 @@ fn set_up_format_file(tests_dir: &Path) -> Result<SingleInputFileIo> {
                 .halt_on_error_mode(true)
                 .initex_mode(true)
                 .process(&mut io, &mut NoopIoEventBackend::new(),
-                          &mut NoopStatusBackend::new(), "UNUSED.fmt.gz", "plain.tex")?;
+                          &mut NoopStatusBackend::new(), "UNUSED.fmt", "plain.tex")?;
         }
 
         let mut fmt_file = File::create(&fmt_path)?;
-        fmt_file.write_all(mem.files.borrow().get(OsStr::new("plain.fmt.gz")).unwrap())?;
+        fmt_file.write_all(mem.files.borrow().get(OsStr::new("plain.fmt")).unwrap())?;
     }
 
     Ok(SingleInputFileIo::new(&fmt_path))
@@ -145,7 +145,7 @@ impl TestCase {
             let mut status = NoopStatusBackend::new();
 
             let tex_res = TexEngine::new()
-                .process(&mut io, &mut events, &mut status, "plain.fmt.gz", &texname);
+                .process(&mut io, &mut events, &mut status, "plain.fmt", &texname);
 
             if self.check_pdf && tex_res.definitely_same(&Ok(TexResult::Spotless)) {
                 // While the xdv and log output is deterministic without setting

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -85,7 +85,7 @@ fn trip_test() {
             .halt_on_error_mode(false)
             .initex_mode(false)
             .process(&mut io, &mut NoopIoEventBackend::new(),
-                      &mut NoopStatusBackend::new(), "trip.fmt.gz", "trip").unwrap();
+                      &mut NoopStatusBackend::new(), "trip.fmt", "trip").unwrap();
     }
 
     // Check that outputs match expectations.
@@ -147,7 +147,7 @@ fn etrip_test() {
             .halt_on_error_mode(false)
             .initex_mode(false)
             .process(&mut io, &mut NoopIoEventBackend::new(),
-                      &mut NoopStatusBackend::new(), "etrip.fmt.gz", "etrip").unwrap();
+                      &mut NoopStatusBackend::new(), "etrip.fmt", "etrip").unwrap();
     }
 
     // Check that outputs match expectations.


### PR DESCRIPTION
The gzip decoder is really slow in debug mode.
Disabling the compression for format files results in a 2x speedup of `load_fmt_file` in release builds.
The difference in debug builds is more noticeable and makes `cargo test`-ing more pleasant on _delicate_ hardware (180s => 30s).
This also results format blobs of doubled size though. Clever tweaks to the format could probably save a bit more space and still be faster than general-purpose compression.
Especially in debug mode, I think this performance/file-size trade-off is worth it.

I guess this shouldn't break anything as the format-file-format isn't stable at all.
If there's a special purpose to the compression or you think the file size is more important, feel free to close the PR.

**EDIT**: 7ac7766b2375cdd76e56f5b7eb9fdbdee7b99fe4 seems relevant here