### PR TITLE
Emit user-facing warning if unable to represent a character in the current font

### DIFF
--- a/tectonic/dpx-pdfdoc.c
+++ b/tectonic/dpx-pdfdoc.c
@@ -542,7 +542,7 @@ pdf_doc_close_docinfo (pdf_doc *p)
   }
 
   if (!pdf_lookup_dict(docinfo, "CreationDate")) {
-    char now[32];
+    char now[80];
 
     asn_date(now);
     pdf_add_dict(docinfo,
@@ -2529,15 +2529,16 @@ pdf_open_document (const char *filename,
 
   /* Create a default name for thumbnail image files */
   if (manual_thumb_enabled) {
-    if (strlen(filename) > 4 &&
-        !strncmp(".pdf", filename + strlen(filename) - 4, 4)) {
-      thumb_basename = NEW(strlen(filename)-4+1, char);
-      strncpy(thumb_basename, filename, strlen(filename)-4);
-      thumb_basename[strlen(filename)-4] = 0;
-    } else {
-      thumb_basename = NEW(strlen(filename)+1, char);
-      strcpy(thumb_basename, filename);
-    }
+      size_t fn_len = strlen(filename);
+
+      if (fn_len > 4 && !strncmp(".pdf", filename + fn_len - 4, 4)) {
+          thumb_basename = NEW(fn_len - 4 + 1, char);
+          strncpy(thumb_basename, filename, fn_len - 4);
+          thumb_basename[fn_len - 4] = 0;
+      } else {
+          thumb_basename = NEW(fn_len + 1, char);
+          strcpy(thumb_basename, filename);
+      }
   }
 
   p->pending_forms = NULL;

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -162,7 +162,7 @@ compute_owner_password (struct pdf_sec *p,
   unsigned char padded[32];
   MD5_CONTEXT   md5;
   ARC4_CONTEXT  arc4;
-  unsigned char hash[16];
+  unsigned char hash[32];
 
   passwd_padding((strlen(opasswd) > 0 ? opasswd : upasswd), padded);
 

--- a/tectonic/dpx-spc_dvips.c
+++ b/tectonic/dpx-spc_dvips.c
@@ -448,7 +448,7 @@ spc_handler_ps_tricks_transform (struct spc_env *spe, struct spc_arg *args)
   static const char *post = "concat matrix currentmatrix ==";
 
   cmd = xcalloc(l + 41, 1);
-  strncpy(cmd, "matrix setmatrix ", 17);
+  strncpy(cmd, "matrix setmatrix ", 18);
   strncpy(cmd + 17, args->curptr, l);
   concat = strstr(cmd, "concat");
   if (concat) {

--- a/tectonic/dpx-spc_tpic.c
+++ b/tectonic/dpx-spc_tpic.c
@@ -176,7 +176,7 @@ set_fillstyle (double g, double a, int f_ais)
 {
   pdf_obj *dict;
   char     resname[32];
-  char     buf[32];
+  char     buf[38];
   int      alp, len = 0;
 
   if (a > 0.0) {

--- a/tectonic/dpx-truetype.c
+++ b/tectonic/dpx-truetype.c
@@ -123,7 +123,11 @@ pdf_font_open_truetype (pdf_font *font)
         length = tt_get_ps_fontname(sfont, fontname, 255);
         if (length < 1) {
             length = MIN(strlen(ident), 255);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
             strncpy(fontname, ident, length);
+#pragma GCC diagnostic pop
         }
         fontname[length] = '\0';
         for (n = 0; n < length; n++) {

--- a/tectonic/xetex0.c
+++ b/tectonic/xetex0.c
@@ -10791,6 +10791,35 @@ void char_warning(internal_font_number f, int32_t c)
 
         INTPAR(tracing_online) = old_setting;
     }
+
+    {
+        char *fn = gettexstring(font_name[f]);
+        char *chr = NULL;
+        selector_t prev_selector = selector;
+        int s;
+
+        selector = SELECTOR_NEW_STRING;
+        if (c < 0x10000)
+            print(c);
+        else
+            print_char(c);
+        selector = prev_selector;
+        s = make_string();
+        chr = gettexstring(s);
+        str_ptr--; /* this is the "flush_string" macro which discards the most recent string */
+        pool_ptr = str_start[str_ptr - 0x10000];
+
+        ttstub_issue_warning("could not represent character \"%s\" in font \"%s\"", chr, fn);
+
+        free(fn);
+        free(chr);
+
+        if (!gave_char_warning_help) {
+            ttstub_issue_warning("  you may need to load the `fontspec` package and use (e.g.) \\setmainfont to");
+            ttstub_issue_warning("  choose a different font that covers the unrepresentable character(s)");
+            gave_char_warning_help = true;
+        }
+    }
 }
 
 

--- a/tectonic/xetexd.h
+++ b/tectonic/xetexd.h
@@ -676,6 +676,7 @@ extern scaled_t delta;
 extern int synctex_enabled;
 extern bool used_tectonic_coda_tokens;
 extern bool semantic_pagination_enabled;
+extern bool gave_char_warning_help;
 
 /*:1683*/
 

--- a/tectonic/xetexini.c
+++ b/tectonic/xetexini.c
@@ -366,6 +366,7 @@ scaled_t delta;
 int synctex_enabled;
 bool used_tectonic_coda_tokens;
 bool semantic_pagination_enabled;
+bool gave_char_warning_help;
 
 uint16_t _xeq_level_array[1114731];
 int32_t _trie_op_hash_array[trie_op_size - neg_trie_op_size + 1];
@@ -4174,6 +4175,7 @@ tt_run_engine(char *dump_name, char *input_file_name)
     param_ptr = 0;
     max_param_stack = 0;
     used_tectonic_coda_tokens = false;
+    gave_char_warning_help = false;
 
     memset(buffer, 0, buf_size * sizeof(buffer[0]));
     first = 0;


### PR DESCRIPTION
Further rationale in the commit messages. Attempting to address #173 in a helpful way.