### PR TITLE
Use an absolute path to reference_sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "reference_sources"]
 	path = reference_sources
-	url = ../tectonic-staging.git
+	url = https://github.com/tectonic-typesetting/tectonic-staging


### PR DESCRIPTION
With a relative path, I can't add tectonic's git repository as a dependency in Cargo.toml; attempting to do so gives:

```
$ cargo build
    Updating git repository `https://github.com/tectonic-typesetting/tectonic`
error: failed to load source for a dependency on `tectonic`                     

Caused by:
  Unable to update https://github.com/tectonic-typesetting/tectonic

Caused by:
  failed to update submodule `reference_sources`

Caused by:
  invalid url `../tectonic-staging.git`: relative URL without a base
```