### PR TITLE
build.rs: make requirement of harfbuzz >= 1.4 more explicit

### DIFF
--- a/.circleci/outer-build.sh
+++ b/.circleci/outer-build.sh
@@ -5,7 +5,7 @@
 set -e -x
 
 buildroot=$HOME
-tarball='https://bintray.com/pkgw/tectonic/download_file?file_path=tectonic-buildenv-ppc-20180128.tar.gz'
+tarball='https://dataverse.harvard.edu/api/access/datafile/:persistentId?persistentId=doi:10.7910/DVN/VM4ZZ3/NT9HFL'
 
 # Validate that our little scheme is going to work. Annoyingly
 # $CIRCLE_WORKING_DIRECTORY (passed in as $1 since we're sudo) is defined with

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 // MacOS platform specifics:
 
 #[cfg(target_os = "macos")]
-const LIBS: &'static str = "harfbuzz harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
+const LIBS: &'static str = "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
 
 #[cfg(target_os = "macos")]
 fn c_platform_specifics(cfg: &mut cc::Build) {
@@ -40,7 +40,7 @@ fn cpp_platform_specifics(cfg: &mut cc::Build) {
 // Not-MacOS:
 
 #[cfg(not(target_os = "macos"))]
-const LIBS: &'static str = "fontconfig harfbuzz harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
+const LIBS: &'static str = "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng zlib";
 
 #[cfg(not(target_os = "macos"))]
 fn c_platform_specifics(_: &mut cc::Build) {


### PR DESCRIPTION
Based on https://github.com/harfbuzz/harfbuzz/blob/master/NEWS, this seems to be the first minor version that includes required OpenType math support.

Closes #199.