### PR TITLE
Add --only-cached/-C command line flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,7 @@ impl PersistentConfig {
         Ok(config)
     }
 
-    pub fn make_cached_url_provider(&self, url: &str, status: &mut StatusBackend) -> Result<LocalCache<ITarBundle<HttpITarIoFactory>>> {
+    pub fn make_cached_url_provider(&self, url: &str, only_cached: bool, status: &mut StatusBackend) -> Result<LocalCache<ITarBundle<HttpITarIoFactory>>> {
         let itb = ITarBundle::<HttpITarIoFactory>::new(url);
 
         let mut url2digest_path = app_dir(AppDataType::UserCache, &::APP_INFO, "urls")?;
@@ -85,16 +85,17 @@ impl PersistentConfig {
             &url2digest_path,
             &app_dir(AppDataType::UserCache, &::APP_INFO, "manifests")?,
             &app_dir(AppDataType::UserCache, &::APP_INFO, "files")?,
+            only_cached,
             status
         )
     }
 
-    pub fn default_bundle(&self, status: &mut StatusBackend) -> Result<Box<Bundle>> {
+    pub fn default_bundle(&self, only_cached: bool, status: &mut StatusBackend) -> Result<Box<Bundle>> {
         if self.default_bundles.len() != 1 {
             return Err(ErrorKind::Msg("exactly one default_bundle item must be specified (for now)".to_owned()).into());
         }
 
-        Ok(Box::new(self.make_cached_url_provider(&self.default_bundles[0].url, status)?))
+        Ok(Box::new(self.make_cached_url_provider(&self.default_bundles[0].url, only_cached, status)?))
     }
 
     pub fn format_cache_path(&self) -> Result<PathBuf> {


### PR DESCRIPTION
This is a preliminary pull request proposing to add a **new command line option**. I want to ask for feedback.

With this flag enabled, tectonic will only use resource files that are already stored in the local cache and will not try to fetch them from a web bundle.

Tectonic at the moment accesses the bundle file whenever a new file like a figure is added to a TeX document or a new TeX file is being compiled. In a majority of these cases, this is unnecessary because the files will not be found in the bundle anyway. Usually, this is not a big issue, but it can be annoying to deal with when the web bundle is not accessible. I believe there should be a way to ask tectonic not to try to fetch the unknown files.

This has at least 3 use cases:
* workaround for web bundle problems like #200 
* no internet connection: preparing a presentation on a plane 
* speed up tectonic's edit-build-view cycle when adding a lot of new figures etc.