### PR TITLE
Do not panic on an empty filename in MemoryIo

### DIFF
--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -116,7 +116,9 @@ impl MemoryIo {
 
 impl IoProvider for MemoryIo {
     fn output_open_name(&mut self, name: &OsStr) -> OpenResult<OutputHandle> {
-        assert!(!name.is_empty(), "name must be non-empty");
+        if name.is_empty() {
+            return OpenResult::NotAvailable;
+        }
 
         let name = normalize_tex_path(name);
 
@@ -132,7 +134,9 @@ impl IoProvider for MemoryIo {
     }
 
     fn input_open_name(&mut self, name: &OsStr, _status: &mut StatusBackend) -> OpenResult<InputHandle> {
-        assert!(!name.is_empty(), "name must be non-empty");
+        if name.is_empty() {
+            return OpenResult::NotAvailable;
+        }
 
         let name = normalize_tex_path(name);
 


### PR DESCRIPTION
  - Just return `OpenResult::NotAvailable`, matching the behavior of
    xelatex.

Fixes #188.