### PR TITLE
Add an all-in-one latex_to_pdf() function and sweet testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /tests/plain.fmt
+/tests/00*00-latex-*.fmt
 /tests/00*00-plain-*.fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ flate2 = "^1.0"
 fs2 = "^0.4"
 hyper = "^0.10"
 hyper-native-tls = "^0.3"
+lazy_static = "^1.1"
 libc = "^0.2"
 tempfile = "^3.0"
 md-5 = "^0.8"
@@ -63,4 +64,3 @@ zip = "^0.4"
 
 [dev-dependencies]
 tempdir = "^0.3"
-lazy_static = "^1.1"

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -222,6 +222,19 @@ fn main() {
         _ => unreachable!()
     };
 
+    // The Tectonic crate comes with a hidden internal "test mode" that forces
+    // it to use a specified set of local files, rather than going to the
+    // bundle -- this makes it so that we can run tests without having to go
+    // to the network or touch the current user's cache.
+    //
+    // This mode is activated by setting a special environment variable. The
+    // following call checks for it and activates the mode if necessary. Note
+    // that this test infrastructure is lightweight, so I don't think it's a
+    // big deal to include the code in the final executable artifacts we
+    // distribute.
+
+    tectonic::test_util::maybe_activate_test_mode();
+
     // I want the CLI program to take as little configuration as possible, but
     // we do need to at least provide a mechanism for storing the default
     // bundle.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1049,4 +1049,17 @@ impl ProcessingSession {
         self.io.mem.files.borrow_mut().remove(&self.tex_xdv_path);
         Ok(0)
     }
+
+
+    /// Consume this session and return the current set of files in memory.
+    ///
+    /// This convenience function tries to help with the annoyances of getting
+    /// access to the in-memory file data after the engine has been run.
+    pub fn into_file_data(self) -> HashMap<OsString, Vec<u8>> {
+        // There must be a better way to do this ... Note that you *cannot*
+        // elide the creation of `rebuild`!
+        let mut borrow_map = self.io.mem.files.borrow_mut();
+        let rebuild = borrow_map.drain().collect();
+        rebuild
+    }
 }

--- a/src/engines/bibtex.rs
+++ b/src/engines/bibtex.rs
@@ -23,6 +23,8 @@ impl BibtexEngine {
     pub fn process (&mut self, io: &mut IoStack,
                     events: &mut IoEventBackend,
                     status: &mut StatusBackend, aux: &str) -> Result<TexResult> {
+        let _guard = super::ENGINE_LOCK.lock().unwrap(); // until we're thread-safe ...
+
         let caux = CString::new(aux)?;
 
         let /*mut*/ state = ExecutionState::new(io, events, status);

--- a/src/engines/tex.rs
+++ b/src/engines/tex.rs
@@ -97,6 +97,8 @@ impl TexEngine {
                     events: &mut IoEventBackend,
                     status: &mut StatusBackend,
                     format_file_name: &str, input_file_name: &str) -> Result<TexResult> {
+        let _guard = super::ENGINE_LOCK.lock().unwrap(); // until we're thread-safe ...
+
         let cformat = CString::new(format_file_name)?;
         let cinput = CString::new(input_file_name)?;
 

--- a/src/engines/xdvipdfmx.rs
+++ b/src/engines/xdvipdfmx.rs
@@ -37,6 +37,8 @@ impl XdvipdfmxEngine {
     pub fn process (&mut self, io: &mut IoStack,
                     events: &mut IoEventBackend,
                     status: &mut StatusBackend, dvi: &str, pdf: &str) -> Result<i32> {
+        let _guard = super::ENGINE_LOCK.lock().unwrap(); // until we're thread-safe ...
+
         let cdvi = CString::new(dvi)?;
         let cpdf = CString::new(pdf)?;
 

--- a/src/io/stdstreams.rs
+++ b/src/io/stdstreams.rs
@@ -83,6 +83,11 @@ pub struct BufferedPrimaryIo {
 }
 
 impl BufferedPrimaryIo {
+    /// Create a new primary-I/O buffer from a type implementing Read.
+    ///
+    /// The stream will be read and buffered in memory — regardless of how
+    /// large it is. This approach is required because Tectonic will generally
+    /// need to make multiple passes over the input file.
     pub fn from_stream<T: Read>(stream: &mut T) -> Result<Self> {
         let mut buf = [0u8; 8192];
         let mut alldata = Vec::<u8>::new();
@@ -102,13 +107,28 @@ impl BufferedPrimaryIo {
         })
     }
 
+    /// Create a new primary-I/O buffer from this processes's standard input.
+    ///
+    /// Standard input will be read and buffered in memory — regardless of how
+    /// large it is. This approach is required because Tectonic will generally
+    /// need to make multiple passes over the input file.
     pub fn from_stdin() -> Result<Self> {
         Self::from_stream(&mut stdin())
     }
 
+    /// Create a new primary-I/O buffer from a string.
+    ///
+    /// The string is converted into bytes as per [`str.as_bytes`].
     pub fn from_text<T: AsRef<str>>(text: T) -> Self {
         BufferedPrimaryIo {
             buffer: SharedByteBuffer::new(text.as_ref().as_bytes().to_owned())
+        }
+    }
+
+    /// Create a new primary-I/O buffer from a byte vector.
+    pub fn from_buffer(buf: Vec<u8>) -> Self {
+        BufferedPrimaryIo {
+            buffer: SharedByteBuffer::new(buf)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate flate2;
 extern crate fs2;
 extern crate hyper;
 extern crate hyper_native_tls;
+#[macro_use] extern crate lazy_static;
 extern crate libc;
 extern crate md5;
 extern crate tempfile;
@@ -121,6 +122,13 @@ const FORMAT_SERIAL: u32 = 28; // keep synchronized with tectonic/xetex-constant
 /// For more sophisticated uses, use the [`driver`] module, which provides a
 /// high-level interface for driving the typesetting engines with much more
 /// control over their behavior.
+///
+/// Note that the current engine implementations use lots of global state, so
+/// they are not thread-safe. This crate uses a global mutex to serialize
+/// invocations of the engines. This means that if you call this function from
+/// multiple threads simultaneously, the bulk of the work will be done in
+/// serial. The aim is to lift this limitation one day, but it will require
+/// extensive work on the underlying C/C++ code.
 pub fn latex_to_pdf<T: AsRef<str>>(latex: T) -> Result<Vec<u8>> {
     use std::ffi::OsStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,26 @@
 //! - The frontend is just a thin shim over the Tectonic Rust crate, so that
 //!   the full engine can be embedded anywhere you can run Rust code.
 //!
-//! Rust API documentation for Tectonic is currently very incomplete. As a
-//! stopgap, please see [the source to the CLI
-//! frontend](https://github.com/tectonic-typesetting/tectonic/blob/master/src/cli_driver.rs)
-//! for a demonstration of how to run the engine.
+//! The main module of this crate provides an all-in-wonder function for compiling
+//! LaTeX code to a PDF:
+//!
+//! ```
+//! extern crate tectonic;
+//!
+//! let latex = r#"
+//! \documentclass{article}
+//! \begin{document}
+//! Hello, world!
+//! \end{document}
+//! "#;
+//!
+//! # tectonic::test_util::activate_test_mode_augmented(env!("CARGO_MANIFEST_DIR"));
+//! let pdf_data: Vec<u8> = tectonic::latex_to_pdf(latex).expect("processing failed");
+//! println!("Output PDF size is {} bytes", pdf_data.len());
+//! ```
+//!
+//! The [`driver`] module provides a high-level interface for driving the
+//! engines in more realistic circumstances.
 
 extern crate aho_corasick;
 extern crate app_dirs;
@@ -58,6 +74,11 @@ pub mod driver;
 pub mod engines;
 pub mod io;
 
+// Note: this module is intentionally *not* gated by #[cfg(test)] -- see its
+// docstring for details.
+#[doc(hidden)]
+pub mod test_util;
+
 pub use engines::bibtex::BibtexEngine;
 pub use engines::spx2html::Spx2HtmlEngine;
 pub use engines::tex::{TexEngine, TexResult};
@@ -67,3 +88,77 @@ pub use errors::{Error, ErrorKind, Result};
 const APP_INFO: app_dirs::AppInfo = app_dirs::AppInfo {name: "Tectonic", author: "TectonicProject"};
 
 const FORMAT_SERIAL: u32 = 28; // keep synchronized with tectonic/xetex-constants.h!!
+
+
+/// Compile LaTeX text to a PDF.
+///
+/// This function is an all-in-one interface to the main Tectonic workflow. Given
+/// a string representing a LaTeX input file, it will compile it to a PDF and return
+/// a byte vector corresponding to the resulting file:
+///
+/// ```
+/// let latex = r#"
+/// \documentclass{article}
+/// \begin{document}
+/// Hello, world!
+/// \end{document}
+/// "#;
+///
+/// # tectonic::test_util::activate_test_mode_augmented(env!("CARGO_MANIFEST_DIR"));
+/// let pdf_data: Vec<u8> = tectonic::latex_to_pdf(latex).expect("processing failed");
+/// println!("Output PDF size is {} bytes", pdf_data.len());
+/// ```
+///
+/// The compilation uses the default bundle, the location of which is embedded
+/// in the crate or potentially specified in the user’s configuration file.
+/// The current working directory will be searched for any `\\input` files.
+/// Messages aimed at the user are suppressed, but (in the default
+/// configuration) network I/O may occur to pull down needed resource files.
+/// No outputs are written to disk; all supporting files besides the PDF
+/// document are discarded. The XeTeX engine is run multiple times if needed
+/// to get the output file to converge.
+///
+/// For more sophisticated uses, use the [`driver`] module, which provides a
+/// high-level interface for driving the typesetting engines with much more
+/// control over their behavior.
+pub fn latex_to_pdf<T: AsRef<str>>(latex: T) -> Result<Vec<u8>> {
+    use std::ffi::OsStr;
+
+    let mut status = status::NoopStatusBackend::new();
+
+    let auto_create_config_file = false;
+    let config = ctry!(config::PersistentConfig::open(auto_create_config_file);
+                       "failed to open the default configuration file");
+
+    let only_cached = false;
+    let bundle = ctry!(config.default_bundle(only_cached, &mut status);
+                       "failed to load the default resource bundle");
+
+    let format_cache_path = ctry!(config.format_cache_path();
+                                  "failed to set up the format cache");
+
+    let mut files = {
+        // Looking forward to non-lexical lifetimes!
+        let mut sb = driver::ProcessingSessionBuilder::default();
+        sb
+            .bundle(bundle)
+            .primary_input_buffer(latex.as_ref().as_bytes())
+            .tex_input_name("texput.tex")
+            .format_name("latex")
+            .format_cache_path(format_cache_path)
+            .keep_logs(false)
+            .keep_intermediates(false)
+            .print_stdout(false)
+            .output_format(driver::OutputFormat::Pdf)
+            .do_not_write_output_files();
+
+        let mut sess = ctry!(sb.create(&mut status); "failed to initialize the LaTeX processing session");
+        ctry!(sess.run(&mut status); "the LaTeX engine failed");
+        sess.into_file_data()
+    };
+
+    match files.remove(OsStr::new("texput.pdf")) {
+        Some(data) => Ok(data),
+        None => Err(errmsg!("LaTeX didn't report failure, but no PDF was created (??)")),
+    }
+}

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -50,7 +50,18 @@ pub enum MessageKind {
 
 
 pub trait StatusBackend {
+    /// Report a message to the status backend.
     fn report(&mut self, kind: MessageKind, args: Arguments, err: Option<&Error>);
+
+    /// Issue a note-level status, idealy highlighting a particular phrase.
+    ///
+    /// This is a bit of a hack. For [`driver::ProcessingSession::run`], I
+    /// like the UX when we issue notes in this style. It's a bit more
+    /// high-level than intended for this trait, but we can provide a nice
+    /// sensible default implementation, so whatever.
+    fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
+        self.report(MessageKind::Note, format_args!("{}{}{}", before, highlighted, after), None)
+    }
 }
 
 /// Report a formatted informational message to the user.

--- a/src/status/termcolor.rs
+++ b/src/status/termcolor.rs
@@ -109,16 +109,6 @@ impl TermcolorStatusBackend {
         }
     }
 
-    pub fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
-        if self.chatter > ChatterLevel::Minimal {
-            write!(self.stdout, "{}", before).expect("write to stdout failed");
-            self.stdout.set_color(&self.highlight_spec).expect("write to stdout failed");
-            write!(self.stdout, "{}", highlighted).expect("write to stdout failed");
-            self.stdout.reset().expect("write to stdout failed");
-            writeln!(self.stdout, "{}", after).expect("write to stdout failed");
-        }
-    }
-
     pub fn error_styled(&mut self, args: Arguments) {
         self.styled(MessageKind::Error, |s| {
             writeln!(s, "{}", args).expect("write to stderr failed");
@@ -173,6 +163,16 @@ impl StatusBackend for TermcolorStatusBackend {
                     writeln!(s, "{:?}", backtrace).expect("backtrace dump failed");
                 });
             }
+        }
+    }
+
+    fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
+        if self.chatter > ChatterLevel::Minimal {
+            write!(self.stdout, "{}", before).expect("write to stdout failed");
+            self.stdout.set_color(&self.highlight_spec).expect("write to stdout failed");
+            write!(self.stdout, "{}", highlighted).expect("write to stdout failed");
+            self.stdout.reset().expect("write to stdout failed");
+            writeln!(self.stdout, "{}", after).expect("write to stdout failed");
         }
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,129 @@
+// Copyright 2016-2018 the Tectonic Project
+// Licensed under the MIT License.
+
+//! This inelegant module helps with testing.
+//!
+//! We would like it if all of our tests -- unit tests (embedded in this
+//! crate), integration tests (in `tests/`), and doctests -- used the "test
+//! bundle" in `tests/assets/`, rather than having to touch the network to
+//! work. Unfortunately, the integration and doctests are compiled against the
+//! "default" build of the main crate -- that is, the version built *without*
+//! #[cfg(test)]. Therefore, to support such usage in all three scenarios, we
+//! need to build the code into the main crate unconditionally. We can hide it
+//! from the documentation, but we can't use #[cfg(test)] attributes to
+//! conditionally compile code.
+//!
+//! So, that's what we do. Importantly, the code here should all be nice and
+//! lightweight, and have very low impact on the final binary artifacts we
+//! produce. We also take care not to embed the build directory into the
+//! final binaries.
+//!
+//! There are two main functionalities covered in this module. First, there
+//! are some functions that help in locating test assets and making a fakey
+//! "bundle" that uses them.
+//!
+//! Second, there is some infrastructure to activate a "test" mode that
+//! affects the crate's behavior in a few ways. The binary we distribute
+//! activates this mode when a magic environment variable is set.
+//!
+//! This is all implemented so that out doctests can look totally innocuous --
+//! they are what you'd actually want in your own code, except we have a hidden
+//! one-liner when needed:
+//!
+//! # tectonic::test_util::activate_test_mode_augmented(env!("CARGO_MANIFEST_DIR"));
+//!
+//! That call simultaneously tells this module where to find the test assets,
+//! and also activates the test mode.
+
+use std::collections::HashSet;
+use std::env;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+use digest::DigestData;
+use errors::Result;
+use io::{Bundle, FilesystemIo, InputHandle, IoProvider, OpenResult};
+use status::StatusBackend;
+
+
+/// The name of the environment variable that the test code will consult to
+/// figure out where to find the testing resource files.
+pub const TEST_ROOT_ENV_VAR: &str = "TECTONIC_INTERNAL_TEST_ROOT";
+
+
+/// Set `TEST_ROOT_ENV_VAR` in the current process to the specified value,
+/// with a path element "tests" appended. If the variable was previously
+/// unset, this will make it such that `test_path()` and the other pieces of
+/// testing infrastructure in this module will start working.
+///
+/// The peculiar form of this function makes for easy one-liners in the test
+/// code exploiting the environment variable $CARGO_MANIFEST_DIR.
+pub fn set_test_root_augmented<V: AsRef<OsStr>>(root: V) {
+    let mut root = PathBuf::from(root.as_ref());
+    root.push("tests");
+    env::set_var(TEST_ROOT_ENV_VAR, root);
+}
+
+
+/// Activate this crate's "test mode", if-and-only-if the magic testing
+/// environment variable has been set. This allows testing of the Tectonic
+/// executable in a transparent way — notably, we avoid embedding the build
+/// prefix in the resulting binary, and we don't need to pass it any magical
+/// command line arguments.
+pub fn maybe_activate_test_mode() {
+    if env::var_os(TEST_ROOT_ENV_VAR).is_none() {
+        return;
+    }
+
+    ::config::activate_config_test_mode(true);
+}
+
+
+/// A combination of the two above functions. Set the "test root" variable,
+/// making it such that the testing infrastructure in this module can work;
+/// and then activate "test mode", such that certain other parts of the crate
+/// alter their behavior for use in the test environment. This makes for
+/// convenient doctests — you can secretly run them in the special test setup
+/// with a one-liner:
+///
+/// # tectonic::test_util::activate_test_mode_augmented(env!("CARGO_MANIFEST_DIR"));
+pub fn activate_test_mode_augmented<V: AsRef<OsStr>>(root: V) {
+    set_test_root_augmented(root);
+    maybe_activate_test_mode();
+}
+
+
+/// Obtain a path to a testing resource file. The environment variable whose
+/// name is stored in the constant `TEST_ROOT_ENV_VAR` must be set to an
+/// appropriate directory. (Note: `TEST_ROOT_ENV_VAR` is a constant giving the
+/// *name* of the relevant variable — not the name of the variable itself!)
+pub fn test_path(parts: &[&str]) -> PathBuf {
+    let mut path = PathBuf::from(env::var_os(TEST_ROOT_ENV_VAR)
+                                 .expect("Tectonic testing infrastructure cannot be used without \
+                                          setting the magic test-root environment variable"));
+    path.push(parts.iter().collect::<PathBuf>());
+    path
+}
+
+
+/// Utility for being able to treat the "assets/" directory as a bundle.
+pub struct TestBundle(FilesystemIo);
+
+impl Default for TestBundle {
+    fn default() -> Self {
+        TestBundle(FilesystemIo::new(&test_path(&["assets"]), false, false, HashSet::new()))
+    }
+}
+
+impl IoProvider for TestBundle {
+    // All other functions can default to NotAvailable/error.
+    fn input_open_name(&mut self, name: &OsStr, status: &mut StatusBackend) -> OpenResult<InputHandle> {
+        self.0.input_open_name(name, status)
+    }
+}
+
+impl Bundle for TestBundle {
+    fn get_digest(&mut self, _status: &mut StatusBackend) -> Result<DigestData> {
+        Ok(DigestData::zeros())
+    }
+}

--- a/tests/assets/tectonic-format-latex.tex
+++ b/tests/assets/tectonic-format-latex.tex
@@ -1,0 +1,29 @@
+% Copyright 2018 the Tectonic Project
+% Licensed under the MIT License.
+%
+% HACK ALERT!!!!
+%
+% Most parts of Tectonic default to using the "latex" format because that's
+% what people almost always want. We also sometimes want to show "best
+% practices" examples in the docs that will call for specifying the "latex"
+% format. That's all good, but it does complicate the test suite -- we'd like
+% to be able to run doctests or executable tests without having to actually go
+% ahead and download the core set of LaTeX support files from whatever the
+% current bundle is.
+%
+% This file is a hack to help enable this. It extends the "plain" format with
+% an absolutely minimal set of control sequences necessary to compile fake
+% documents that look like LaTeX. This helps our documentation look more
+% realistic while avoiding making the test suite much more heavyweight.
+
+\input knuth-plain%
+\message{THIS IS A FAKE LATEX FORMAT}%
+
+\def\fmtname{fakelatex}%
+\def\fmtversion{1.0}%
+\def\documentclass#1{}%
+\def\begin#1{}%
+\let\realend=\end%
+\def\end#1{\par\vfill\supereject\realend}%
+
+\dump

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -8,11 +8,9 @@
 //! ProcessingSessionBuilder will need to learn how to tell `xdvipdfmx` to
 //! enable the reproducibility options used in the `tex-outputs` test rig.
 
-#[macro_use] extern crate lazy_static;
 extern crate tectonic;
 extern crate tempdir;
 
-use std::sync::Mutex;
 use tectonic::config::PersistentConfig;
 use tectonic::driver::ProcessingSessionBuilder;
 use tectonic::status::ChatterLevel;
@@ -21,20 +19,12 @@ use tempdir::TempDir;
 
 mod util;
 
-lazy_static! {
-    static ref LOCK: Mutex<u8> = {
-        // Hack, one-time test setup:
-        util::set_test_root();
-        Mutex::new(0u8)
-    };
-}
-
 
 // Keep these alphabetized.
 
 #[test]
 fn the_letter_a() {
-    let _guard = LOCK.lock().unwrap(); // until we're thread-safe ...
+    util::set_test_root();
 
     let _config = PersistentConfig::default();
 

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -22,7 +22,11 @@ use tempdir::TempDir;
 mod util;
 
 lazy_static! {
-    static ref LOCK: Mutex<u8> = Mutex::new(0u8);
+    static ref LOCK: Mutex<u8> = {
+        // Hack, one-time test setup:
+        util::set_test_root();
+        Mutex::new(0u8)
+    };
 }
 
 

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -15,13 +15,11 @@
 /// to disk, which may be helpful in debugging. There is probably a less gross
 /// way to implement that option.
 
-#[macro_use] extern crate lazy_static;
 extern crate tectonic;
 
 use std::collections::{HashSet, HashMap};
 use std::ffi::{OsStr, OsString};
 use std::str::FromStr;
-use std::sync::Mutex;
 
 use tectonic::digest::DigestData;
 use tectonic::engines::IoEventBackend;
@@ -34,15 +32,6 @@ mod util;
 use util::test_path;
 
 const DEBUG: bool = false; // TODO: this is kind of ugly
-
-
-lazy_static! {
-    static ref LOCK: Mutex<u8> = {
-        // Hack, one-time test setup:
-        util::set_test_root();
-        Mutex::new(0u8)
-    };
-}
 
 
 /// A stunted version of cli_driver:FileSummary for examining the format file
@@ -81,7 +70,7 @@ impl IoEventBackend for FormatTestEvents {
 
 
 fn test_format_generation(texname: &str, fmtname: &str, sha256: &str) {
-    let _guard = LOCK.lock().unwrap(); // until we're thread-safe ...
+    util::set_test_root();
 
     let mut p = test_path(&["assets"]);
 

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -37,7 +37,11 @@ const DEBUG: bool = false; // TODO: this is kind of ugly
 
 
 lazy_static! {
-    static ref LOCK: Mutex<u8> = Mutex::new(0u8);
+    static ref LOCK: Mutex<u8> = {
+        // Hack, one-time test setup:
+        util::set_test_root();
+        Mutex::new(0u8)
+    };
 }
 
 

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -22,7 +22,11 @@ mod util;
 use util::{ensure_plain_format, test_path, ExpectedInfo};
 
 lazy_static! {
-    static ref LOCK: Mutex<u8> = Mutex::new(0u8);
+    static ref LOCK: Mutex<u8> = {
+        // Hack, one-time test setup:
+        util::set_test_root();
+        Mutex::new(0u8)
+    };
 }
 
 struct TestCase {
@@ -212,6 +216,10 @@ fn unicode_file_name() {
 
 #[test]
 fn file_encoding() {
+    // Need to do this here since we can call test_path before the lazy_static
+    // is initialized.
+    util::set_test_root();
+
     TestCase::new("file_encoding.tex")
         .with_fs(&test_path(&["tex-outputs"]))
         .expect(Ok(TexResult::Warnings))

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -1,13 +1,10 @@
 // Copyright 2016-2018 the Tectonic Project
 // Licensed under the MIT License.
 
-#[macro_use]
-extern crate lazy_static;
 extern crate tectonic;
 
 use std::collections::HashSet;
 use std::env;
-use std::sync::Mutex;
 use std::path::Path;
 
 use tectonic::engines::tex::TexResult;
@@ -21,13 +18,6 @@ use tectonic::{TexEngine, XdvipdfmxEngine};
 mod util;
 use util::{ensure_plain_format, test_path, ExpectedInfo};
 
-lazy_static! {
-    static ref LOCK: Mutex<u8> = {
-        // Hack, one-time test setup:
-        util::set_test_root();
-        Mutex::new(0u8)
-    };
-}
 
 struct TestCase {
     stem: String,
@@ -78,7 +68,7 @@ impl TestCase {
     }
 
     fn go(&mut self) {
-        let _guard = LOCK.lock().unwrap(); // until we're thread-safe ...
+        util::set_test_root();
 
         let expect_xdv = self.expected_result.is_ok();
 
@@ -216,8 +206,7 @@ fn unicode_file_name() {
 
 #[test]
 fn file_encoding() {
-    // Need to do this here since we can call test_path before the lazy_static
-    // is initialized.
+    // Need to do this here since we call test_path unusually early.
     util::set_test_root();
 
     TestCase::new("file_encoding.tex")

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -14,11 +14,9 @@
 /// variable to "1", but that's an annoying solution. So, we use a global mutex
 /// to achieve the same effect. Classy.
 
-#[macro_use] extern crate lazy_static;
 extern crate tectonic;
 
 use std::ffi::OsStr;
-use std::sync::Mutex;
 
 use tectonic::engines::NoopIoEventBackend;
 use tectonic::io::{FilesystemPrimaryInputIo, IoProvider, IoStack, MemoryIo};
@@ -29,18 +27,10 @@ use tectonic::TexEngine;
 mod util;
 use util::{ExpectedInfo, test_path};
 
-lazy_static! {
-    static ref LOCK: Mutex<u8> = {
-        // Hack, one-time test setup:
-        util::set_test_root();
-        Mutex::new(0u8)
-    };
-}
-
 
 #[test]
 fn trip_test() {
-    let _guard = LOCK.lock().unwrap(); // until we're thread-safe ...
+    util::set_test_root();
 
     let mut p = test_path(&["trip", "trip"]);
 
@@ -102,7 +92,7 @@ fn trip_test() {
 
 #[test]
 fn etrip_test() {
-    let _guard = LOCK.lock().unwrap(); // until we're thread-safe ...
+    util::set_test_root();
 
     let mut p = test_path(&["trip", "etrip"]);
 

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -30,7 +30,11 @@ mod util;
 use util::{ExpectedInfo, test_path};
 
 lazy_static! {
-    static ref LOCK: Mutex<u8> = Mutex::new(0u8);
+    static ref LOCK: Mutex<u8> = {
+        // Hack, one-time test setup:
+        util::set_test_root();
+        Mutex::new(0u8)
+    };
 }
 
 


### PR DESCRIPTION
The front page of our API docs will now look way better! And the "executable" tests now have better behavior, not touching the local user's cache or the network.