### PR TITLE
src/config.rs: default to archive.org, not purl.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 The following changes will appear in the next release:
 
-- None yet
+- The URL embedded in the code that points to the default bundle has been
+  changed to point to the archive.org domain. Hopefully this will result in
+  more reliable service — there have been problems with SSL certificate
+  updates on purl.org in the past.
 
 
 # 0.1.10 (2018 Sep 28)

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ pub fn activate_config_test_mode(forced: bool) {
 
 
 const DEFAULT_CONFIG: &'static str = r#"[[default_bundles]]
-url = "https://purl.org/net/pkgwpub/tectonic-default"
+url = "https://archive.org/services/purl/net/pkgwpub/tectonic-default"
 "#;
 
 


### PR DESCRIPTION
As per https://github.com/tectonic-typesetting/tectonic/issues/131 , there have been problems with purl.org historically. The archive.org domain should have more reliable SSL certificate updates.