### PR TITLE
Remove serde-derive dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,22 +492,6 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "proc-macro2"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rand"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,16 +612,6 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "serde_derive"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "sha2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,16 +637,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "syn"
-version = "0.15.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tectonic"
 version = "0.1.12-dev"
 dependencies = [
@@ -691,7 +655,6 @@ dependencies = [
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tectonic_xdv 0.1.9-dev",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,11 +790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -989,8 +947,6 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
-"checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
@@ -1006,11 +962,9 @@ dependencies = [
 "checksum security-framework 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697d3f3c23a618272ead9e1fb259c1411102b31c6af8b93f1d64cca9c3b0e8e0"
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
-"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
@@ -1027,7 +981,6 @@ dependencies = [
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a321979c09843d272956e73700d12c4e7d3d92b2ee112b31548aef0d4efc5a6"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ tempfile = "^3.0"
 md-5 = "^0.8"
 sha2 = "^0.8"
 serde = "^1.0"
-serde_derive = "^1.0"
 tectonic_xdv = { path = "xdv", version = "0.1.9-dev" }
 termcolor = "^1.0"
 toml = "^0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,9 +16,13 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::result;
+use std::fmt;
 
 use app_dirs::{app_dir, app_root, get_app_root, sanitized, AppDataType};
 use toml;
+
+use serde::de::{self, Deserialize, Deserializer, Visitor, MapAccess};
 
 use errors::{ErrorKind, Result};
 use io::itarbundle::{HttpITarIoFactory, ITarBundle};
@@ -47,14 +51,155 @@ url = "https://archive.org/services/purl/net/pkgwpub/tectonic-default"
 "#;
 
 
-#[derive(Deserialize)]
 pub struct PersistentConfig {
     default_bundles: Vec<BundleInfo>,
 }
 
-#[derive(Deserialize)]
+// Manual implementation of Deserialize because serde_derive does not work with musl
+// See https://github.com/rust-lang/rust/issues/40174
+// Implementation based on https://serde.rs/deserialize-struct.html
+impl<'de> Deserialize<'de> for PersistentConfig {
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field { DefaultBundles };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> result::Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`default_bundles`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> result::Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "default_bundles" => Ok(Field::DefaultBundles),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct PersistentConfigVisitor;
+
+        impl<'de> Visitor<'de> for PersistentConfigVisitor {
+            type Value = PersistentConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct PersistentConfig")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> result::Result<PersistentConfig, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut default_bundles = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::DefaultBundles => {
+                            if default_bundles.is_some() {
+                                return Err(de::Error::duplicate_field("default_bundles"));
+                            }
+                            default_bundles = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let default_bundles = default_bundles.ok_or_else(|| de::Error::missing_field("default_bundles"))?;
+                Ok(PersistentConfig { default_bundles })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["default_bundles"];
+        deserializer.deserialize_struct("PersistentConfig", FIELDS, PersistentConfigVisitor)
+    }
+}
+
 pub struct BundleInfo {
     url: String,
+}
+
+impl<'de> Deserialize<'de> for BundleInfo {
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field { Url };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> result::Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("`url`")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> result::Result<Field, E>
+                    where
+                        E: de::Error,
+                    {
+                        match value {
+                            "url" => Ok(Field::Url),
+                            _ => Err(de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct BundleInfoVisitor;
+
+        impl<'de> Visitor<'de> for BundleInfoVisitor {
+            type Value = BundleInfo;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct BundleInfo")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> result::Result<BundleInfo, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut url = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Url => {
+                            if url.is_some() {
+                                return Err(de::Error::duplicate_field("url"));
+                            }
+                            url = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let url = url.ok_or_else(|| de::Error::missing_field("url"))?;
+                Ok(BundleInfo { url })
+            }
+        }
+
+        const FIELDS: &'static [&'static str] = &["url"];
+        deserializer.deserialize_struct("BundleInfo", FIELDS, BundleInfoVisitor)
+    }
 }
 
 impl PersistentConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ extern crate hyper_native_tls;
 extern crate libc;
 extern crate md5;
 extern crate tempfile;
-#[macro_use] extern crate serde_derive;
 extern crate serde;
 extern crate sha2;
 extern crate tectonic_xdv;


### PR DESCRIPTION
Musl target does not work with proc-macro.
See https://github.com/rust-lang/rust/issues/40174

Removing serde-derive allows building tectonic for musl targets.