### PR TITLE
Make serde dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ toml = "^0.4"
 zip = "^0.4"
 
 [features]
-default = ["config_file"]
-config_file = ["serde", "serde_derive"]
+default = ["serialization"]
+serialization = ["serde", "serde_derive"]
 
 # freetype-sys = "^0.4"
 # harfbuzz-sys = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,16 @@ libc = "^0.2"
 tempfile = "^3.0"
 md-5 = "^0.8"
 sha2 = "^0.8"
-serde = "^1.0"
-serde_derive = "^1.0"
+serde = { version = "^1.0", optional = true }
+serde_derive = { version = "^1.0", optional = true }
 tectonic_xdv = { path = "xdv", version = "0.1.9-dev" }
 termcolor = "^1.0"
 toml = "^0.4"
 zip = "^0.4"
+
+[features]
+default = ["config_file"]
+config_file = ["serde", "serde_derive"]
 
 # freetype-sys = "^0.4"
 # harfbuzz-sys = "^0.1"

--- a/README.md
+++ b/README.md
@@ -52,13 +52,20 @@ Please see
 [the tectonic-staging README](https://github.com/tectonic-typesetting/tectonic-staging#readme)
 for more information. (Or at least, more words on the topic.)
 
+
 ## Features
 
-Tectonic provides the feature `config_file` that is enabled by default. This
-feature allows reading configuration from
-a [TOML](https://github.com/toml-lang/toml) and uses the `serde` and
-`serde_derive` crates.
+The Tectonic build can be customized with the following features:
 
-The feature `config_file` must be disabled when compiling for musl targets
-because `serde_derive` uses `proc_macro` and `proc_macro` [is
-not](https://github.com/rust-lang/rust/issues/40174) available on musl targets.
+##### serialization (enabled by default)
+
+This feature enables (de)serialization using the [serde](https://serde.rs/)
+crate. At the moment, this is only used to read per-user configuration from a
+[TOML](https://github.com/toml-lang/toml) file. If this feature is disabled,
+the per-user configuration file will be silently ignored.
+
+This functionality is optional because it requires the `serde_derive` crate,
+which in turn uses Rust’s `proc_macro` feature. The `proc_macro` functionality
+[is not available on musl targets](https://github.com/rust-lang/rust/issues/40174),
+and so must be turned off if you wish to build a completely static Tectonic
+executable.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ any given time.
 Please see
 [the tectonic-staging README](https://github.com/tectonic-typesetting/tectonic-staging#readme)
 for more information. (Or at least, more words on the topic.)
+
+## Features
+
+Tectonic provides the feature `config_file` that is enabled by default. This
+feature allows reading configuration from
+a [TOML](https://github.com/toml-lang/toml) and uses the `serde` and
+`serde_derive` crates.
+
+The feature `config_file` must be disabled when compiling for musl targets
+because `serde_derive` uses `proc_macro` and `proc_macro` [is
+not](https://github.com/rust-lang/rust/issues/40174) available on musl targets.

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,16 @@ pub struct BundleInfo {
 }
 
 impl PersistentConfig {
-    #[cfg(feature = "config_file")]
+    #[cfg(feature = "serialization")]
+    /// Open the per-user configuration file.
+    ///
+    /// This file is stored in TOML format. If the configuration file does not
+    /// exist, no error is signaled — instead, a basic default configuration
+    /// is returned. In this case, if `auto_create_config_file` is true, the
+    /// configuration file (and the directory containing it) will be
+    /// automatically created, filling in the default configuration. If it is
+    /// false, the default configuration is returned and the filesystem is not
+    /// modified.
     pub fn open(auto_create_config_file: bool) -> Result<PersistentConfig> {
         use toml;
         use std::io::{Read, Write};
@@ -87,7 +96,14 @@ impl PersistentConfig {
         Ok(config)
     }
 
-    #[cfg(not(feature = "config_file"))]
+    #[cfg(not(feature = "serialization"))]
+    /// Return a default configuration structure.
+    ///
+    /// In most builds of Tectonic, this function reads a per-user
+    /// configuration file and returns it. However, this version of Tectonic
+    /// has been built without the `serde` feature, so it cannot deserialize
+    /// the file. Therefore, this function always returns the default
+    /// configuration.
     pub fn open(_auto_create_config_file: bool) -> Result<PersistentConfig> {
         Ok(PersistentConfig::default())
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,7 @@ error_chain! {
         ParseInt(num::ParseIntError);
         Persist(tempfile::PersistError);
         TomlDe(toml::de::Error);
+        TomlSer(toml::ser::Error);
         Utf8(str::Utf8Error);
         Xdv(tectonic_xdv::XdvError);
         Zip(ZipError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,8 @@ extern crate hyper_native_tls;
 extern crate libc;
 extern crate md5;
 extern crate tempfile;
-#[cfg(feature = "serde_derive")]
-#[macro_use] extern crate serde_derive;
-#[cfg(feature = "serde")]
-extern crate serde;
+#[cfg(feature = "serde_derive")] #[macro_use] extern crate serde_derive;
+#[cfg(feature = "serde")] extern crate serde;
 extern crate sha2;
 extern crate tectonic_xdv;
 extern crate termcolor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,9 @@ extern crate hyper_native_tls;
 extern crate libc;
 extern crate md5;
 extern crate tempfile;
+#[cfg(feature = "serde_derive")]
 #[macro_use] extern crate serde_derive;
+#[cfg(feature = "serde")]
 extern crate serde;
 extern crate sha2;
 extern crate tectonic_xdv;


### PR DESCRIPTION
This introduces the `confile_file` feature that is enabled by default. Disabling the feature allow building for musl targets.