### PR TITLE
tectonic/core-foundation.h: fix build for certain versions of g++

### DIFF
--- a/tectonic/core-foundation.h
+++ b/tectonic/core-foundation.h
@@ -15,6 +15,11 @@
 
 #define _DARWIN_USE_64_BIT_INODE 1
 
+/* Some versions of g++ do not define PRId64 and friends unless we #define
+ * this before including inttypes.h. This was apparently an idea that was
+ * proposed for C++11 but didn't make it into the final standard. */
+#define __STDC_FORMAT_MACROS
+
 /* Universal headers */
 
 #include <assert.h>


### PR DESCRIPTION
Some versions apparently do not #define PRId64 and friends unless you add a special triggering #define.

This fixes a problem discovered when trying to build 0.1.11 on conda-forge ([tectonic-feedstock #11](https://github.com/conda-forge/tectonic-feedstock/pull/14)).