### PR TITLE
Fix changelog grammar: "the code [...] mode [...] reusable" → "the code [...] has been made [...] reusable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ Developer-facing improvements:
 - Tectonic is now more up-front about the fact that it requires Harfbuzz
   version 1.4 or higher.
 - Much of the code that drives compilation for the CLI tool has been moved
-  into the Tectonic library and mode (more) reusable
+  into the Tectonic library and made (more) reusable
   ([#184](https://github.com/tectonic-typesetting/tectonic/pull/184)). Thanks
   to new contributor [@jneem](https://github.com/jneem) for doing this!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ Developer-facing improvements:
 - Tectonic is now more up-front about the fact that it requires Harfbuzz
   version 1.4 or higher.
 - Much of the code that drives compilation for the CLI tool has been moved
-  into the Tectonic library and made (more) reusable
+  into the Tectonic library and has been made (more) reusable
   ([#184](https://github.com/tectonic-typesetting/tectonic/pull/184)). Thanks
   to new contributor [@jneem](https://github.com/jneem) for doing this!
 


### PR DESCRIPTION
I first noticed this on the [releases page](https://github.com/tectonic-typesetting/tectonic/releases). Probably should be fixed there, too, if possible.