### PR TITLE
Suppress unknown warnings on Clang

### DIFF
--- a/tectonic/dpx-truetype.c
+++ b/tectonic/dpx-truetype.c
@@ -122,11 +122,13 @@ pdf_font_open_truetype (pdf_font *font)
         length = tt_get_ps_fontname(sfont, fontname, 255);
         if (length < 1) {
             length = MIN(strlen(ident), 255);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#define SUPPRESS_WARNING "-Wstringop-overflow"
+#include "suppress_warning/push.h"
+#define SUPPRESS_WARNING "-Wstringop-truncation"
+#include "suppress_warning/push.h"
             strncpy(fontname, ident, length);
-#pragma GCC diagnostic pop
+#include "suppress_warning/pop.h"
+#include "suppress_warning/pop.h"
         }
         fontname[length] = '\0';
         for (n = 0; n < length; n++) {

--- a/tectonic/suppress_warning/LICENSE
+++ b/tectonic/suppress_warning/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 David M Krauss (potatoswatter)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tectonic/suppress_warning/README.md
+++ b/tectonic/suppress_warning/README.md
@@ -1,0 +1,48 @@
+`suppress_warning` library
+==========================
+
+A small C and C++ preprocessor library to suppress warnings without compromising backward compatibility.
+
+*by David Krauss (potatoswatter)*
+<!-- language: lang-c lang-cxx -->
+
+Summary
+=======
+
+Compilers, particularly Clang, implement ever-more warnings as friendly reminders to follow good coding practices.
+Sometimes warnings are spurious and they must be silenced in particular instances.
+
+There is a `#pragma` directive to do so, but it generates another warning if the compiler simply doesn't implement the warning.
+Clang offers a `__has_warning` macro to avoid this issue, but then you also need to check that `__has_warning` exists… it gets complicated.
+
+With this library, if you wanted to write `char q = { 800 };` in C++, you can suppress the two resulting diagnostic messages like so:
+
+    // Specify the warning flag by defining the SUPPRESS_WARNING macro.
+    #define SUPPRESS_WARNING "-Wnarrowing"
+    // Include the header to suppress the warning and un-define the SUPPRESS_WARNING parameter.
+    #include "suppress_warning/push.h"
+
+    // Warning suppressions may be nested.
+    #define SUPPRESS_WARNING "-Wconstant-conversion"
+    #include "suppress_warning/push.h"
+
+    char q = { 800 }; // Do dastardly deeds without reprimand.
+
+    // Re-enable warnings when finished.
+    #include "suppress_warning/pop.h"
+    #include "suppress_warning/pop.h"
+
+Compatibility
+=============
+
+Unfortunately, GCC does not yet implement `__has_warning`. Anticipating that it will, this library is coded for forward compatibility.
+Until then, only Clang is supported and warnings are not suppressed on GCC.
+
+Tectonic Notes
+==============
+
+* Original source: <https://github.com/potswa/suppress_warning>
+* Commit: 85b6451fd02916d4c8c94caf9d7f6c96e88826ca
+* Discovered at <https://stackoverflow.com/a/42979988/545794>
+* Changes: The header file names were modified from the original. Everything
+  else is the same.

--- a/tectonic/suppress_warning/pop.h
+++ b/tectonic/suppress_warning/pop.h
@@ -1,0 +1,6 @@
+// unsuppress_warning.h
+// This inclusion file has no header guard because it may be multiply included.
+
+#if __GNUC__
+#   pragma GCC diagnostic pop
+#endif

--- a/tectonic/suppress_warning/push.h
+++ b/tectonic/suppress_warning/push.h
@@ -1,0 +1,18 @@
+// suppress_warning.h
+// This inclusion file has no header guard because it may be multiply included.
+
+#if __GNUC__
+#   pragma GCC diagnostic push
+#   ifdef __has_warning
+#       define S6_SUPPRESS_HAS_WARNING( X ) __has_warning( X )
+#       if S6_SUPPRESS_HAS_WARNING( SUPPRESS_WARNING )
+
+             // Use the _Pragma operator to access the macro flag from the directive.
+#            define S6_SUPPRESS_LITERAL_PRAGMA( X ) _Pragma( # X )
+#            define S6_SUPPRESS_EXPAND_PRAGMA( X ) S6_SUPPRESS_LITERAL_PRAGMA( X )
+             S6_SUPPRESS_EXPAND_PRAGMA( GCC diagnostic ignored SUPPRESS_WARNING )
+#       endif
+#   endif
+#endif
+
+#undef SUPPRESS_WARNING


### PR DESCRIPTION
For this line:

```c
#pragma GCC diagnostic ignored "-Wstringop-overflow"
```

Clang prints this warning:

```
warning: unknown warning group '-Wstringop-overflow', ignored [-Wunknown-warning-option]
```

This change imports a library with clever CPP that suppresses warnings for GCC and avoids showing warnings for Clang.

I imported the whole library to include the license and helpful documentation.

I renamed the header files to hint that push and pop need to be included in equal (nested) numbers.