### PR TITLE
cargo clippy: fix redundant_field_names

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -79,8 +79,8 @@ pub struct FileSummary {
 impl FileSummary {
     fn new(access_pattern: AccessPattern, input_origin: InputOrigin) -> FileSummary {
         FileSummary {
-            access_pattern: access_pattern,
-            input_origin: input_origin,
+            access_pattern,
+            input_origin,
             read_digest: None,
             write_digest: None,
             got_written_to_disk: false,
@@ -504,7 +504,7 @@ impl ProcessingSessionBuilder {
             io: io.create(status)?,
             events: IoEvents::new(),
             pass: self.pass,
-            primary_input_path: primary_input_path,
+            primary_input_path,
             primary_input_tex_path: tex_input_name,
             format_name: self.format_name.unwrap(),
             tex_aux_path: aux_path.into_os_string(),
@@ -512,7 +512,7 @@ impl ProcessingSessionBuilder {
             tex_pdf_path: pdf_path.into_os_string(),
             output_format: self.output_format,
             makefile_output_path: self.makefile_output_path,
-            output_path: output_path,
+            output_path,
             tex_rerun_specification: self.reruns,
             keep_intermediates: self.keep_intermediates,
             keep_logs: self.keep_logs,

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -135,9 +135,9 @@ impl<'a, I: 'a + IoProvider> ExecutionState<'a, I> {
         status: &'a mut StatusBackend,
     ) -> ExecutionState<'a, I> {
         ExecutionState {
-            io: io,
-            events: events,
-            status: status,
+            io,
+            events,
+            status,
             output_handles: Vec::new(),
             input_handles: Vec::new(),
         }

--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -75,10 +75,10 @@ impl<'a, 'b: 'a> State<'a, 'b> {
         status: &'a mut StatusBackend,
     ) -> Self {
         Self {
-            outname: outname,
-            io: io,
-            events: events,
-            status: status,
+            outname,
+            io,
+            events,
+            status,
             cur_output: None,
             warned_lost_chars: false,
             buf: Vec::new(),

--- a/src/io/filesystem.rs
+++ b/src/io/filesystem.rs
@@ -74,9 +74,9 @@ impl FilesystemIo {
     ) -> FilesystemIo {
         FilesystemIo {
             root: PathBuf::from(root),
-            writes_allowed: writes_allowed,
-            absolute_allowed: absolute_allowed,
-            hidden_input_paths: hidden_input_paths,
+            writes_allowed,
+            absolute_allowed,
+            hidden_input_paths,
         }
     }
 

--- a/src/io/format_cache.rs
+++ b/src/io/format_cache.rs
@@ -34,8 +34,8 @@ impl FormatCache {
     /// a local cache directory.
     pub fn new(bundle_digest: DigestData, formats_base: PathBuf) -> FormatCache {
         FormatCache {
-            bundle_digest: bundle_digest,
-            formats_base: formats_base,
+            bundle_digest,
+            formats_base,
         }
     }
 

--- a/src/io/itarbundle.rs
+++ b/src/io/itarbundle.rs
@@ -34,11 +34,9 @@ pub struct HttpRangeReader {
 
 impl HttpRangeReader {
     pub fn new(url: &str) -> HttpRangeReader {
-        let client = create_hyper_client();
-
         HttpRangeReader {
             url: url.to_owned(),
-            client: client,
+            client: create_hyper_client(),
         }
     }
 }
@@ -90,7 +88,7 @@ pub struct ITarBundle<F: ITarIoFactory> {
 impl<F: ITarIoFactory> ITarBundle<F> {
     fn construct(factory: F) -> ITarBundle<F> {
         ITarBundle {
-            factory: factory,
+            factory,
             data: None,
             index: HashMap::new(),
         }
@@ -114,14 +112,11 @@ impl<F: ITarIoFactory> ITarBundle<F> {
                 continue; // TODO: preserve the warning info or something!
             }
 
-            let name = OsString::from(bits[0]);
-            let offset = bits[1].parse::<u64>()?;
-            let length = bits[2].parse::<u64>()?;
             self.index.insert(
-                name,
+                OsString::from(bits[0]),
                 FileInfo {
-                    offset: offset,
-                    length: length,
+                    offset: bits[1].parse::<u64>()?,
+                    length: bits[2].parse::<u64>()?,
                 },
             );
         }

--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -138,7 +138,7 @@ impl<B: Bundle> LocalCache<B> {
                         name,
                         LocalCacheItem {
                             _length: length,
-                            digest: digest,
+                            digest,
                         },
                     );
                 }
@@ -148,14 +148,14 @@ impl<B: Bundle> LocalCache<B> {
         // All set.
 
         Ok(LocalCache {
-            backend: backend,
+            backend,
             digest_path: digest.to_owned(),
-            cached_digest: cached_digest,
-            checked_digest: checked_digest,
-            manifest_path: manifest_path,
+            cached_digest,
+            checked_digest,
+            manifest_path,
             data_path: data.to_owned(),
-            contents: contents,
-            only_cached: only_cached,
+            contents,
+            only_cached,
         })
     }
 
@@ -192,7 +192,7 @@ impl<B: Bundle> LocalCache<B> {
             name.to_owned(),
             LocalCacheItem {
                 _length: length,
-                digest: digest,
+                digest,
             },
         );
         Ok(())

--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -105,7 +105,7 @@ impl MemoryIo {
     pub fn new(stdout_allowed: bool) -> MemoryIo {
         MemoryIo {
             files: Rc::new(RefCell::new(HashMap::new())),
-            stdout_allowed: stdout_allowed,
+            stdout_allowed,
         }
     }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -96,7 +96,7 @@ impl InputHandle {
             name: name.to_os_string(),
             inner: Box::new(inner),
             digest: Default::default(),
-            origin: origin,
+            origin,
             ever_read: false,
             did_unhandled_seek: false,
             ungetc_char: None,

--- a/src/io/setup.rs
+++ b/src/io/setup.rs
@@ -242,7 +242,7 @@ impl IoSetupBuilder {
                 true,
                 self.hidden_input_paths,
             ),
-            format_cache: format_cache,
+            format_cache,
             bundle: self.bundle,
             genuine_stdout: if self.use_genuine_stdout {
                 Some(GenuineStdoutIo::new())

--- a/src/io/stack.rs
+++ b/src/io/stack.rs
@@ -18,7 +18,7 @@ pub struct IoStack<'a> {
 
 impl<'a> IoStack<'a> {
     pub fn new(items: Vec<&'a mut IoProvider>) -> IoStack<'a> {
-        IoStack { items: items }
+        IoStack { items }
     }
 }
 

--- a/src/status/termcolor.rs
+++ b/src/status/termcolor.rs
@@ -38,13 +38,13 @@ impl TermcolorStatusBackend {
         error_spec.set_fg(Some(Color::Red)).set_bold(true);
 
         TermcolorStatusBackend {
-            chatter: chatter,
+            chatter,
             stdout: StandardStream::stdout(ColorChoice::Auto),
             stderr: StandardStream::stderr(ColorChoice::Auto),
-            note_spec: note_spec,
-            highlight_spec: highlight_spec,
-            warning_spec: warning_spec,
-            error_spec: error_spec,
+            note_spec,
+            highlight_spec,
+            warning_spec,
+            error_spec,
         }
     }
 


### PR DESCRIPTION
I started looking at [`clippy`](https://github.com/rust-lang/rust-clippy) output. There are a large number of warnings. Rather than do them all and have an overwhelming PR, I started with `redundant_field_names`.

I think it would be good to eventually add `cargo clippy` to CI, but, first, I'd like to get feedback on this bit of lint fixing.