### PR TITLE
cargo clippy: fix unused_io_amount

### DIFF
--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -153,7 +153,7 @@ impl<'a, 'b: 'a> XdvEvents for State<'a, 'b> {
 
         if self.buf.len() > 0 {
             self.buf.push(0x0a); // newline
-            dest.write(&self.buf)?;
+            dest.write_all(&self.buf)?;
         }
 
         Ok(())


### PR DESCRIPTION
Fixes [`unused_io_amount`](https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount)

Note that this change may affect your logic. But, considering you're not checking for the number of bytes written by `io::Write::write`, I'm guessing it's safe.