### PR TITLE
cargo clippy: fix cast_lossless

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -732,7 +732,7 @@ extern "C" fn input_getc<'a, I: 'a + IoProvider>(
     // No need to complain. Fun match statement here.
 
     match es.input_getc(rhandle) {
-        Ok(b) => b as libc::c_int,
+        Ok(b) => libc::c_int::from(b),
         Err(Error(ErrorKind::Io(ref ioe), _)) if ioe.kind() == io::ErrorKind::UnexpectedEof => {
             libc::EOF
         }


### PR DESCRIPTION
Fixes [`cast_lossless`](https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless)