### PR TITLE
Suppress unknown warnings on Clang, alternate version

### DIFF
--- a/tectonic/dpx-truetype.c
+++ b/tectonic/dpx-truetype.c
@@ -122,11 +122,18 @@ pdf_font_open_truetype (pdf_font *font)
         length = tt_get_ps_fontname(sfont, fontname, 255);
         if (length < 1) {
             length = MIN(strlen(ident), 255);
+/* Suppress some warnings on GCC. Clang supports the same warning control
+ * #pragmas (and #defines __GNUC__!), but not these particular warnings, which
+ * leads to a meta-warning if they're left unguarded. */
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
             strncpy(fontname, ident, length);
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
         }
         fontname[length] = '\0';
         for (n = 0; n < length; n++) {

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -28,6 +28,7 @@ lazy_static! {
 }
 
 fn get_plain_format_arg() -> String {
+    util::set_test_root();
     let path = ensure_plain_format().expect("couldn't write format file");
     format!("--format={}", path.display())
 }
@@ -177,8 +178,6 @@ fn relative_include() {
     if env::var("RUNNING_COVERAGE").is_ok() {
         return;
     }
-
-    util::set_test_root();
 
     let fmt_arg = get_plain_format_arg();
     let tempdir = setup_and_copy_files(&[


### PR DESCRIPTION
Inspired by #328 by @spl, but takes a different tack. The limitation with the other PR is that the header file didn't actually suppress the warnings on GCC! At the moment, I think it's just simpler to gate the pragmas by compiler explicitly.

This PR also includes a fix against a race condition in the test suite.