### PR TITLE
Run clippy on Travis-CI

### DIFF
--- a/dist/travis.sh
+++ b/dist/travis.sh
@@ -22,6 +22,7 @@ set -e
 
 # Helpful context.
 
+echo "TRAVIS_ALLOW_FAILURE: $TRAVIS_ALLOW_FAILURE"
 echo "TRAVIS_BRANCH: $TRAVIS_BRANCH"
 echo "TRAVIS_BUILD_ID: $TRAVIS_BUILD_ID"
 echo "TRAVIS_COMMIT: $TRAVIS_COMMIT"
@@ -136,27 +137,17 @@ elif [[ "$TRAVIS_OS_NAME" == linux ]] ; then
     fi
 fi
 
-rustup component add rustfmt
-
 travis_end_fold pre_build
 
-# Check that the code is properly rustfmt'd.
+# Check that the code is properly rustfmt'd and clippy'd.
 
-travis_start_fold check_rustfmt "Maybe check rustfmt? ($is_main_build)"
+travis_start_fold check_rustfmt_clippy "Maybe rustfmt and clippy? ($is_main_build)"
 if $is_main_build ; then
+    rustup component add rustfmt clippy
     cargo fmt --all -- --check
+    cargo clippy --all --all-targets --all-features -- --deny warnings
 fi
-travis_end_fold check_rustfmt
-
-rustup component add clippy
-
-# Check that the code is properly clippy'd.
-
-travis_start_fold check_clippy "Maybe check clippy? ($is_main_build)"
-if $is_main_build ; then
-    cargo clippy --all-targets --all-features -- -D warnings
-fi
-travis_end_fold check_clippy
+travis_end_fold check_rustfmt_clippy
 
 # OK, the biggie: does it compile and pass the test suite?
 

--- a/dist/travis.sh
+++ b/dist/travis.sh
@@ -148,6 +148,16 @@ if $is_main_build ; then
 fi
 travis_end_fold check_rustfmt
 
+rustup component add clippy
+
+# Check that the code is properly clippy'd.
+
+travis_start_fold check_clippy "Maybe check clippy? ($is_main_build)"
+if $is_main_build ; then
+    cargo clippy --all-targets --all-features -- -D warnings
+fi
+travis_end_fold check_clippy
+
 # OK, the biggie: does it compile and pass the test suite?
 
 travis_start_fold build_and_test "Build and test"


### PR DESCRIPTION
This causes Travis-CI to fail if `clippy` finds any warning lints. It will, of course, fail now, since there are warnings to be found. But if #351 and #352 are merged and this branch is updated, it will pass.