### PR TITLE
Install Homebrew packages in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ addons:
       - libssl-dev
       - openssl
       - zlib1g-dev
+  homebrew:
+    packages:
+      - harfbuzz
+      - openssl
 
 install: true
 script: bash dist/travis.sh

--- a/dist/travis.sh
+++ b/dist/travis.sh
@@ -103,10 +103,6 @@ travis_end_fold continuous_abort
 
 travis_start_fold pre_build "Pre-build setup for OS = $TRAVIS_OS_NAME"
 if [[ "$TRAVIS_OS_NAME" == osx ]]; then
-    brew update
-    brew install harfbuzz
-    brew install --force openssl
-
     export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include
     export OPENSSL_LIB_DIR=$(brew --prefix openssl)/lib
     export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include


### PR DESCRIPTION
Use the Travis-CI [`homebrew` add-on](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-macos) to `brew install` packages on macOS.

Comments:
* This does not do a `brew update` since that slows down the build quite a bit.
* I don't think the `--force` flag is necessary for `brew install openssl`.