### PR TITLE
replace usage of deprecated tempdir crate with tempfile.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,18 +523,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -818,7 +806,6 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tectonic_xdv 0.1.9-dev",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -831,15 +818,6 @@ version = "0.1.9-dev"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1120,7 +1098,6 @@ dependencies = [
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -1152,7 +1129,6 @@ dependencies = [
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,4 +69,4 @@ serialization = ["serde"]
 # libz-sys = "^1.0"
 
 [dev-dependencies]
-tempdir = "^0.3"
+tempfile = "^3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,6 @@ impl PersistentConfig {
         use app_dirs::{app_root, get_app_root};
         use std::io::ErrorKind as IoErrorKind;
         use std::io::{Read, Write};
-        use toml;
         let mut cfg_path = if auto_create_config_file {
             app_root(AppDataType::UserConfig, &::APP_INFO)?
         } else {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -619,7 +619,6 @@ impl ProcessingSession {
     fn _dump_access_info<S: StatusBackend>(&self, status: &mut S) {
         for (name, info) in &self.events.0 {
             if info.access_pattern != AccessPattern::Read {
-                use std::string::ToString;
                 let r = match info.read_digest {
                     Some(ref d) => d.to_string(),
                     None => "-".into(),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -288,8 +288,6 @@ impl<T> OpenResult<T> {
 
     /// Convert this object into a plain Result, erroring if the item was not available.
     pub fn must_exist(self) -> Result<T> {
-        use std::io;
-
         match self {
             OpenResult::Ok(t) => Ok(t),
             OpenResult::Err(e) => Err(e),

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -9,13 +9,12 @@
 //! enable the reproducibility options used in the `tex-outputs` test rig.
 
 extern crate tectonic;
-extern crate tempdir;
+extern crate tempfile;
 
 use tectonic::config::PersistentConfig;
 use tectonic::driver::ProcessingSessionBuilder;
 use tectonic::status::termcolor::TermcolorStatusBackend;
 use tectonic::status::ChatterLevel;
-use tempdir::TempDir;
 
 mod util;
 
@@ -32,7 +31,10 @@ fn the_letter_a() {
 
     let bundle = util::TestBundle::default();
 
-    let tempdir = TempDir::new("tectonic_driver_test").unwrap();
+    let tempdir = tempfile::Builder::new()
+        .prefix("tectonic_driver_test")
+        .tempdir()
+        .unwrap();
 
     let mut pbuilder = ProcessingSessionBuilder::default();
     pbuilder

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -14,6 +14,7 @@ use std::process::{Command, Output, Stdio};
 use std::str;
 use tempfile::TempDir;
 
+#[path = "util/mod.rs"]
 mod util;
 use util::{cargo_dir, ensure_plain_format};
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate tectonic;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::env;
 use std::fs::{self, File};
@@ -12,7 +12,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::str;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 mod util;
 use util::{cargo_dir, ensure_plain_format};
@@ -80,7 +80,10 @@ fn run_tectonic_with_stdin(cwd: &Path, args: &[&str], stdin: &str) -> Output {
 }
 
 fn setup_and_copy_files(files: &[&str]) -> TempDir {
-    let tempdir = TempDir::new("tectonic_executable_test").unwrap();
+    let tempdir = tempfile::Builder::new()
+        .prefix("tectonic_executable_test")
+        .tempdir()
+        .unwrap();
     let executable_test_dir =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("tests/executable");
 

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -15,6 +15,7 @@ use tectonic::io::{FilesystemIo, FilesystemPrimaryInputIo, IoProvider, IoStack, 
 use tectonic::status::NoopStatusBackend;
 use tectonic::{TexEngine, XdvipdfmxEngine};
 
+#[path = "util/mod.rs"]
 mod util;
 use util::{ensure_plain_format, test_path, ExpectedInfo};
 

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -23,6 +23,7 @@ use tectonic::io::{FilesystemPrimaryInputIo, IoProvider, IoStack, MemoryIo};
 use tectonic::status::NoopStatusBackend;
 use tectonic::TexEngine;
 
+#[path = "util/mod.rs"]
 mod util;
 use util::{test_path, ExpectedInfo};
 

--- a/xdv/src/lib.rs
+++ b/xdv/src/lib.rs
@@ -275,7 +275,7 @@ impl<T: XdvEvents> XdvParser<T> {
     /// not the same as the buffer size, some of the existing bytes must be
     /// re-fed to the parser. If the returned value is 0, you need a bigger
     /// buffer in order to be able to parse the next directive.
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     pub fn parse(&mut self, chunk: &[u8]) -> Result<usize, T::Error> {
         let mut cursor = Cursor::new(chunk, self.offset);
 


### PR DESCRIPTION
It's only used in tests, but the tempdir crate has been deprecated here:
https://github.com/rust-lang-deprecated/tempdir

This updates the tests to use tempfile.