### PR TITLE
Cleanup rust warnings and update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 keywords = ["tex", "latex", "typesetting", "font"]
 categories = ["command-line-interface", "parser-implementations", "rendering", "science", "text-processing"]
 license = "MIT"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "tectonic-typesetting/tectonic" }

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,8 @@
 //
 // TODO: this surely needs to become much smarter and more flexible.
 
-extern crate cc;
-extern crate pkg_config;
-extern crate regex;
-extern crate sha2;
+use cc;
+use pkg_config;
 
 use std::path::PathBuf;
 

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -2,12 +2,8 @@
 // Copyright 2016-2018 the Tectonic Project
 // Licensed under the MIT License.
 
-extern crate aho_corasick;
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate tectonic;
-extern crate termcolor;
+use clap::crate_version;
+use tectonic;
 
 use clap::{App, Arg, ArgMatches};
 use std::fs::File;
@@ -20,6 +16,8 @@ use tectonic::errors::{ErrorKind, Result};
 use tectonic::io::zipbundle::ZipBundle;
 use tectonic::status::termcolor::TermcolorStatusBackend;
 use tectonic::status::{ChatterLevel, StatusBackend};
+
+use tectonic::{ctry, errmsg, tt_error, tt_error_styled, tt_note};
 
 fn inner(
     args: ArgMatches,

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,12 +19,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_dirs::{app_dir, sanitized, AppDataType};
 
-use errors::{ErrorKind, Result};
-use io::itarbundle::{HttpITarIoFactory, ITarBundle};
-use io::local_cache::LocalCache;
-use io::zipbundle::ZipBundle;
-use io::Bundle;
-use status::StatusBackend;
+use crate::errors::{ErrorKind, Result};
+use crate::io::itarbundle::{HttpITarIoFactory, ITarBundle};
+use crate::io::local_cache::LocalCache;
+use crate::io::zipbundle::ZipBundle;
+use crate::io::Bundle;
+use crate::status::StatusBackend;
 
 /// Awesome hack time!!!
 ///
@@ -65,9 +65,9 @@ impl PersistentConfig {
         use std::io::ErrorKind as IoErrorKind;
         use std::io::{Read, Write};
         let mut cfg_path = if auto_create_config_file {
-            app_root(AppDataType::UserConfig, &::APP_INFO)?
+            app_root(AppDataType::UserConfig, &crate::APP_INFO)?
         } else {
-            get_app_root(AppDataType::UserConfig, &::APP_INFO)?
+            get_app_root(AppDataType::UserConfig, &crate::APP_INFO)?
         };
         cfg_path.push("config.toml");
 
@@ -116,14 +116,14 @@ impl PersistentConfig {
     ) -> Result<Box<dyn Bundle>> {
         let itb = ITarBundle::<HttpITarIoFactory>::new(url);
 
-        let mut url2digest_path = app_dir(AppDataType::UserCache, &::APP_INFO, "urls")?;
+        let mut url2digest_path = app_dir(AppDataType::UserCache, &crate::APP_INFO, "urls")?;
         url2digest_path.push(sanitized(url));
 
         let bundle = LocalCache::<ITarBundle<HttpITarIoFactory>>::new(
             itb,
             &url2digest_path,
-            &app_dir(AppDataType::UserCache, &::APP_INFO, "manifests")?,
-            &app_dir(AppDataType::UserCache, &::APP_INFO, "files")?,
+            &app_dir(AppDataType::UserCache, &crate::APP_INFO, "manifests")?,
+            &app_dir(AppDataType::UserCache, &crate::APP_INFO, "files")?,
             only_cached,
             status,
         )?;
@@ -152,7 +152,7 @@ impl PersistentConfig {
         use std::io;
 
         if CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst) {
-            return Ok(Box::new(::test_util::TestBundle::default()));
+            return Ok(Box::new(crate::test_util::TestBundle::default()));
         }
 
         if self.default_bundles.len() != 1 {
@@ -180,9 +180,13 @@ impl PersistentConfig {
 
     pub fn format_cache_path(&self) -> Result<PathBuf> {
         if CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst) {
-            Ok(::test_util::test_path(&[]))
+            Ok(crate::test_util::test_path(&[]))
         } else {
-            Ok(app_dir(AppDataType::UserCache, &::APP_INFO, "formats")?)
+            Ok(app_dir(
+                AppDataType::UserCache,
+                &crate::APP_INFO,
+                "formats",
+            )?)
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,8 +112,8 @@ impl PersistentConfig {
         &self,
         url: &str,
         only_cached: bool,
-        status: &mut StatusBackend,
-    ) -> Result<Box<Bundle>> {
+        status: &mut dyn StatusBackend,
+    ) -> Result<Box<dyn Bundle>> {
         let itb = ITarBundle::<HttpITarIoFactory>::new(url);
 
         let mut url2digest_path = app_dir(AppDataType::UserCache, &::APP_INFO, "urls")?;
@@ -134,8 +134,8 @@ impl PersistentConfig {
     pub fn make_local_file_provider(
         &self,
         file_path: &OsStr,
-        _status: &mut StatusBackend,
-    ) -> Result<Box<Bundle>> {
+        _status: &mut dyn StatusBackend,
+    ) -> Result<Box<dyn Bundle>> {
         use std::path::Path;
 
         let zip_bundle = ZipBundle::<File>::open(Path::new(file_path))?;
@@ -146,8 +146,8 @@ impl PersistentConfig {
     pub fn default_bundle(
         &self,
         only_cached: bool,
-        status: &mut StatusBackend,
-    ) -> Result<Box<Bundle>> {
+        status: &mut dyn StatusBackend,
+    ) -> Result<Box<dyn Bundle>> {
         use hyper::Url;
         use std::io;
 

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::ToString;
 
-use errors::{Error, ErrorKind, Result};
+use crate::errors::{Error, ErrorKind, Result};
 
 // Generic helpers
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -24,6 +24,7 @@ use crate::engines::IoEventBackend;
 use crate::errors::{ErrorKind, Result, ResultExt};
 use crate::io::{Bundle, InputOrigin, IoProvider, IoSetup, IoSetupBuilder, OpenResult};
 use crate::status::StatusBackend;
+use crate::{ctry, errmsg, tt_error, tt_note, tt_warning};
 use crate::{BibtexEngine, Spx2HtmlEngine, TexEngine, TexResult, XdvipdfmxEngine};
 
 /// Different patterns with which files may have been accessed by the

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -19,12 +19,12 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use digest::DigestData;
-use engines::IoEventBackend;
-use errors::{ErrorKind, Result, ResultExt};
-use io::{Bundle, InputOrigin, IoProvider, IoSetup, IoSetupBuilder, OpenResult};
-use status::StatusBackend;
-use {BibtexEngine, Spx2HtmlEngine, TexEngine, TexResult, XdvipdfmxEngine};
+use crate::digest::DigestData;
+use crate::engines::IoEventBackend;
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::io::{Bundle, InputOrigin, IoProvider, IoSetup, IoSetupBuilder, OpenResult};
+use crate::status::StatusBackend;
+use crate::{BibtexEngine, Spx2HtmlEngine, TexEngine, TexResult, XdvipdfmxEngine};
 
 /// Different patterns with which files may have been accessed by the
 /// underlying engines. Once a file is marked as ReadThenWritten or

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -289,7 +289,7 @@ pub struct ProcessingSessionBuilder {
     pass: PassSetting,
     reruns: Option<usize>,
     print_stdout: bool,
-    bundle: Option<Box<Bundle>>,
+    bundle: Option<Box<dyn Bundle>>,
     keep_intermediates: bool,
     keep_logs: bool,
     synctex: bool,
@@ -408,7 +408,7 @@ impl ProcessingSessionBuilder {
 
     /// Sets the bundle, which the various engines will use for finding style files, font files,
     /// etc.
-    pub fn bundle(&mut self, b: Box<Bundle>) -> &mut Self {
+    pub fn bundle(&mut self, b: Box<dyn Bundle>) -> &mut Self {
         self.bundle = Some(b);
         self
     }
@@ -432,7 +432,7 @@ impl ProcessingSessionBuilder {
     }
 
     /// Creates a `ProcessingSession`.
-    pub fn create(self, status: &mut StatusBackend) -> Result<ProcessingSession> {
+    pub fn create(self, status: &mut dyn StatusBackend) -> Result<ProcessingSession> {
         let mut io = IoSetupBuilder::default();
         io.bundle(self.bundle.expect("a bundle must be specified"))
             .use_genuine_stdout(self.print_stdout);

--- a/src/engines/bibtex.rs
+++ b/src/engines/bibtex.rs
@@ -21,8 +21,8 @@ impl BibtexEngine {
     pub fn process(
         &mut self,
         io: &mut IoStack,
-        events: &mut IoEventBackend,
-        status: &mut StatusBackend,
+        events: &mut dyn IoEventBackend,
+        status: &mut dyn StatusBackend,
         aux: &str,
     ) -> Result<TexResult> {
         let _guard = super::ENGINE_LOCK.lock().unwrap(); // until we're thread-safe ...

--- a/src/engines/bibtex.rs
+++ b/src/engines/bibtex.rs
@@ -6,9 +6,9 @@ use std::ffi::{CStr, CString};
 
 use super::tex::TexResult;
 use super::{ExecutionState, IoEventBackend, TectonicBridgeApi};
-use errors::{ErrorKind, Result};
-use io::IoStack;
-use status::StatusBackend;
+use crate::errors::{ErrorKind, Result};
+use crate::io::IoStack;
+use crate::status::StatusBackend;
 
 #[derive(Default)]
 pub struct BibtexEngine {}

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -14,6 +14,7 @@
 
 use flate2::read::GzDecoder;
 use flate2::{Compression, GzBuilder};
+use lazy_static::lazy_static;
 use libc;
 use md5::{Digest, Md5};
 use std::borrow::Cow;
@@ -27,6 +28,7 @@ use crate::digest::DigestData;
 use crate::errors::{Error, ErrorKind, Result};
 use crate::io::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle};
 use crate::status::StatusBackend;
+use crate::{tt_error, tt_warning};
 
 // Public sub-modules and reexports.
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -23,10 +23,10 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::{io, ptr, slice};
 
-use digest::DigestData;
-use errors::{Error, ErrorKind, Result};
-use io::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle};
-use status::StatusBackend;
+use crate::digest::DigestData;
+use crate::errors::{Error, ErrorKind, Result};
+use crate::io::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle};
+use crate::status::StatusBackend;
 
 // Public sub-modules and reexports.
 

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -123,8 +123,8 @@ lazy_static! {
 
 struct ExecutionState<'a, I: 'a + IoProvider> {
     io: &'a mut I,
-    events: &'a mut IoEventBackend,
-    status: &'a mut StatusBackend,
+    events: &'a mut dyn IoEventBackend,
+    status: &'a mut dyn StatusBackend,
     #[allow(clippy::vec_box)]
     input_handles: Vec<Box<InputHandle>>,
     #[allow(clippy::vec_box)]
@@ -134,8 +134,8 @@ struct ExecutionState<'a, I: 'a + IoProvider> {
 impl<'a, I: 'a + IoProvider> ExecutionState<'a, I> {
     pub fn new(
         io: &'a mut I,
-        events: &'a mut IoEventBackend,
-        status: &'a mut StatusBackend,
+        events: &'a mut dyn IoEventBackend,
+        status: &'a mut dyn StatusBackend,
     ) -> ExecutionState<'a, I> {
         ExecutionState {
             io,

--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -13,6 +13,7 @@ use super::IoEventBackend;
 use crate::errors::{Error, Result};
 use crate::io::{IoProvider, IoStack, OpenResult, OutputHandle};
 use crate::status::StatusBackend;
+use crate::{errmsg, tt_warning};
 
 #[derive(Default)]
 pub struct Spx2HtmlEngine {}

--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -25,8 +25,8 @@ impl Spx2HtmlEngine {
     pub fn process(
         &mut self,
         io: &mut IoStack,
-        events: &mut IoEventBackend,
-        status: &mut StatusBackend,
+        events: &mut dyn IoEventBackend,
+        status: &mut dyn StatusBackend,
         spx: &str,
     ) -> Result<()> {
         let mut input = io.input_open_name(OsStr::new(spx), status).must_exist()?;
@@ -61,8 +61,8 @@ impl Spx2HtmlEngine {
 struct State<'a, 'b: 'a> {
     outname: String,
     io: &'a mut IoStack<'b>,
-    events: &'a mut IoEventBackend,
-    status: &'a mut StatusBackend,
+    events: &'a mut dyn IoEventBackend,
+    status: &'a mut dyn StatusBackend,
     cur_output: Option<OutputHandle>,
     warned_lost_chars: bool,
     buf: Vec<u8>,
@@ -72,8 +72,8 @@ impl<'a, 'b: 'a> State<'a, 'b> {
     pub fn new(
         outname: String,
         io: &'a mut IoStack<'b>,
-        events: &'a mut IoEventBackend,
-        status: &'a mut StatusBackend,
+        events: &'a mut dyn IoEventBackend,
+        status: &'a mut dyn StatusBackend,
     ) -> Self {
         Self {
             outname,

--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -10,9 +10,9 @@ use std::io::Write;
 use tectonic_xdv::{FileType, XdvEvents, XdvParser};
 
 use super::IoEventBackend;
-use errors::{Error, Result};
-use io::{IoProvider, IoStack, OpenResult, OutputHandle};
-use status::StatusBackend;
+use crate::errors::{Error, Result};
+use crate::io::{IoProvider, IoStack, OpenResult, OutputHandle};
+use crate::status::StatusBackend;
 
 #[derive(Default)]
 pub struct Spx2HtmlEngine {}

--- a/src/engines/tex.rs
+++ b/src/engines/tex.rs
@@ -5,9 +5,9 @@
 use std::ffi::{CStr, CString};
 
 use super::{ExecutionState, IoEventBackend, TectonicBridgeApi};
-use errors::{DefinitelySame, ErrorKind, Result};
-use io::IoStack;
-use status::StatusBackend;
+use crate::errors::{DefinitelySame, ErrorKind, Result};
+use crate::io::IoStack;
+use crate::status::StatusBackend;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TexResult {

--- a/src/engines/tex.rs
+++ b/src/engines/tex.rs
@@ -94,8 +94,8 @@ impl TexEngine {
     pub fn process(
         &mut self,
         io: &mut IoStack,
-        events: &mut IoEventBackend,
-        status: &mut StatusBackend,
+        events: &mut dyn IoEventBackend,
+        status: &mut dyn StatusBackend,
         format_file_name: &str,
         input_file_name: &str,
     ) -> Result<TexResult> {

--- a/src/engines/xdvipdfmx.rs
+++ b/src/engines/xdvipdfmx.rs
@@ -5,9 +5,9 @@
 use std::ffi::{CStr, CString};
 
 use super::{ExecutionState, IoEventBackend, TectonicBridgeApi};
-use errors::{ErrorKind, Result};
-use io::IoStack;
-use status::StatusBackend;
+use crate::errors::{ErrorKind, Result};
+use crate::io::IoStack;
+use crate::status::StatusBackend;
 
 pub struct XdvipdfmxEngine {
     enable_compression: bool,

--- a/src/engines/xdvipdfmx.rs
+++ b/src/engines/xdvipdfmx.rs
@@ -35,8 +35,8 @@ impl XdvipdfmxEngine {
     pub fn process(
         &mut self,
         io: &mut IoStack,
-        events: &mut IoEventBackend,
-        status: &mut StatusBackend,
+        events: &mut dyn IoEventBackend,
+        status: &mut dyn StatusBackend,
         dvi: &str,
         pdf: &str,
     ) -> Result<i32> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@
 #![allow(deprecated)]
 
 use app_dirs;
+use error_chain::error_chain;
 use hyper;
 use std::io::Write;
 use std::result::Result as StdResult;

--- a/src/io/filesystem.rs
+++ b/src/io/filesystem.rs
@@ -38,7 +38,7 @@ impl FilesystemPrimaryInputIo {
 }
 
 impl IoProvider for FilesystemPrimaryInputIo {
-    fn input_open_primary(&mut self, _status: &mut StatusBackend) -> OpenResult<InputHandle> {
+    fn input_open_primary(&mut self, _status: &mut dyn StatusBackend) -> OpenResult<InputHandle> {
         let f = match try_open_file(&self.path) {
             OpenResult::Ok(f) => f,
             OpenResult::NotAvailable => return OpenResult::NotAvailable,
@@ -121,7 +121,7 @@ impl IoProvider for FilesystemIo {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        _status: &mut StatusBackend,
+        _status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         let path = match self.construct_path(name) {
             Ok(p) => p,

--- a/src/io/filesystem.rs
+++ b/src/io/filesystem.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use super::{
     try_open_file, InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle,
 };
-use errors::{ErrorKind, Result};
-use status::StatusBackend;
+use crate::errors::{ErrorKind, Result};
+use crate::status::StatusBackend;
 
 /// FilesystemPrimaryInputIo is an I/O provider that provides the TeX "primary input"
 /// file off of the filesystem. This can *pretty much* be achieved with

--- a/src/io/format_cache.rs
+++ b/src/io/format_cache.rs
@@ -11,9 +11,9 @@ use std::path::PathBuf;
 use tempfile;
 
 use super::{InputHandle, InputOrigin, IoProvider, OpenResult};
-use digest::DigestData;
-use errors::{ErrorKind, Result};
-use status::StatusBackend;
+use crate::digest::DigestData;
+use crate::errors::{ErrorKind, Result};
+use crate::status::StatusBackend;
 
 /// A local cache for compiled format files.
 ///
@@ -61,7 +61,7 @@ impl FormatCache {
             "{}-{}-{}.fmt",
             self.bundle_digest.to_string(),
             stem,
-            ::FORMAT_SERIAL
+            crate::FORMAT_SERIAL
         ));
         Ok(p)
     }

--- a/src/io/format_cache.rs
+++ b/src/io/format_cache.rs
@@ -71,7 +71,7 @@ impl IoProvider for FormatCache {
     fn input_open_format(
         &mut self,
         name: &OsStr,
-        _status: &mut StatusBackend,
+        _status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         let path = match self.path_for_format(name) {
             Ok(p) => p,
@@ -91,7 +91,12 @@ impl IoProvider for FormatCache {
         ))
     }
 
-    fn write_format(&mut self, name: &str, data: &[u8], _status: &mut StatusBackend) -> Result<()> {
+    fn write_format(
+        &mut self,
+        name: &str,
+        data: &[u8],
+        _status: &mut dyn StatusBackend,
+    ) -> Result<()> {
         let final_path = self.path_for_format(OsStr::new(name))?;
         let mut temp_dest = tempfile::Builder::new()
             .prefix("format_")

--- a/src/io/itarbundle.rs
+++ b/src/io/itarbundle.rs
@@ -69,9 +69,9 @@ pub trait ITarIoFactory {
     type IndexReader: Read;
     type DataReader: RangeRead;
 
-    fn get_index(&mut self, status: &mut StatusBackend) -> Result<Self::IndexReader>;
+    fn get_index(&mut self, status: &mut dyn StatusBackend) -> Result<Self::IndexReader>;
     fn get_data(&self) -> Result<Self::DataReader>;
-    fn report_fetch(&self, name: &OsStr, status: &mut StatusBackend);
+    fn report_fetch(&self, name: &OsStr, status: &mut dyn StatusBackend);
 }
 
 struct FileInfo {
@@ -94,7 +94,7 @@ impl<F: ITarIoFactory> ITarBundle<F> {
         }
     }
 
-    fn ensure_loaded(&mut self, status: &mut StatusBackend) -> Result<()> {
+    fn ensure_loaded(&mut self, status: &mut dyn StatusBackend) -> Result<()> {
         if self.data.is_some() {
             return Ok(());
         }
@@ -132,7 +132,7 @@ impl<F: ITarIoFactory> IoProvider for ITarBundle<F> {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         if let Err(e) = self.ensure_loaded(status) {
             return OpenResult::Err(e);
@@ -214,7 +214,7 @@ impl ITarIoFactory for HttpITarIoFactory {
     type IndexReader = GzDecoder<Response>;
     type DataReader = HttpRangeReader;
 
-    fn get_index(&mut self, status: &mut StatusBackend) -> Result<GzDecoder<Response>> {
+    fn get_index(&mut self, status: &mut dyn StatusBackend) -> Result<GzDecoder<Response>> {
         tt_note!(status, "indexing {}", self.url);
 
         // First, we actually do a HEAD request on the URL for the data file.
@@ -275,7 +275,7 @@ impl ITarIoFactory for HttpITarIoFactory {
         Ok(HttpRangeReader::new(&self.url))
     }
 
-    fn report_fetch(&self, name: &OsStr, status: &mut StatusBackend) {
+    fn report_fetch(&self, name: &OsStr, status: &mut dyn StatusBackend) {
         tt_note!(status, "downloading {}", name.to_string_lossy());
     }
 }

--- a/src/io/itarbundle.rs
+++ b/src/io/itarbundle.rs
@@ -12,8 +12,8 @@ use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader, Cursor, Read};
 
 use super::{create_hyper_client, Bundle, InputHandle, InputOrigin, IoProvider, OpenResult};
-use errors::{Error, ErrorKind, Result, ResultExt};
-use status::StatusBackend;
+use crate::errors::{Error, ErrorKind, Result, ResultExt};
+use crate::status::StatusBackend;
 
 const MAX_HTTP_ATTEMPTS: usize = 4;
 

--- a/src/io/itarbundle.rs
+++ b/src/io/itarbundle.rs
@@ -14,6 +14,7 @@ use std::io::{BufRead, BufReader, Cursor, Read};
 use super::{create_hyper_client, Bundle, InputHandle, InputOrigin, IoProvider, OpenResult};
 use crate::errors::{Error, ErrorKind, Result, ResultExt};
 use crate::status::StatusBackend;
+use crate::{tt_note, tt_warning};
 
 const MAX_HTTP_ATTEMPTS: usize = 4;
 

--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -13,9 +13,9 @@ use std::str::FromStr;
 use tempfile;
 
 use super::{try_open_file, Bundle, InputHandle, InputOrigin, IoProvider, OpenResult};
-use digest::{self, Digest, DigestData};
-use errors::{ErrorKind, Result};
-use status::StatusBackend;
+use crate::digest::{self, Digest, DigestData};
+use crate::errors::{ErrorKind, Result};
+use crate::status::StatusBackend;
 
 struct LocalCacheItem {
     _length: u64,

--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -16,6 +16,7 @@ use super::{try_open_file, Bundle, InputHandle, InputOrigin, IoProvider, OpenRes
 use crate::digest::{self, Digest, DigestData};
 use crate::errors::{ErrorKind, Result};
 use crate::status::StatusBackend;
+use crate::{ctry, tt_warning};
 
 struct LocalCacheItem {
     _length: u64,

--- a/src/io/local_cache.rs
+++ b/src/io/local_cache.rs
@@ -40,7 +40,7 @@ impl<B: Bundle> LocalCache<B> {
         manifest_base: &Path,
         data: &Path,
         only_cached: bool,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> Result<LocalCache<B>> {
         // If the `digest` file exists, we assume that it is valid; this is
         // *essential* so that we can use a URL as our default IoProvider
@@ -203,7 +203,7 @@ impl<B: Bundle> LocalCache<B> {
     /// error out but set things up so that things should succeed if the
     /// program is re-run. Exactly the lame TeX user experience that I've been
     /// trying to avoid!
-    fn check_digest(&mut self, status: &mut StatusBackend) -> Result<()> {
+    fn check_digest(&mut self, status: &mut dyn StatusBackend) -> Result<()> {
         if self.checked_digest {
             return Ok(());
         }
@@ -250,7 +250,11 @@ impl<B: Bundle> LocalCache<B> {
         Ok(())
     }
 
-    fn path_for_name(&mut self, name: &OsStr, status: &mut StatusBackend) -> OpenResult<PathBuf> {
+    fn path_for_name(
+        &mut self,
+        name: &OsStr,
+        status: &mut dyn StatusBackend,
+    ) -> OpenResult<PathBuf> {
         if let Some(info) = self.contents.get(name) {
             return match info.digest {
                 None => OpenResult::NotAvailable,
@@ -376,7 +380,7 @@ impl<B: Bundle> IoProvider for LocalCache<B> {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         let path = match self.path_for_name(name, status) {
             OpenResult::Ok(p) => p,
@@ -398,7 +402,7 @@ impl<B: Bundle> IoProvider for LocalCache<B> {
 }
 
 impl<B: Bundle> Bundle for LocalCache<B> {
-    fn get_digest(&mut self, _status: &mut StatusBackend) -> Result<DigestData> {
+    fn get_digest(&mut self, _status: &mut dyn StatusBackend) -> Result<DigestData> {
         Ok(self.cached_digest)
     }
 }

--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -12,8 +12,8 @@ use super::{
     normalize_tex_path, InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult,
     OutputHandle,
 };
-use errors::Result;
-use status::StatusBackend;
+use crate::errors::Result;
+use crate::status::StatusBackend;
 
 // MemoryIo is an IoProvider that stores "files" in in-memory buffers.
 //
@@ -170,7 +170,7 @@ impl IoProvider for MemoryIo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use status::NoopStatusBackend;
+    use crate::status::NoopStatusBackend;
     use std::io::{BufRead, BufReader};
 
     /// Early versions had a bug where files were not truncated when opened

--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -147,7 +147,7 @@ impl IoProvider for MemoryIo {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        _status: &mut StatusBackend,
+        _status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         if name.is_empty() {
             return OpenResult::NotAvailable;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -15,6 +15,7 @@ use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::str::FromStr;
 
+use crate::ctry;
 use crate::digest::{self, Digest, DigestData};
 use crate::errors::{Error, ErrorKind, Result};
 use crate::status::StatusBackend;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -15,9 +15,9 @@ use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::str::FromStr;
 
-use digest::{self, Digest, DigestData};
-use errors::{Error, ErrorKind, Result};
-use status::StatusBackend;
+use crate::digest::{self, Digest, DigestData};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::status::StatusBackend;
 
 pub mod filesystem;
 pub mod format_cache;

--- a/src/io/setup.rs
+++ b/src/io/setup.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use errors::Result;
-use io::format_cache::FormatCache;
-use io::stdstreams::BufferedPrimaryIo;
-use io::{
+use crate::errors::Result;
+use crate::io::format_cache::FormatCache;
+use crate::io::stdstreams::BufferedPrimaryIo;
+use crate::io::{
     Bundle, FilesystemIo, FilesystemPrimaryInputIo, GenuineStdoutIo, IoProvider, IoStack, MemoryIo,
 };
-use status::StatusBackend;
+use crate::status::StatusBackend;
 
 /// An `IoSetup` is essentially a typed, structured version of an [`IoStack`].
 ///

--- a/src/io/setup.rs
+++ b/src/io/setup.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use crate::ctry;
 use crate::errors::Result;
 use crate::io::format_cache::FormatCache;
 use crate::io::stdstreams::BufferedPrimaryIo;

--- a/src/io/stack.rs
+++ b/src/io/stack.rs
@@ -13,11 +13,11 @@ use status::StatusBackend;
 /// need to run multiple passes of the TeX engine.
 
 pub struct IoStack<'a> {
-    items: Vec<&'a mut IoProvider>,
+    items: Vec<&'a mut dyn IoProvider>,
 }
 
 impl<'a> IoStack<'a> {
-    pub fn new(items: Vec<&'a mut IoProvider>) -> IoStack<'a> {
+    pub fn new(items: Vec<&'a mut dyn IoProvider>) -> IoStack<'a> {
         IoStack { items }
     }
 }
@@ -52,7 +52,7 @@ impl<'a> IoProvider for IoStack<'a> {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         for item in &mut self.items {
             let r = item.input_open_name(name, status);
@@ -66,7 +66,7 @@ impl<'a> IoProvider for IoStack<'a> {
         OpenResult::NotAvailable
     }
 
-    fn input_open_primary(&mut self, status: &mut StatusBackend) -> OpenResult<InputHandle> {
+    fn input_open_primary(&mut self, status: &mut dyn StatusBackend) -> OpenResult<InputHandle> {
         for item in &mut self.items {
             let r = item.input_open_primary(status);
 
@@ -82,7 +82,7 @@ impl<'a> IoProvider for IoStack<'a> {
     fn input_open_format(
         &mut self,
         name: &OsStr,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         for item in &mut self.items {
             let r = item.input_open_format(name, status);

--- a/src/io/stack.rs
+++ b/src/io/stack.rs
@@ -5,7 +5,7 @@
 use std::ffi::OsStr;
 
 use super::{InputHandle, IoProvider, OpenResult, OutputHandle};
-use status::StatusBackend;
+use crate::status::StatusBackend;
 
 /// An IoStack is an IoProvider that delegates to an ordered list of
 /// subordinate IoProviders. It also checks the order in which files are read

--- a/src/io/stdstreams.rs
+++ b/src/io/stdstreams.rs
@@ -129,7 +129,7 @@ impl BufferedPrimaryIo {
 }
 
 impl IoProvider for BufferedPrimaryIo {
-    fn input_open_primary(&mut self, _status: &mut StatusBackend) -> OpenResult<InputHandle> {
+    fn input_open_primary(&mut self, _status: &mut dyn StatusBackend) -> OpenResult<InputHandle> {
         OpenResult::Ok(InputHandle::new(
             OsStr::new(""),
             Cursor::new(self.buffer.clone()),

--- a/src/io/stdstreams.rs
+++ b/src/io/stdstreams.rs
@@ -7,8 +7,8 @@ use std::io::{stdin, stdout, Cursor, Read, Seek, SeekFrom};
 use std::rc::Rc;
 
 use super::{InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle};
-use errors::Result;
-use status::StatusBackend;
+use crate::errors::Result;
+use crate::status::StatusBackend;
 
 /// GenuineStdoutIo provides a mechanism for the "stdout" output to actually
 /// go to the process's stdout.

--- a/src/io/zipbundle.rs
+++ b/src/io/zipbundle.rs
@@ -35,7 +35,7 @@ impl<R: Read + Seek> IoProvider for ZipBundle<R> {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        _status: &mut StatusBackend,
+        _status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         // We need to be able to look at other items in the Zip file while
         // reading this one, so the only path forward is to read the entire

--- a/src/io/zipbundle.rs
+++ b/src/io/zipbundle.rs
@@ -10,8 +10,8 @@ use zip::result::ZipError;
 use zip::ZipArchive;
 
 use super::{Bundle, InputHandle, InputOrigin, IoProvider, OpenResult};
-use errors::Result;
-use status::StatusBackend;
+use crate::errors::Result;
+use crate::status::StatusBackend;
 
 pub struct ZipBundle<R: Read + Seek> {
     zip: ZipArchive<R>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! LaTeX code to a PDF:
 //!
 //! ```
-//! extern crate tectonic;
+//! use tectonic;
 //!
 //! let latex = r#"
 //! \documentclass{article}
@@ -48,36 +48,13 @@
 //! The [`driver`] module provides a high-level interface for driving the
 //! engines in more realistic circumstances.
 
-extern crate aho_corasick;
-extern crate app_dirs;
-#[macro_use]
-extern crate error_chain;
-extern crate flate2;
-extern crate fs2;
-extern crate hyper;
-extern crate hyper_native_tls;
-#[macro_use]
-extern crate lazy_static;
-extern crate libc;
-extern crate md5;
-#[cfg(feature = "serde")]
-extern crate serde;
-extern crate sha2;
-extern crate tectonic_xdv;
-extern crate tempfile;
-extern crate termcolor;
-extern crate toml;
-extern crate zip;
-
-#[macro_use]
-pub mod status;
-#[macro_use]
-pub mod errors;
 pub mod config;
 pub mod digest;
 pub mod driver;
 pub mod engines;
+pub mod errors;
 pub mod io;
+pub mod status;
 
 // Note: this module is intentionally *not* gated by #[cfg(test)] -- see its
 // docstring for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,11 @@ pub mod io;
 #[doc(hidden)]
 pub mod test_util;
 
-pub use engines::bibtex::BibtexEngine;
-pub use engines::spx2html::Spx2HtmlEngine;
-pub use engines::tex::{TexEngine, TexResult};
-pub use engines::xdvipdfmx::XdvipdfmxEngine;
-pub use errors::{Error, ErrorKind, Result};
+pub use crate::engines::bibtex::BibtexEngine;
+pub use crate::engines::spx2html::Spx2HtmlEngine;
+pub use crate::engines::tex::{TexEngine, TexResult};
+pub use crate::engines::xdvipdfmx::XdvipdfmxEngine;
+pub use crate::errors::{Error, ErrorKind, Result};
 
 const APP_INFO: app_dirs::AppInfo = app_dirs::AppInfo {
     name: "Tectonic",

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -4,7 +4,6 @@
 
 //! A framework for showing status messages to the user.
 
-#[macro_use]
 pub mod termcolor;
 
 use std::cmp;

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -10,7 +10,7 @@ pub mod termcolor;
 use std::cmp;
 use std::fmt::Arguments;
 
-use errors::Error;
+use crate::errors::Error;
 
 #[repr(usize)]
 #[derive(Clone, Copy, Eq, Debug)]

--- a/src/status/termcolor.rs
+++ b/src/status/termcolor.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use super::{ChatterLevel, MessageKind, StatusBackend};
-use errors::Error;
+use crate::errors::Error;
 
 pub struct TermcolorStatusBackend {
     chatter: ChatterLevel,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -40,10 +40,10 @@ use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use digest::DigestData;
-use errors::Result;
-use io::{Bundle, FilesystemIo, InputHandle, IoProvider, OpenResult};
-use status::StatusBackend;
+use crate::digest::DigestData;
+use crate::errors::Result;
+use crate::io::{Bundle, FilesystemIo, InputHandle, IoProvider, OpenResult};
+use crate::status::StatusBackend;
 
 /// The name of the environment variable that the test code will consult to
 /// figure out where to find the testing resource files.
@@ -72,7 +72,7 @@ pub fn maybe_activate_test_mode() {
         return;
     }
 
-    ::config::activate_config_test_mode(true);
+    crate::config::activate_config_test_mode(true);
 }
 
 /// A combination of the two above functions. Set the "test root" variable,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -120,14 +120,14 @@ impl IoProvider for TestBundle {
     fn input_open_name(
         &mut self,
         name: &OsStr,
-        status: &mut StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         self.0.input_open_name(name, status)
     }
 }
 
 impl Bundle for TestBundle {
-    fn get_digest(&mut self, _status: &mut StatusBackend) -> Result<DigestData> {
+    fn get_digest(&mut self, _status: &mut dyn StatusBackend) -> Result<DigestData> {
         Ok(DigestData::zeros())
     }
 }

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -8,9 +8,6 @@
 //! ProcessingSessionBuilder will need to learn how to tell `xdvipdfmx` to
 //! enable the reproducibility options used in the `tex-outputs` test rig.
 
-extern crate tectonic;
-extern crate tempfile;
-
 use tectonic::config::PersistentConfig;
 use tectonic::driver::ProcessingSessionBuilder;
 use tectonic::status::termcolor::TermcolorStatusBackend;

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -1,10 +1,7 @@
 // Copyright 2016-2018 the Tectonic Project
 // Licensed under the MIT License.
 
-#[macro_use]
-extern crate lazy_static;
-extern crate tectonic;
-extern crate tempfile;
+use lazy_static::lazy_static;
 
 use std::env;
 use std::fs::{self, File};

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 #[path = "util/mod.rs"]
 mod util;
-use util::{cargo_dir, ensure_plain_format};
+use crate::util::{cargo_dir, ensure_plain_format};
 
 lazy_static! {
     static ref TEST_ROOT: PathBuf = {

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -28,7 +28,7 @@ use tectonic::status::NoopStatusBackend;
 use tectonic::TexEngine;
 
 mod util;
-use util::test_path;
+use crate::util::test_path;
 
 const DEBUG: bool = false; // TODO: this is kind of ugly
 

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -14,8 +14,6 @@
 /// Temporarily set the constant DEBUG to true to dump out the generated files
 /// to disk, which may be helpful in debugging. There is probably a less gross
 /// way to implement that option.
-extern crate tectonic;
-
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::str::FromStr;

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -24,7 +24,7 @@ struct TestCase {
     expected_result: Result<TexResult>,
     check_synctex: bool,
     check_pdf: bool,
-    extra_io: Vec<Box<IoProvider>>,
+    extra_io: Vec<Box<dyn IoProvider>>,
 }
 
 impl TestCase {
@@ -104,7 +104,8 @@ impl TestCase {
 
         // Run the engine(s)!
         let res = {
-            let mut io_list: Vec<&mut IoProvider> = vec![&mut mem, &mut tex, &mut fmt, &mut assets];
+            let mut io_list: Vec<&mut dyn IoProvider> =
+                vec![&mut mem, &mut tex, &mut fmt, &mut assets];
             for io in &mut self.extra_io {
                 io_list.push(&mut **io);
             }

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -1,8 +1,6 @@
 // Copyright 2016-2018 the Tectonic Project
 // Licensed under the MIT License.
 
-extern crate tectonic;
-
 use std::collections::HashSet;
 use std::env;
 use std::path::Path;

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -17,7 +17,7 @@ use tectonic::{TexEngine, XdvipdfmxEngine};
 
 #[path = "util/mod.rs"]
 mod util;
-use util::{ensure_plain_format, test_path, ExpectedInfo};
+use crate::util::{ensure_plain_format, test_path, ExpectedInfo};
 
 struct TestCase {
     stem: String,

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -54,7 +54,7 @@ fn trip_test() {
 
     // First engine pass -- make the format file.
     {
-        let mut io = IoStack::new(vec![&mut mem as &mut IoProvider, &mut tex, &mut tfm]);
+        let mut io = IoStack::new(vec![&mut mem as &mut dyn IoProvider, &mut tex, &mut tfm]);
         TexEngine::new()
             .halt_on_error_mode(false)
             .initex_mode(true)
@@ -70,7 +70,7 @@ fn trip_test() {
 
     // Second pass -- process it
     {
-        let mut io = IoStack::new(vec![&mut mem as &mut IoProvider, &mut tex, &mut tfm]);
+        let mut io = IoStack::new(vec![&mut mem as &mut dyn IoProvider, &mut tex, &mut tfm]);
         TexEngine::new()
             .halt_on_error_mode(false)
             .initex_mode(false)
@@ -119,7 +119,7 @@ fn etrip_test() {
 
     // First engine pass -- make the format file.
     {
-        let mut io = IoStack::new(vec![&mut mem as &mut IoProvider, &mut tex, &mut tfm]);
+        let mut io = IoStack::new(vec![&mut mem as &mut dyn IoProvider, &mut tex, &mut tfm]);
         TexEngine::new()
             .halt_on_error_mode(false)
             .initex_mode(true)

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -13,8 +13,6 @@
 /// multithreading can be disabled by setting the RUST_TEST_THREADS environment
 /// variable to "1", but that's an annoying solution. So, we use a global mutex
 /// to achieve the same effect. Classy.
-extern crate tectonic;
-
 use std::ffi::OsStr;
 
 use tectonic::engines::NoopIoEventBackend;

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -25,7 +25,7 @@ use tectonic::TexEngine;
 
 #[path = "util/mod.rs"]
 mod util;
-use util::{test_path, ExpectedInfo};
+use crate::util::{test_path, ExpectedInfo};
 
 #[test]
 fn trip_test() {

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -11,7 +11,7 @@
 #![allow(dead_code)]
 
 
-use self::flate2::read::GzDecoder;
+use ::flate2::read::GzDecoder;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -19,15 +19,15 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use self::tectonic::errors::Result;
-pub use self::tectonic::test_util::{test_path, TestBundle};
+use ::tectonic::errors::Result;
+pub use ::tectonic::test_util::{test_path, TestBundle};
 
 /// Set the magic environment variable that enables the testing infrastructure
 /// embedded in the main Tectonic crate. This function is separated out from
 /// the main crate because it embeds `CARGO_MANIFEST_DIR`, which is not
 /// something we want to leak into the binary artifacts we produce.
 pub fn set_test_root() {
-    self::tectonic::test_util::set_test_root_augmented(env!("CARGO_MANIFEST_DIR"));
+    ::tectonic::test_util::set_test_root_augmented(env!("CARGO_MANIFEST_DIR"));
 }
 
 // Duplicated from Cargo's own testing code:
@@ -54,12 +54,12 @@ pub fn cargo_dir() -> PathBuf {
 /// the moment we just let everybody write and overwrite the file, but we
 /// could use a locking scheme to get smarter about this.
 pub fn ensure_plain_format() -> Result<PathBuf> {
-    use self::tectonic::engines::NoopIoEventBackend;
-    use self::tectonic::io::{
+    use ::tectonic::engines::NoopIoEventBackend;
+    use ::tectonic::io::{
         try_open_file, FilesystemIo, FilesystemPrimaryInputIo, IoStack, MemoryIo,
     };
-    use self::tectonic::status::NoopStatusBackend;
-    use self::tectonic::TexEngine;
+    use ::tectonic::status::NoopStatusBackend;
+    use ::tectonic::TexEngine;
 
     let fmt_path = test_path(&["plain.fmt"]);
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -10,9 +10,6 @@
 // using this testing setup...
 #![allow(dead_code)]
 
-extern crate flate2;
-extern crate tectonic;
-extern crate tempfile;
 
 use self::flate2::read::GzDecoder;
 use std::collections::{HashMap, HashSet};

--- a/xdv/Cargo.toml
+++ b/xdv/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/tectonic"
 repository = "https://github.com/tectonic-typesetting/tectonic/"
 readme = "README.md"
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 byteorder = "^1.3"

--- a/xdv/examples/xdvdump.rs
+++ b/xdv/examples/xdvdump.rs
@@ -3,11 +3,7 @@
 
 //! Parse an XDV/SPX file and dump some stats about its contents.
 
-#[macro_use]
-extern crate clap;
-extern crate tectonic_xdv;
-
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use std::fmt::{Display, Error as FmtError, Formatter};
 use std::fs::File;
 use std::io;

--- a/xdv/src/lib.rs
+++ b/xdv/src/lib.rs
@@ -13,8 +13,6 @@
 //! expresses output that is not paginated for print — this is what Tectonic
 //! uses to produce its HTML output.
 
-extern crate byteorder;
-
 use byteorder::{BigEndian, ByteOrder};
 use std::error;
 use std::fmt::{Debug, Display, Error as FmtError, Formatter};

--- a/xdv/src/lib.rs
+++ b/xdv/src/lib.rs
@@ -60,7 +60,7 @@ impl error::Error for XdvError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }


### PR DESCRIPTION
`rustc v1.37` introduces a warning about the bare trait syntax being deprecated.
The [new `dyn Trait` syntax](https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html) was introduced in rust `rustc v1.27`.
This also adds the `edition = "2018"` flag to the `Cargo.toml`.
The main differences between the 2015 and 2018 edition are changes to the [path resolution](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html).