### PR TITLE
Fix an off-by-one in usages of the `name_of_file` variable.

### DIFF
--- a/tectonic/xetex-ext.c
+++ b/tectonic/xetex-ext.c
@@ -795,7 +795,7 @@ find_native_font(char* uname, int32_t scaled_size)
             if (varString != NULL)
                 name_length += strlen(varString) + 1;
             free(name_of_file);
-            name_of_file = xmalloc(name_length + 3); /* +1 would be correct here (trailing \0). +3 is kept for Pascal-like access patterns. */
+            name_of_file = xmalloc(name_length + 1);
             strcpy(name_of_file, fullName);
 
             if (scaled_size < 0) {

--- a/tectonic/xetex-ini.c
+++ b/tectonic/xetex-ini.c
@@ -2509,7 +2509,7 @@ pack_buffered_name(small_number n, int32_t a, int32_t b)
     free(name_of_file);
     name_of_file = xmalloc_array(UTF8_code, format_default_length + 1);
 
-    strcpy(name_of_file, TEX_format_default + 1);
+    strcpy(name_of_file, TEX_format_default);
     name_length = strlen(name_of_file);
 }
 
@@ -3912,13 +3912,10 @@ tt_run_engine(char *dump_name, char *input_file_name)
 
     rust_stdout = ttstub_output_open_stdout ();
 
-    /* TEX_format_default must get a leading space character for Pascal
-     * style string magic. */
     size_t len = strlen (dump_name);
-    TEX_format_default = xmalloc (len + 2);
-    TEX_format_default[0] = ' ';
-    strcpy (TEX_format_default + 1, dump_name);
-    format_default_length = len + 1;
+    TEX_format_default = xmalloc (len + 1);
+    strcpy (TEX_format_default, dump_name);
+    format_default_length = len;
 
     /* Not sure why these get custom initializations. */
 

--- a/tectonic/xetex-xetex0.c
+++ b/tectonic/xetex-xetex0.c
@@ -10964,9 +10964,6 @@ new_native_character(internal_font_number f, UnicodeScalar c)
 
 void font_feature_warning(const void *featureNameP, int32_t featLen, const void *settingNameP, int32_t setLen)
 {
-
-    int32_t i;
-
     begin_diagnostic();
     print_nl_cstr("Unknown ");
     if (setLen > 0) {
@@ -10977,20 +10974,14 @@ void font_feature_warning(const void *featureNameP, int32_t featLen, const void 
     print_cstr("feature `");
     print_utf8_str(featureNameP, featLen);
     print_cstr("' in font `");
-    i = 1;
-    while (name_of_file[i] != 0) {
+    for (int32_t i = 0; name_of_file[i] != 0; i++)
         print_raw_char(name_of_file[i], true);
-        i++;
-    }
     print_cstr("'.");
     end_diagnostic(false);
 }
 
 void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int32_t warningType)
 {
-
-    int32_t i;
-
     begin_diagnostic();
     if (warningType == 0)
         print_nl_cstr("Loaded mapping `");
@@ -10998,11 +10989,10 @@ void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int3
         print_nl_cstr("Font mapping `");
     print_utf8_str(mappingNameP, mappingNameLen);
     print_cstr("' for font `");
-    i = 1;
-    while (name_of_file[i] != 0) {
+
+    for (int32_t i = 0; name_of_file[i] != 0; i++)
         print_raw_char(name_of_file[i], true);
-        i++;
-    }
+
     switch (warningType) {
     case 1:
         print_cstr("' not found.");
@@ -11022,16 +11012,12 @@ void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int3
 
 void graphite_warning(void)
 {
-
-    int32_t i;
-
     begin_diagnostic();
     print_nl_cstr("Font `");
-    i = 1;
-    while (name_of_file[i] != 0) {
+
+    for (int32_t i = 0; name_of_file[i] != 0; i++)
         print_raw_char(name_of_file[i], true);
-        i++;
-    }
+
     print_cstr("' does not support Graphite. Trying OpenType layout instead.");
     end_diagnostic(false);
 }
@@ -11062,7 +11048,7 @@ load_native_font(int32_t u, str_number nom, str_number aire, scaled_t s)
     if (pool_ptr + name_length > pool_size)
         overflow("pool size", pool_size - init_pool_ptr);
 
-    for (k = 1; k <= name_length; k++)
+    for (k = 0; k < name_length; k++)
         str_pool[pool_ptr++] = name_of_file[k];
 
     full_name = make_string();

--- a/tests/tex-outputs/otf_basic.log
+++ b/tests/tex-outputs/otf_basic.log
@@ -1,5 +1,5 @@
 **
 (otf_basic.tex
-Missing character: There is no 𐐷 in font lmroman12-regular]^^@!
+Missing character: There is no 𐐷 in font [lmroman12-regular]!
  [1] )
 Output written on otf_basic.xdv (1 page, 6300 bytes).


### PR DESCRIPTION
I missed a bit of pascal-like string handling in my refactoring PR: #165

---------------------------------------------

This is an example use-case for the regression tester (#397).

This comparison reveals the regression:
https://tt.ente.ninja/#/compare/v0.1.9-dirty/v0.1.10
This is the changeset for this PR:
https://tt.ente.ninja/#/compare/v0.1.11/fix-font-name-v0.1.11-276-g62ce204
This confirms that the regression was fixed:
https://tt.ente.ninja/#/compare/v0.1.9-dirty/fix-font-name-v0.1.11-276-g62ce204

_The differences in `CAG_D-17-00218_Edited.pdf` are not related._