### PR TITLE
supress some downloading progress output

### DIFF
--- a/dist/docker/x86_64-alpine-linux-musl/setup_priv.sh
+++ b/dist/docker/x86_64-alpine-linux-musl/setup_priv.sh
@@ -24,14 +24,18 @@ cd /
 
 export TERM=dumb
 apt-get update
+# use curl for rust's installer so it is quieter
+# needed until we can configure the options passed to the installer
+# https://github.com/rust-lang/rustup.rs/issues/1928
 apt-get install -y \
         build-essential \
         sudo \
-        wget
+        wget \
+        curl
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
-wget https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.10.0/alpine-chroot-install
+wget -q --progress=dot https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.10.0/alpine-chroot-install
 echo 'dcceb34aa63767579f533a7f2e733c4d662b0d1b  alpine-chroot-install' |sha1sum -c
 
 # This command will error out when it attempts to bind-mount things like /proc

--- a/dist/docker/x86_64-alpine-linux-musl/setup_unpriv.sh
+++ b/dist/docker/x86_64-alpine-linux-musl/setup_unpriv.sh
@@ -8,7 +8,7 @@ platform="x86_64-unknown-linux-musl"
 
 cd
 
-wget -O rustup.sh https://sh.rustup.rs
+wget -q --progress=dot -O rustup.sh https://sh.rustup.rs
 sh rustup.sh -y --default-toolchain stable
 rm -f rustup.sh
 


### PR DESCRIPTION
Cuts down onthe noise when building the container for static binary
generation:
```
docker build -t tectonic-builder:v1 dist/docker/x86_64-alpine-linux-musl/
```
It would be nice to configure the options for `wget` instead of installing `curl`: https://github.com/rust-lang/rustup.rs/issues/1928