### PR TITLE
create an mdbook for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /tests/plain.fmt
 /tests/00*00-latex-*.fmt
 /tests/00*00-plain-*.fmt
+
+# ignore mdbook compiled output (HTML)
+docs/book/*

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ which in turn uses Rust’s `proc_macro` feature. The `proc_macro` functionality
 [is not available on musl targets](https://github.com/rust-lang/rust/issues/40174),
 and so must be turned off if you wish to build a completely static Tectonic
 executable.
+
+## Documentation System
+Per [this rust subreddit discussion](https://www.reddit.com/r/rust/comments/7eohmt/whats_the_best_practice_for_documenting_a_rust/), [Doxidize](https://steveklabnik.github.io/doxidize/index.html) seems like it could suit us well.
+

--- a/README.md
+++ b/README.md
@@ -70,7 +70,3 @@ which in turn uses Rust’s `proc_macro` feature. The `proc_macro` functionality
 [is not available on musl targets](https://github.com/rust-lang/rust/issues/40174),
 and so must be turned off if you wish to build a completely static Tectonic
 executable.
-
-## Documentation System
-Per [this rust subreddit discussion](https://www.reddit.com/r/rust/comments/7eohmt/whats_the_best_practice_for_documenting_a_rust/), [Doxidize](https://steveklabnik.github.io/doxidize/index.html) seems like it could suit us well.
-

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,5 @@
+[book]
+authors = ["Tectonic Contributers"]
+language = "en"
+multilingual = false
+src = "src"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,5 +1,13 @@
 [book]
+title = "The Tectonic Typesetting System"
 authors = ["Tectonic Contributers"]
+description = "a book documenting the tectonic project for developers"
 language = "en"
 multilingual = false
 src = "src"
+[output.html]
+# see lively issue: https://github.com/rust-lang-nursery/mdBook/issues/847
+google-analytics = false
+# FIXME these do not seem to appear anywhere?
+git-repository-url = "https://github.com/tectonic-typesetting/tectonic"
+git-repository-icon = "fa-github"

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,13 @@
+# Tectonic Overview
+
+Tectonic is a modernized, complete, self-contained
+[TeX](https://en.wikipedia.org/wiki/TeX)/[LaTeX](https://www.latex-project.org/)
+engine, powered by [XeTeX](http://xetex.sourceforge.net/) and
+[TeXLive](https://www.tug.org/texlive/).
+
+## documentation
+
+We are writing developer facing documentation using [mdbook](https://rust-lang-nursery.github.io/mdBook/index.html).
+This lives in the `docs` sub directory of the main [tectonic repository](https://github.com/tectonic-typesetting/tectonic).
+
+See discussion in [#62](https://github.com/tectonic-typesetting/tectonic/issues/62) for ideas.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,9 @@
+# Tectonic Documentation
+
+- [Overview](README.md)
+- [Project Structure](project/README.md)
+    - [tectonic](project/tectonic.md)
+    - [tectonic-fuzz](project/fuzz.md)
+- [Resources](resources/README.md)
+
+-----------

--- a/docs/src/project/README.md
+++ b/docs/src/project/README.md
@@ -1,0 +1,5 @@
+# overview of tectonic project structure
+
+## Goals of the Project
+## How the Code is Structured
+## How to Contribute

--- a/docs/src/project/fuzz.md
+++ b/docs/src/project/fuzz.md
@@ -1,0 +1,4 @@
+# tectonic-fuzz
+
+A fuzzing tool to test tectonic.
+See the directory's [README.md](https://github.com/tectonic-typesetting/tectonic/tree/master/fuzz) for more.

--- a/docs/src/project/tectonic.md
+++ b/docs/src/project/tectonic.md
@@ -1,0 +1,11 @@
+# tectonic
+
+To see available options, run `tectonic --help`.
+This page documents usage details not appropriate to the CLI.
+
+
+## the configuration file
+
+You can configure common options by using a configuration file.
+
+See [issue 59](https://github.com/tectonic-typesetting/tectonic/issues/59) for some discussion.

--- a/docs/src/resources/README.md
+++ b/docs/src/resources/README.md
@@ -1,0 +1,4 @@
+# Resources
+
+A collection of recipes and tips relating to working with tectonic.
+


### PR DESCRIPTION
Start to resolve #62 and other documentation related issues.

I found this  [this rust subreddit discussion](https://www.reddit.com/r/rust/comments/7eohmt/whats_the_best_practice_for_documenting_a_rust/) about best practices for documentation. [Doxidize](https://steveklabnik.github.io/doxidize/index.html) seems like it could suit us well but [isn't ready for use](https://github.com/steveklabnik/doxidize/issues/116#issuecomment-421607742).
mdBook may not integrate as nicely with a crate but it seems like the community standard.
I started a preliminary structure but am sure we should establish the audience and then establish a suitable TOC.