### PR TITLE
remove outdated documentation comment

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -8,7 +8,7 @@
 //! struct is [`ProcessingSession`], which knows how to run (and re-run if
 //! necessary) the various engines in the right order.
 //!
-//! For an example of how to use this module, see `cli_driver.rs`, which contains tectonic's main
+//! For an example of how to use this module, see `src/bin/tectonic.rs`, which contains tectonic's main
 //! CLI program.
 
 use aho_corasick::AhoCorasick;


### PR DESCRIPTION
I could not find this example so removed the line.
If the `cli_driver.rs` moved somewhere else I can instead update the text to that location.