### PR TITLE
Disable exceptions and rtti for C++ code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -325,6 +325,8 @@ fn main() {
         // "-Wunreachable-code-aggresive",
         "-Wno-unused-parameter",
         "-Wno-implicit-fallthrough",
+        "-fno-exceptions",
+        "-fno-rtti",
     ];
 
     for flag in &cppflags {

--- a/tectonic/teckit-Engine.cpp
+++ b/tectonic/teckit-Engine.cpp
@@ -1937,20 +1937,12 @@ TECkit_CreateConverter(
 	TECkit_Status	status = kStatus_NoError;
 	Converter*	cnv = 0;
 	*converter = 0;
-	try {
-		cnv = new Converter(mapping, mappingSize, mapForward, inputForm, outputForm);
-		status = cnv->creationStatus();
-		if (status == kStatus_NoError)
-			*converter = (TECkit_Converter)cnv;
-		else
-			delete cnv;
-	}
-	catch (Converter::Exception e) {
-		status = e.errorCode;
-	}
-	catch (...) {
-		status = kStatus_Exception;
-	}
+	cnv = new Converter(mapping, mappingSize, mapForward, inputForm, outputForm);
+	status = cnv->creationStatus();
+	if (status == kStatus_NoError)
+		*converter = (TECkit_Converter)cnv;
+	else
+		delete cnv;
 	return status;
 }
 

--- a/tectonic/teckit-cxx-Engine.h
+++ b/tectonic/teckit-cxx-Engine.h
@@ -171,15 +171,6 @@ public:
 	void				GetFlags(UInt32& sourceFlags, UInt32& targetFlags) const;
 	bool				GetNamePtr(UInt16 inNameID, const Byte*& outNamePtr, UInt32& outNameLen) const;
 
-	class Exception
-	{
-	public:
-						Exception(UInt32 errCode)
-							: errorCode(errCode)
-							{ }
-		UInt32			errorCode;
-	};
-
 	long				creationStatus() const
 							{ return status; }
 


### PR DESCRIPTION
There is no throw clause in the source code and Converter::Exception is never created, so I think this is dead code.