### PR TITLE
Commit updated Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,6 @@ dependencies = [
 name = "tectonic"
 version = "0.1.12-dev"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
#439 removes a line from `Cargo.lock`. This should be committed I believe.