### PR TITLE
Prototype infrastructure to publish the docs/ HTML

### DIFF
--- a/dist/build-mdbook.sh
+++ b/dist/build-mdbook.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+# A helper script to build a book built via the [mdbook] documentation
+# program.
+#
+# [mdbook]: https://rust-lang-nursery.github.io/mdBook/
+#
+# Arguments:
+#
+# $1 - path to the mdbook directory in this project, relative to PWD
+
+set -e
+set -x # TEMP DEBUG
+
+# Parameters
+
+src_path="$1"
+
+# Configuration that we expect to be stable.
+
+mdbook_version=0.3.1
+ci_platform=x86_64-unknown-linux-gnu
+mdbook_binary_fn="mdbook-v${mdbook_version}-${ci_platform}.tar.gz"
+mdbook_binary_url="https://github.com/rust-lang-nursery/mdBook/releases/download/v${mdbook_version}/${mdbook_binary_fn}"
+mdbook_binary_sha256=4511fb1d4d95331099a4c1777d6af8022ac5783af70b83f018c78c896a4027ab
+
+# Get an mdbook executable. If we end up with multiple books to build,
+# this script might run multiple times, so avoid the work if possible.
+
+mdbook="$(pwd)/mdbook"
+
+if [ ! -x "$mdbook" ] ; then
+    echo "Getting mdbook executable ..."
+    wget -q --progress=dot "$mdbook_binary_url"
+    echo "$mdbook_binary_sha256  $mdbook_binary_fn" |sha256sum -c
+    tar xzf "$mdbook_binary_fn"
+    rm -f "$mdbook_binary_fn"
+fi
+
+# Build the book.
+
+echo "Building book ..."
+pushd "$src_path"
+"$mdbook" build
+"$mdbook" test
+popd
+
+# And that's it.
+
+echo "Success."

--- a/dist/force-push-tree.sh
+++ b/dist/force-push-tree.sh
@@ -1,0 +1,70 @@
+#! /bin/bash
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+# A helper script to deploy a tree of files to another Git repository by
+# copying them, amend-committing, and force-pushing. The main use case for
+# this script is to deploy generated HTML trees to make them available using
+# GitHub pages.
+#
+# Arguments:
+#
+# $1 - path to the file tree to be deployed
+# $2 - HTTPS URL of the GitHub repository that will receive the files
+# $3 - path within the destination Git repository where the tree will land
+# $4 - brief free text identifying the commit/version of what's being deployed
+#      (used in the Git logs)
+#
+# Environment:
+#
+# $GITHUB_TOKEN - a bearer-token authentication token that can be used to
+#   authenticate writes to the repository specified by $2.
+#
+# See the code for how the token authentication is set up -- it is somewhat
+# magical.
+
+set -e
+set -x # TEMP DEBUG
+
+# Parameters
+
+src_path="$1"
+dest_repo_url="$2"
+dest_repo_path="$3"
+commit_desc="$4"
+
+# Configuration that we expect to be stable.
+
+git_user_email="notifications@github.com"
+git_user_name="Tectonic CI"
+
+# Set up Git and authentication.
+# Derived from: https://www.appveyor.com/docs/how-to/git-push/
+
+echo "Setting up Git ..."
+git config --global credential.helper store
+echo "https://$GITHUB_TOKEN:x-oauth-basic@github.com" >~/.git-credentials
+git config --global user.email "$git_user_email"
+git config --global user.name "$git_user_name"
+
+# Set up the target repo.
+
+echo "Cloning target repository $dest_repo_url ..."
+tmprepo="$(mktemp -d)"
+git clone "$dest_repo_url" "$tmprepo"
+mkdir -p "$tmprepo/$dest_repo_path"
+rm -rf "$tmprepo/$dest_repo_path"
+
+# Update the HTML and commit.
+
+echo "Committing and pushing changes ..."
+cp -a "$src_path" "$tmprepo/$dest_repo_path"
+
+pushd "$tmprepo"
+git add "$dest_repo_path"
+git commit --amend -m "Most recent update: $dest_repo_path - $commit_desc"
+git push -f
+popd
+
+# And that's it.
+echo "Success."

--- a/dist/travis.sh
+++ b/dist/travis.sh
@@ -120,10 +120,12 @@ if [[ "$TRAVIS_BRANCH" == master && "$TRAVIS_EVENT_TYPE" == push && "$TRAVIS_TAG
     # above, so this seems to be a tagged release. As above, this variable can
     # be true with $is_main_build being false.
     is_release_build=true
+    release_version="$(echo "$TRAVIS_TAG" |sed -e 's/^v//')"
 else
     is_release_build=false
+    release_version=none
 fi
-echo "is_release_build: $is_release_build"
+echo "is_release_build: $is_release_build ($release_version)"
 travis_fold_end env
 
 # The special tag "continuous" is used to maintain a GitHub "release" that
@@ -285,6 +287,13 @@ if $is_release_build; then
         chmod 600 /tmp/deploy_key
         bash dist/arch/deploy.sh
         travis_fold_end release
+
+        # Deploy the docs book (UNTESTED as of 0.1.11!)
+        dist/force-push-tree.sh \
+            docs/book \
+            https://github.com/tectonic-typesetting/book.git \
+            "$release_version" \
+            "docs mdbook @ v$release_version"
     fi
 
     # TODO: Do something with the Linux static build?


### PR DESCRIPTION
See the main commit message for a bit of rationale. The best way I can see to graft multiple static HTML trees into the tectonic-typesetting.github.io URL family is to use helper repos with simple names that serve as targets for static HTML force-pushes.

Unfortunately this logic can only *really* be tested by merging to master, so if things look good that's what I'll do.