### PR TITLE
Do not compute the sha256 digest for read-only files

### DIFF
--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -680,7 +680,7 @@ impl IoProvider for CachedITarBundle {
             Err(e) => return OpenResult::Err(e.into()),
         };
 
-        OpenResult::Ok(InputHandle::new(
+        OpenResult::Ok(InputHandle::new_read_only(
             name,
             BufReader::new(f),
             InputOrigin::Other,

--- a/src/io/format_cache.rs
+++ b/src/io/format_cache.rs
@@ -84,7 +84,7 @@ impl IoProvider for FormatCache {
             OpenResult::Err(e) => return OpenResult::Err(e),
         };
 
-        OpenResult::Ok(InputHandle::new(
+        OpenResult::Ok(InputHandle::new_read_only(
             name,
             BufReader::new(f),
             InputOrigin::Other,

--- a/src/io/zipbundle.rs
+++ b/src/io/zipbundle.rs
@@ -66,7 +66,11 @@ impl<R: Read + Seek> IoProvider for ZipBundle<R> {
             return OpenResult::Err(e.into());
         }
 
-        OpenResult::Ok(InputHandle::new(name, Cursor::new(buf), InputOrigin::Other))
+        OpenResult::Ok(InputHandle::new_read_only(
+            name,
+            Cursor::new(buf),
+            InputOrigin::Other,
+        ))
     }
 }
 


### PR DESCRIPTION
As observed in #452, a big chuck of runtime is spend computing sha256 digests. However, these are for the most part never used.

This pull request adds `InputHandle::read_only: bool` field and `fn
InputHandle::new_read_only` that sets this field to `true`. It indicates
that it is not possible to write into such file, for example, the format
file, the tar bundle or zip bundle, and so `InputHandle` does not need
to compute sha256 digest.

Saves 15--25% of tectonics runtime for a typical document.

On my machine, `tests/xenia/paper.tex` the run time is 1s vs 1.3s, and on a 30 pages tex file 1.9s vs. 2.2s.