### PR TITLE
Avoid deprecated harfbuzz APIs

### DIFF
--- a/tectonic/xetex-XeTeXFontInst.cpp
+++ b/tectonic/xetex-XeTeXFontInst.cpp
@@ -106,19 +106,19 @@ XeTeXFontInst::~XeTeXFontInst()
 }
 
 /* HarfBuzz font functions */
-
 static hb_bool_t
-_get_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t vs, hb_codepoint_t *gid, void*)
+_get_nominal_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t *gid, void*)
 {
     FT_Face face = (FT_Face) font_data;
-    *gid = 0;
+    *gid = FT_Get_Char_Index (face, ch);
+    return *gid != 0;
+}
 
-    if (vs)
-        *gid = FT_Face_GetCharVariantIndex (face, ch, vs);
-
-    if (*gid == 0)
-        *gid = FT_Get_Char_Index (face, ch);
-
+static hb_bool_t
+_get_variation_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t vs, hb_codepoint_t *gid, void*)
+{
+    FT_Face face = (FT_Face) font_data;
+    *gid = FT_Face_GetCharVariantIndex (face, ch, vs);
     return *gid != 0;
 }
 
@@ -265,7 +265,8 @@ _get_font_funcs(void)
 {
     static hb_font_funcs_t* funcs = hb_font_funcs_create();
 
-    hb_font_funcs_set_glyph_func                (funcs, _get_glyph, NULL, NULL);
+    hb_font_funcs_set_nominal_glyph_func        (funcs, _get_nominal_glyph, NULL, NULL);
+    hb_font_funcs_set_variation_glyph_func      (funcs, _get_variation_glyph, NULL, NULL);
     hb_font_funcs_set_glyph_h_advance_func      (funcs, _get_glyph_h_advance, NULL, NULL);
     hb_font_funcs_set_glyph_v_advance_func      (funcs, _get_glyph_v_advance, NULL, NULL);
     hb_font_funcs_set_glyph_h_origin_func       (funcs, _get_glyph_h_origin, NULL, NULL);


### PR DESCRIPTION
Somewhat recently a bunch of deprecation warnings started showing up in my builds , because Arch Linux updated the `harfbuzz` package.
<details>
<summary>build log for reference</summary>

```
warning: tectonic/xetex-XeTeXFontInst.cpp: In function ‘hb_font_funcs_t* _get_font_funcs()’:
warning: tectonic/xetex-XeTeXFontInst.cpp:268:79: warning: ‘void hb_font_funcs_set_glyph_func(hb_font_funcs_t*, hb_font_get_glyph_func_t, void*, hb_destroy_func_t)’ is deprecated: Use 'hb_font_funcs_set_nominal_glyph_func and hb_font_funcs_set_variation_glyph_func' instead [-Wdeprecated-declarations]
warning:   268 |     hb_font_funcs_set_glyph_func                (funcs, _get_glyph, NULL, NULL);
warning:       |                                                                               ^
warning: In file included from /usr/include/harfbuzz/hb.h:34,
warning:                  from tectonic/xetex-core.h:28,
warning:                  from tectonic/xetex-XeTeXFontInst.cpp:42:
warning: /usr/include/harfbuzz/hb-deprecated.h:67:1: note: declared here
warning:    67 | hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXFontInst.cpp:268:79: warning: ‘void hb_font_funcs_set_glyph_func(hb_font_funcs_t*, hb_font_get_glyph_func_t, void*, hb_destroy_func_t)’ is deprecated: Use 'hb_font_funcs_set_nominal_glyph_func and hb_font_funcs_set_variation_glyph_func' instead [-Wdeprecated-declarations]
warning:   268 |     hb_font_funcs_set_glyph_func                (funcs, _get_glyph, NULL, NULL);
warning:       |                                                                               ^
warning: In file included from /usr/include/harfbuzz/hb.h:34,
warning:                  from tectonic/xetex-core.h:28,
warning:                  from tectonic/xetex-XeTeXFontInst.cpp:42:
warning: /usr/include/harfbuzz/hb-deprecated.h:67:1: note: declared here
warning:    67 | hb_font_funcs_set_glyph_func (hb_font_funcs_t *ffuncs,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp: In function ‘unsigned int countFeatures(XeTeXFont, hb_tag_t, hb_tag_t)’:
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:395:100: warning: ‘hb_bool_t hb_ot_layout_script_find_language(hb_face_t*, hb_tag_t, unsigned int, hb_tag_t, unsigned int*)’ is deprecated: Use 'hb_ot_layout_script_select_language' instead [-Wdeprecated-declarations]
warning:   395 |             if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
warning:       |                                                                                                    ^
warning: In file included from /usr/include/harfbuzz/hb-ot.h:34,
warning:                  from tectonic/xetex-core.h:29,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-ot-deprecated.h:56:1: note: declared here
warning:    56 | hb_ot_layout_script_find_language (hb_face_t    *face,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:395:100: warning: ‘hb_bool_t hb_ot_layout_script_find_language(hb_face_t*, hb_tag_t, unsigned int, hb_tag_t, unsigned int*)’ is deprecated: Use 'hb_ot_layout_script_select_language' instead [-Wdeprecated-declarations]
warning:   395 |             if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
warning:       |                                                                                                    ^
warning: In file included from /usr/include/harfbuzz/hb-ot.h:34,
warning:                  from tectonic/xetex-core.h:29,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-ot-deprecated.h:56:1: note: declared here
warning:    56 | hb_ot_layout_script_find_language (hb_face_t    *face,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp: In function ‘hb_tag_t getIndFeature(XeTeXFont, hb_tag_t, hb_tag_t, unsigned int)’:
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:415:100: warning: ‘hb_bool_t hb_ot_layout_script_find_language(hb_face_t*, hb_tag_t, unsigned int, hb_tag_t, unsigned int*)’ is deprecated: Use 'hb_ot_layout_script_select_language' instead [-Wdeprecated-declarations]
warning:   415 |             if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
warning:       |                                                                                                    ^
warning: In file included from /usr/include/harfbuzz/hb-ot.h:34,
warning:                  from tectonic/xetex-core.h:29,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-ot-deprecated.h:56:1: note: declared here
warning:    56 | hb_ot_layout_script_find_language (hb_face_t    *face,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:415:100: warning: ‘hb_bool_t hb_ot_layout_script_find_language(hb_face_t*, hb_tag_t, unsigned int, hb_tag_t, unsigned int*)’ is deprecated: Use 'hb_ot_layout_script_select_language' instead [-Wdeprecated-declarations]
warning:   415 |             if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
warning:       |                                                                                                    ^
warning: In file included from /usr/include/harfbuzz/hb-ot.h:34,
warning:                  from tectonic/xetex-core.h:29,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-ot-deprecated.h:56:1: note: declared here
warning:    56 | hb_ot_layout_script_find_language (hb_face_t    *face,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp: In function ‘hb_unicode_funcs_t* _get_unicode_funcs()’:
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:741:92: warning: ‘void hb_unicode_funcs_set_decompose_compatibility_func(hb_unicode_funcs_t*, hb_unicode_decompose_compatibility_func_t, void*, hb_destroy_func_t)’ is deprecated [-Wdeprecated-declarations]
warning:   741 |     hb_unicode_funcs_set_decompose_compatibility_func(ufuncs, _decompose_compat, NULL, NULL);
warning:       |                                                                                            ^
warning: In file included from /usr/include/harfbuzz/hb.h:34,
warning:                  from tectonic/xetex-core.h:28,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-deprecated.h:158:1: note: declared here
warning:   158 | hb_unicode_funcs_set_decompose_compatibility_func (hb_unicode_funcs_t *ufuncs,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:741:92: warning: ‘void hb_unicode_funcs_set_decompose_compatibility_func(hb_unicode_funcs_t*, hb_unicode_decompose_compatibility_func_t, void*, hb_destroy_func_t)’ is deprecated [-Wdeprecated-declarations]
warning:   741 |     hb_unicode_funcs_set_decompose_compatibility_func(ufuncs, _decompose_compat, NULL, NULL);
warning:       |                                                                                            ^
warning: In file included from /usr/include/harfbuzz/hb.h:34,
warning:                  from tectonic/xetex-core.h:28,
warning:                  from tectonic/xetex-XeTeXLayoutInterface.cpp:34:
warning: /usr/include/harfbuzz/hb-deprecated.h:158:1: note: declared here
warning:   158 | hb_unicode_funcs_set_decompose_compatibility_func (hb_unicode_funcs_t *ufuncs,
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp: In function ‘bool initGraphiteBreaking(XeTeXLayoutEngine, const uint16_t*, int)’:
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:1004:78: warning: ‘gr_font* hb_graphite2_font_get_gr_font(hb_font_t*)’ is deprecated: Use 'hb_graphite2_face_get_gr_face' instead [-Wdeprecated-declarations]
warning:  1004 |     gr_font* grFont = hb_graphite2_font_get_gr_font(engine->font->getHbFont());
warning:       |                                                                              ^
warning: In file included from tectonic/xetex-XeTeXLayoutInterface.cpp:42:
warning: /usr/include/harfbuzz/hb-graphite2.h:45:1: note: declared here
warning:    45 | hb_graphite2_font_get_gr_font (hb_font_t *font);
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
warning: tectonic/xetex-XeTeXLayoutInterface.cpp:1004:78: warning: ‘gr_font* hb_graphite2_font_get_gr_font(hb_font_t*)’ is deprecated: Use 'hb_graphite2_face_get_gr_face' instead [-Wdeprecated-declarations]
warning:  1004 |     gr_font* grFont = hb_graphite2_font_get_gr_font(engine->font->getHbFont());
warning:       |                                                                              ^
warning: In file included from tectonic/xetex-XeTeXLayoutInterface.cpp:42:
warning: /usr/include/harfbuzz/hb-graphite2.h:45:1: note: declared here
warning:    45 | hb_graphite2_font_get_gr_font (hb_font_t *font);
warning:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

The replacement APIs for the deprecated functions have been introduced in harfbuzz `>=1.2.3` for `hb_font_funcs_set_nominal_glyph_func` and
`>=2.0.0` for `hb_ot_layout_script_select_language`.

Looking at Ubuntu's harfbuzz versions, this probably shouldn't get merged until the deprecated APIs are removed as Ubuntu has been a bit slow to update harfbuzz:

| Distro | Version |
| --- | --- |
| Ubuntu 16.04 (ci) | 1.0.1 |
| Ubuntu 18.04 | 1.7.2 |
| Ubuntu 19.04 | 2.3.1 |