### PR TITLE
use structopt for CLI argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -422,14 +422,13 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -443,16 +442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "headers-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -491,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.12.34"
+version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -525,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -585,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -777,7 +766,7 @@ dependencies = [
  "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -817,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1067,13 +1056,13 @@ dependencies = [
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1158,7 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1181,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1191,7 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1316,15 +1305,15 @@ dependencies = [
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tectonic_xdv 0.1.9-dev",
@@ -1575,7 +1564,7 @@ name = "toml"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1818,14 +1807,13 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2512b3191f22e2763a5db387f1c9409379772e2050841722eb4a8c4f497bf096"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
-"checksum headers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6e2e51d356081258ef05ff4c648138b5d3fe64b7300aaad3b820554a2b7fb6"
+"checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
-"checksum headers-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97c462e8066bca4f0968ddf8d12de64c40f2c2187b3b9a2fa994d06e8ad444a9"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-"checksum hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)" = "898a87371a3999b2f731b9af636cd76aa20de10e69c2daf3e71388326b619fe0"
+"checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
@@ -1860,7 +1848,7 @@ dependencies = [
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
+"checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
@@ -1899,7 +1887,7 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "f4473e8506b213730ff2061073b48fa51dcc66349219e2e7c5608f0296a1d95a"
+"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,6 @@ version = "0.1.12-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "http"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,11 +831,29 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -848,6 +874,14 @@ version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1221,6 +1255,27 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1283,16 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1262,6 +1327,7 @@ dependencies = [
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tectonic_xdv 0.1.9-dev",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1556,6 +1622,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1634,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1746,6 +1822,7 @@ dependencies = [
 "checksum headers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6e2e51d356081258ef05ff4c648138b5d3fe64b7300aaad3b820554a2b7fb6"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 "checksum headers-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97c462e8066bca4f0968ddf8d12de64c40f2c2187b3b9a2fa994d06e8ad444a9"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
@@ -1787,9 +1864,12 @@ dependencies = [
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
@@ -1832,7 +1912,10 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48399718b3ad695558b979b08a9056a5272ec573cd3070f5ca34165bd4a5bf35"
+"checksum structopt-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2558075232402034384db060831349fb2d1303479593177cc84c25febbebbc6d"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
@@ -1860,8 +1943,10 @@ dependencies = [
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ vcpkg = "0.2.7"
 [dependencies]
 app_dirs = "^1.1"
 clap = "^2.33"
+structopt = "0.3"
 error-chain = "^0.12"
 flate2 = { version = "^1.0", default-features = false, features = ["zlib"] }
 fs2 = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ vcpkg = "0.2.7"
 
 [dependencies]
 app_dirs = "^1.1"
-clap = "^2.33"
 structopt = "0.3"
 error-chain = "^0.12"
 flate2 = { version = "^1.0", default-features = false, features = ["zlib"] }

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -2,12 +2,14 @@
 // Copyright 2016-2018 the Tectonic Project
 // Licensed under the MIT License.
 
-use clap::crate_version;
 use tectonic;
 
+use structopt::StructOpt;
+
+use clap::crate_version;
 use clap::{App, Arg, ArgMatches};
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process;
 
 use tectonic::config::PersistentConfig;
@@ -19,6 +21,26 @@ use tectonic::status::{ChatterLevel, StatusBackend};
 
 use tectonic::{ctry, errmsg, tt_error, tt_error_styled, tt_note};
 
+#[derive(Debug, StructOpt)]
+#[structopt(name = "Tectonic", about = "Process a (La)TeX document")]
+struct Opt {
+    /// The name of the "format" file used to initialize the TeX engine
+    #[structopt(long, short, name = "PATH", default_value = "latex")]
+    format: String,
+    /// Use this Zip-format bundle file to find resource files instead of the default
+    #[structopt(
+        takes_value(true),
+        parse(from_os_str),
+        long,
+        short,
+        name = "zip_file_path"
+    )]
+    bundle: PathBuf,
+    /// Use this URL find resource files instead of the default
+    #[structopt(takes_value(true), long, short, name = "url")]
+    web_bundle: String,
+    // TODO add URL validation
+}
 fn inner(
     args: ArgMatches,
     config: PersistentConfig,
@@ -154,6 +176,8 @@ fn inner(
 }
 
 fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
     let matches = App::new("Tectonic")
         .version(crate_version!())
         .about("Process a (La)TeX document")

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -42,8 +42,8 @@ struct Opt {
     // TODO add URL validation
     web_bundle: Option<String>,
     /// How much chatter to print when running
-    #[structopt(long = "chatter", short, name = "LEVEL", default_value = "default", possible_values(&["default", "minimal"]))]
-    chatter_level: String,
+    #[structopt(long = "chatter", short, name = "LEVEL", default_value = "normal", possible_values = &ChatterLevel::variants(), case_insensitive = true)]
+    chatter_level: ChatterLevel,
     /// Use only resource files cached locally
     #[structopt(short = "C")]
     only_cached: bool,
@@ -78,11 +78,7 @@ struct Opt {
     #[structopt(name = "OUTDIR", short, parse(from_os_str))]
     outdir: Option<PathBuf>,
 }
-fn inner(
-    args: Opt,
-    config: PersistentConfig,
-    status: &mut TermcolorStatusBackend,
-) -> Result<()> {
+fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBackend) -> Result<()> {
     let mut sess_builder = ProcessingSessionBuilder::default();
     let format_path = args.format;
     sess_builder
@@ -214,15 +210,6 @@ fn inner(
 
 fn main() {
     let args = Opt::from_args();
-    // TODO avoid matching and use enums
-    // in structopt definition
-    let def = "default";
-    let minimal = "minimal";
-    let chatter = match &args.chatter_level {
-        def => ChatterLevel::Normal,
-        minimal => ChatterLevel::Minimal,
-        _ => unreachable!(),
-    };
 
     // The Tectonic crate comes with a hidden internal "test mode" that forces
     // it to use a specified set of local files, rather than going to the
@@ -259,7 +246,7 @@ fn main() {
     // something I'd be relatively OK with since it'd only affect the progam
     // UI, not the processing results).
 
-    let mut status = TermcolorStatusBackend::new(chatter);
+    let mut status = TermcolorStatusBackend::new(args.chatter_level);
 
     // For now ...
 

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -233,7 +233,8 @@ fn main() {
     // something I'd be relatively OK with since it'd only affect the progam
     // UI, not the processing results).
 
-    let mut status = TermcolorStatusBackend::new(ChatterLevel::from_str(&args.chatter_level).unwrap());
+    let mut status =
+        TermcolorStatusBackend::new(ChatterLevel::from_str(&args.chatter_level).unwrap());
 
     // For now ...
 

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -44,8 +44,8 @@ struct Opt {
     // TODO add URL validation
     web_bundle: Option<String>,
     /// How much chatter to print when running
-    #[structopt(long = "chatter", short, name = "LEVEL", default_value = "normal", possible_values = &ChatterLevel::variants(), case_insensitive = true)]
-    chatter_level: ChatterLevel,
+    #[structopt(long = "chatter", short, name = "LEVEL", default_value = "default", possible_values(&["default", "minimal"]))]
+    chatter_level: String,
     /// Use only resource files cached locally
     #[structopt(short = "C")]
     only_cached: bool,
@@ -235,7 +235,7 @@ fn main() {
     // something I'd be relatively OK with since it'd only affect the progam
     // UI, not the processing results).
 
-    let mut status = TermcolorStatusBackend::new(args.chatter_level);
+    let mut status = TermcolorStatusBackend::new(ChatterLevel::from_str(&args.chatter_level).unwrap());
 
     // For now ...
 

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -92,12 +92,7 @@ fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBacken
 
     sess_builder.output_format(OutputFormat::from_str(&args.outfmt).unwrap());
 
-    let pass = match args.pass {
-        "default" => PassSetting::Default,
-        "bibtex_first" => PassSetting::BibtexFirst,
-        "tex" => PassSetting::Tex,
-        _ => unreachable!(),
-    };
+    let pass = PassSetting::from_str(&args.pass).unwrap();
     sess_builder.pass(pass);
 
     if let Some(s) = args.reruns {

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -49,7 +49,7 @@ struct Opt {
     #[structopt(short = "C")]
     only_cached: bool,
     /// The kind of output to generate
-    #[structopt(short, name = "format", default_value = "pdf", possible_values(&["pdf", "html", "xdv", "aux", "format"]))]
+    #[structopt(long, name = "format", default_value = "pdf", possible_values(&["pdf", "html", "xdv", "aux", "format"]))]
     outfmt: String,
     /// Write Makefile-format rules expressing the dependencies of this run to <DEST_PATH>
     #[structopt(long, name = "DEST_PATH")]
@@ -61,7 +61,7 @@ struct Opt {
     #[structopt(name = "count", long = "reruns", short = "r")]
     reruns: Option<f64>,
     /// Keep the intermediate files generated during processing
-    #[structopt(short,long)]
+    #[structopt(short, long)]
     keep_intermediates: bool,
     /// Keep the log files generated during processing
     #[structopt(long)]
@@ -69,6 +69,15 @@ struct Opt {
     /// Generate SyncTeX data
     #[structopt(long)]
     synctex: bool,
+    /// Tell the engine that no file at <HIDE_PATH> exists, if it tries to read it
+    #[structopt(long, name = "hide_path")]
+    hide: Option<Vec<PathBuf>>,
+    /// Print the engine's chatter during processing
+    #[structopt(long = "print", short)]
+    print_stdout: bool,
+    /// The directory in which to place output files [default: the directory containing INPUT]
+    #[structopt(name = "OUTDIR", short, parse(from_os_str))]
+    outdir: Option<PathBuf>,
 }
 fn inner(
     args: ArgMatches,
@@ -215,7 +224,6 @@ fn main() {
         minimal => ChatterLevel::Minimal,
         _ => unreachable!(),
     };
-    println!("{:?}", opt);
 
     // The Tectonic crate comes with a hidden internal "test mode" that forces
     // it to use a specified set of local files, rather than going to the

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -22,12 +22,12 @@ use tectonic::{ctry, errmsg, tt_error, tt_error_styled, tt_note};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Tectonic", about = "Process a (La)TeX document")]
-struct Opt {
+struct CliOptions {
     /// The file to process, or "-" to process the standard input stream"
-    #[structopt(name = "INPUT")]
+    #[structopt(name = "input")]
     input: String,
     /// The name of the "format" file used to initialize the TeX engine
-    #[structopt(long, short, name = "PATH", default_value = "latex")]
+    #[structopt(long, short, name = "path", default_value = "latex")]
     format: String,
     /// Use this Zip-format bundle file to find resource files instead of the default
     #[structopt(
@@ -43,7 +43,7 @@ struct Opt {
     // TODO add URL validation
     web_bundle: Option<String>,
     /// How much chatter to print when running
-    #[structopt(long = "chatter", short, name = "LEVEL", default_value = "default", possible_values(&["default", "minimal"]))]
+    #[structopt(long = "chatter", short, name = "level", default_value = "default", possible_values(&["default", "minimal"]))]
     chatter_level: String,
     /// Use only resource files cached locally
     #[structopt(short = "C")]
@@ -51,8 +51,8 @@ struct Opt {
     /// The kind of output to generate
     #[structopt(long, name = "format", default_value = "pdf", possible_values(&["pdf", "html", "xdv", "aux", "format"]))]
     outfmt: String,
-    /// Write Makefile-format rules expressing the dependencies of this run to <DEST_PATH>
-    #[structopt(long, name = "DEST_PATH")]
+    /// Write Makefile-format rules expressing the dependencies of this run to <dest_path>
+    #[structopt(long, name = "dest_path")]
     makefile_rules: Option<PathBuf>,
     /// Which engines to run
     #[structopt(long, default_value = "default", possible_values(&["default", "tex", "bibtex_first"]))]
@@ -69,17 +69,21 @@ struct Opt {
     /// Generate SyncTeX data
     #[structopt(long)]
     synctex: bool,
-    /// Tell the engine that no file at <HIDE_PATH> exists, if it tries to read it
+    /// Tell the engine that no file at <hide_path> exists, if it tries to read it
     #[structopt(long, name = "hide_path")]
     hide: Option<Vec<PathBuf>>,
     /// Print the engine's chatter during processing
     #[structopt(long = "print", short)]
     print_stdout: bool,
-    /// The directory in which to place output files [default: the directory containing INPUT]
-    #[structopt(name = "OUTDIR", short, long, parse(from_os_str))]
+    /// The directory in which to place output files [default: the directory containing <input>]
+    #[structopt(name = "outdir", short, long, parse(from_os_str))]
     outdir: Option<PathBuf>,
 }
-fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBackend) -> Result<()> {
+fn inner(
+    args: CliOptions,
+    config: PersistentConfig,
+    status: &mut TermcolorStatusBackend,
+) -> Result<()> {
     let mut sess_builder = ProcessingSessionBuilder::default();
     let format_path = args.format;
     sess_builder
@@ -196,7 +200,7 @@ fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBacken
 }
 
 fn main() {
-    let args = Opt::from_args();
+    let args = CliOptions::from_args();
 
     // The Tectonic crate comes with a hidden internal "test mode" that forces
     // it to use a specified set of local files, rather than going to the

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -25,8 +25,8 @@ use tectonic::{ctry, errmsg, tt_error, tt_error_styled, tt_note};
 #[structopt(name = "Tectonic", about = "Process a (La)TeX document")]
 struct Opt {
     /// The file to process, or "-" to process the standard input stream"
-    #[structopt(name = "INPUT", parse(from_os_str))]
-    input: PathBuf,
+    #[structopt(name = "INPUT")]
+    input: String,
     /// The name of the "format" file used to initialize the TeX engine
     #[structopt(long, short, name = "PATH", default_value = "latex")]
     format: String,
@@ -60,7 +60,7 @@ struct Opt {
     pass: String,
     /// Rerun the TeX engine exactly this many times after the first
     #[structopt(name = "count", long = "reruns", short = "r")]
-    reruns: Option<f64>,
+    reruns: Option<usize>,
     /// Keep the intermediate files generated during processing
     #[structopt(short, long)]
     keep_intermediates: bool,
@@ -96,7 +96,7 @@ fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBacken
     sess_builder.pass(pass);
 
     if let Some(s) = args.reruns {
-        sess_builder.reruns(usize::from_str_radix(s, 10)?);
+        sess_builder.reruns(s);
     }
 
     if let Some(p) = args.makefile_rules {
@@ -105,7 +105,7 @@ fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBacken
 
     // Input and path setup
 
-    let input_path = args.value_of_os("INPUT").unwrap();
+    let input_path = args.input;
     if input_path == "-" {
         // Don't provide an input path to the ProcessingSession, so it will default to stdin.
         sess_builder.tex_input_name("texput.tex");
@@ -115,7 +115,7 @@ fn inner(args: Opt, config: PersistentConfig, status: &mut TermcolorStatusBacken
             "reading from standard input; outputs will appear under the base name \"texput\""
         );
     } else {
-        let input_path = Path::new(input_path);
+        let input_path = Path::new(&input_path);
         sess_builder.primary_input_path(input_path);
 
         if let Some(fname) = input_path.file_name() {

--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -20,7 +20,6 @@ use tectonic::status::{ChatterLevel, StatusBackend};
 
 use tectonic::{ctry, errmsg, tt_error, tt_error_styled, tt_note};
 
-
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Tectonic", about = "Process a (La)TeX document")]
 struct Opt {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -252,6 +252,23 @@ impl Default for PassSetting {
     }
 }
 
+impl FromStr for PassSetting {
+
+    type Err = &'static str;
+
+    fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
+
+        let actual = match a_str {
+            "default" => PassSetting::Default,
+            "bibtex_first" => PassSetting::BibtexFirst,
+            "tex" => PassSetting::Tex,
+            _    => unreachable!()
+        };
+
+        Ok(actual)
+    }
+}
+
 /// Different places from which the "primary input" might originate.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum PrimaryInputMode {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -22,11 +22,11 @@ use std::str::FromStr;
 use crate::digest::DigestData;
 use crate::engines::IoEventBackend;
 use crate::errors::{ErrorKind, Result, ResultExt};
-use std::result::Result as StdResult;
 use crate::io::{Bundle, InputOrigin, IoProvider, IoSetup, IoSetupBuilder, OpenResult};
 use crate::status::StatusBackend;
 use crate::{ctry, errmsg, tt_error, tt_note, tt_warning};
 use crate::{BibtexEngine, Spx2HtmlEngine, TexEngine, TexResult, XdvipdfmxEngine};
+use std::result::Result as StdResult;
 
 /// Different patterns with which files may have been accessed by the
 /// underlying engines. Once a file is marked as ReadThenWritten or
@@ -222,7 +222,7 @@ impl FromStr for OutputFormat {
             "xdv" => OutputFormat::Xdv,
             "pdf" => OutputFormat::Pdf,
             "fmt" => OutputFormat::Format,
-            _    => unreachable!()
+            _ => unreachable!(),
         };
 
         Ok(actual)
@@ -254,16 +254,14 @@ impl Default for PassSetting {
 }
 
 impl FromStr for PassSetting {
-
     type Err = &'static str;
 
     fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
-
         let actual = match a_str {
             "default" => PassSetting::Default,
             "bibtex_first" => PassSetting::BibtexFirst,
             "tex" => PassSetting::Tex,
-            _    => unreachable!()
+            _ => unreachable!(),
         };
 
         Ok(actual)

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -228,6 +228,7 @@ impl FromStr for OutputFormat {
         Ok(actual)
     }
 }
+
 impl Default for OutputFormat {
     fn default() -> OutputFormat {
         OutputFormat::Pdf

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -215,17 +215,15 @@ pub enum OutputFormat {
 impl FromStr for OutputFormat {
     type Err = &'static str;
 
-    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
-        let actual = match s {
-            "aux" => OutputFormat::Aux,
-            "html" => OutputFormat::Html,
-            "xdv" => OutputFormat::Xdv,
-            "pdf" => OutputFormat::Pdf,
-            "fmt" => OutputFormat::Format,
-            _ => unreachable!(),
-        };
-
-        Ok(actual)
+    fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
+        match a_str {
+            "aux" => Ok(OutputFormat::Aux),
+            "html" => Ok(OutputFormat::Html),
+            "xdv" => Ok(OutputFormat::Xdv),
+            "pdf" => Ok(OutputFormat::Pdf),
+            "fmt" => Ok(OutputFormat::Format),
+            _ => Err("unsupported or unknown format"),
+        }
     }
 }
 
@@ -257,14 +255,12 @@ impl FromStr for PassSetting {
     type Err = &'static str;
 
     fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
-        let actual = match a_str {
-            "default" => PassSetting::Default,
-            "bibtex_first" => PassSetting::BibtexFirst,
-            "tex" => PassSetting::Tex,
-            _ => unreachable!(),
-        };
-
-        Ok(actual)
+        match a_str {
+            "default" => Ok(PassSetting::Default),
+            "bibtex_first" => Ok(PassSetting::BibtexFirst),
+            "tex" => Ok(PassSetting::Tex),
+            _ => Err("unsupported or unknown pass setting"),
+        }
     }
 }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -17,10 +17,12 @@ use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::str::FromStr;
 
 use crate::digest::DigestData;
 use crate::engines::IoEventBackend;
 use crate::errors::{ErrorKind, Result, ResultExt};
+use std::result::Result as StdResult;
 use crate::io::{Bundle, InputOrigin, IoProvider, IoSetup, IoSetupBuilder, OpenResult};
 use crate::status::StatusBackend;
 use crate::{ctry, errmsg, tt_error, tt_note, tt_warning};
@@ -210,6 +212,22 @@ pub enum OutputFormat {
     Format,
 }
 
+impl FromStr for OutputFormat {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        let actual = match s {
+            "aux" => OutputFormat::Aux,
+            "html" => OutputFormat::Html,
+            "xdv" => OutputFormat::Xdv,
+            "pdf" => OutputFormat::Pdf,
+            "fmt" => OutputFormat::Format,
+            _    => unreachable!()
+        };
+
+        Ok(actual)
+    }
+}
 impl Default for OutputFormat {
     fn default() -> OutputFormat {
         OutputFormat::Pdf

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -6,19 +6,33 @@
 
 pub mod termcolor;
 
-use clap::arg_enum;
 use std::cmp;
 use std::fmt::Arguments;
-use structopt::StructOpt;
+use std::str::FromStr;
+use std::result::Result as StdResult;
 
 use crate::errors::Error;
 
-arg_enum! {
-    #[repr(usize)]
-    #[derive(Clone, Copy, Eq, Debug, StructOpt)]
-    pub enum ChatterLevel {
-        Minimal = 0,
-        Normal,
+#[repr(usize)]
+#[derive(Clone, Copy, Eq, Debug)]
+pub enum ChatterLevel {
+    Minimal = 0,
+    Normal,
+}
+
+impl FromStr for ChatterLevel {
+
+    type Err = &'static str;
+
+    fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
+
+        let actual = match a_str {
+            "default" => ChatterLevel::Normal,
+            "minimal" => ChatterLevel::Minimal,
+            _    => unreachable!()
+        };
+
+        Ok(actual)
     }
 }
 

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -6,16 +6,20 @@
 
 pub mod termcolor;
 
+use clap::arg_enum;
 use std::cmp;
 use std::fmt::Arguments;
+use structopt::StructOpt;
 
 use crate::errors::Error;
 
-#[repr(usize)]
-#[derive(Clone, Copy, Eq, Debug)]
-pub enum ChatterLevel {
-    Minimal = 0,
-    Normal,
+arg_enum! {
+    #[repr(usize)]
+    #[derive(Clone, Copy, Eq, Debug, StructOpt)]
+    pub enum ChatterLevel {
+        Minimal = 0,
+        Normal,
+    }
 }
 
 impl PartialEq for ChatterLevel {

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -8,8 +8,8 @@ pub mod termcolor;
 
 use std::cmp;
 use std::fmt::Arguments;
-use std::str::FromStr;
 use std::result::Result as StdResult;
+use std::str::FromStr;
 
 use crate::errors::Error;
 
@@ -21,15 +21,13 @@ pub enum ChatterLevel {
 }
 
 impl FromStr for ChatterLevel {
-
     type Err = &'static str;
 
     fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
-
         let actual = match a_str {
             "default" => ChatterLevel::Normal,
             "minimal" => ChatterLevel::Minimal,
-            _    => unreachable!()
+            _ => unreachable!(),
         };
 
         Ok(actual)

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -24,13 +24,11 @@ impl FromStr for ChatterLevel {
     type Err = &'static str;
 
     fn from_str(a_str: &str) -> StdResult<Self, Self::Err> {
-        let actual = match a_str {
-            "default" => ChatterLevel::Normal,
-            "minimal" => ChatterLevel::Minimal,
-            _ => unreachable!(),
-        };
-
-        Ok(actual)
+        match a_str {
+            "default" => Ok(ChatterLevel::Normal),
+            "minimal" => Ok(ChatterLevel::Minimal),
+            _ => Err("unsupported or unknown chatter level"),
+        }
     }
 }
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -144,6 +144,16 @@ fn check_file(tempdir: &TempDir, rest: &str) {
 /* Keep tests alphabetized */
 
 #[test]
+fn bad_chatter_1() {
+    if env::var("RUNNING_COVERAGE").is_ok() {
+        return;
+    }
+
+    let output = run_tectonic(&PathBuf::from("."), &["-", "--chatter=reticent"]);
+    error_or_panic(output);
+}
+
+#[test]
 fn bad_input_path_1() {
     if env::var("RUNNING_COVERAGE").is_ok() {
         return;
@@ -160,6 +170,16 @@ fn bad_input_path_2() {
     }
 
     let output = run_tectonic(&PathBuf::from("."), &["somedir/.."]);
+    error_or_panic(output);
+}
+
+#[test]
+fn bad_outfmt_1() {
+    if env::var("RUNNING_COVERAGE").is_ok() {
+        return;
+    }
+
+    let output = run_tectonic(&PathBuf::from("."), &["-", "--outfmt=dd"]);
     error_or_panic(output);
 }
 


### PR DESCRIPTION
Per conversations [here](https://github.com/tectonic-typesetting/tectonic/issues/405#issuecomment-509207477) and in other issues.

I manually reviewed each of the flags but acceptance testing would be helpful.
- I decided to use the `FromStr` trait for parsing certain switches that end up as an enum. You can use enums [directly](https://github.com/TeXitoi/structopt/blob/master/examples/enum_in_args.rs) in structopt, but you need to wrap them in a clap macro. It changed the existing design too much and I hit a wall with some compiler errors so I took this approach.
- structopt seems to lowercase the `name` argument configuration. E.g. ` <input>    The file to process, or "-" to process the standard input stream"`