### PR TITLE
omit-frame-pointer and profile feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,11 @@ dependencies = [
 [[package]]
 name = "cc"
 version = "1.0.45"
+source = "git+https://github.com/alexcrichton/cc-rs.git#02ed9e6895c6524afa23caa2ac1d2b48d1739e0a"
+
+[[package]]
+name = "cc"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1300,7 +1305,7 @@ name = "tectonic"
 version = "0.1.12-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (git+https://github.com/alexcrichton/cc-rs.git)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1773,6 +1778,7 @@ dependencies = [
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum cc 1.0.45 (git+https://github.com/alexcrichton/cc-rs.git)" = "<none>"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,10 @@ name = "tectonic"
 crate-type = ["rlib"]
 
 [build-dependencies]
-cc = "^1.0"
+cc = { git="https://github.com/alexcrichton/cc-rs.git" }
+# FIXME presumably the next version containing cc::Build::force_frame_pointer
+# will be 1.46, which is not released yet. Double check.
+#cc = "^1.46"
 pkg-config = "^0.3"  # note: sync dist/docker/*/pkg-config-rs.sh with the version in Cargo.lock
 regex = "^1.3"
 sha2 = "^0.8"
@@ -64,7 +67,8 @@ default = ["serialization"]
 # adopted the newer scheme to avoid having to depend on both -- should maybe
 # just get rid of this feature:
 serialization = ["serde"]
-
+# developer feature to compile with the necessary flags for profiling tectonic.
+profile = []
 # freetype-sys = "^0.4"
 # harfbuzz-sys = "^0.1"
 # libz-sys = "^1.0"

--- a/build.rs
+++ b/build.rs
@@ -202,6 +202,22 @@ fn main() {
         ccfg.flag_if_supported(flag);
     }
 
+    const PROFILE_BUILD_PLATFORM_REQUIRES_FRAME_POINTER: bool = cfg!(not(any(
+        // Whitelist of platforms which do not require frame pointers.
+        all(target_os = "linux", target_arch = "x86_64"),
+        // Add more platforms here.
+    )));
+    const PROFILE_BUILD_ENABLED: bool = cfg!(feature = "profile");
+
+    fn profile_config(cfg: &mut cc::Build) {
+        if PROFILE_BUILD_ENABLED {
+            cfg.debug(true)
+                .force_frame_pointer(PROFILE_BUILD_PLATFORM_REQUIRES_FRAME_POINTER);
+        }
+    }
+
+    profile_config(&mut ccfg);
+
     ccfg.file("tectonic/bibtex.c")
         .file("tectonic/core-bridge.c")
         .file("tectonic/core-memory.c")
@@ -332,6 +348,8 @@ fn main() {
     for flag in &cppflags {
         cppcfg.flag_if_supported(flag);
     }
+
+    profile_config(&mut cppcfg);
 
     cppcfg
         .cpp(true)


### PR DESCRIPTION
This PR is waiting on a release of cc-rs, containing the cc::Build::force_frame_pointer func,
and will at least need updating of Cargo.toml at that time.

Until then:
This implements a profile feature which emits debug info, and enables/disables frame-pointers dependent upon whether the target architecture is known to be capable of profiling with frame-pointers omitted.

cc'ing @rekka for comments since he has a profile branch.