### PR TITLE
move target directed cfg! target checks to using a cfg_support module.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,10 +146,6 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cfg_support"
-version = "0.0.1"
-
-[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1301,6 @@ version = "0.1.12-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg_support 0.0.1",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1321,6 +1316,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tectonic_cfg_support 0.0.1",
  "tectonic_xdv 0.1.9-dev",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1329,6 +1325,10 @@ dependencies = [
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tectonic_cfg_support"
+version = "0.0.1"
 
 [[package]]
 name = "tectonic_xdv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,10 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cfg_support"
+version = "0.0.1"
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1305,7 @@ version = "0.1.12-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg_support 0.0.1",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,9 @@ dependencies = [
 [[package]]
 name = "tectonic_cfg_support"
 version = "0.0.1"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tectonic_xdv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pkg-config = "^0.3"  # note: sync dist/docker/*/pkg-config-rs.sh with the versio
 regex = "^1.3"
 sha2 = "^0.8"
 vcpkg = "0.2.7"
+cfg_support = { path = "cfg_support" }
 
 [dependencies]
 app_dirs = "^1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ cc = "^1.0"
 pkg-config = "^0.3"  # note: sync dist/docker/*/pkg-config-rs.sh with the version in Cargo.lock
 regex = "^1.3"
 sha2 = "^0.8"
+tectonic_cfg_support = { path = "cfg_support", version = "0.0.1" }
 vcpkg = "0.2.7"
-cfg_support = { path = "cfg_support" }
 
 [dependencies]
 app_dirs = "^1.1"

--- a/build.rs
+++ b/build.rs
@@ -351,7 +351,7 @@ fn main() {
 
     // Platform-specific adjustments:
 
-    let is_mac_os = build_cfg!(target_os = "macos");
+    let is_mac_os = target_cfg!(target_os = "macos");
 
     if is_mac_os {
         ccfg.define("XETEX_MAC", Some("1"));
@@ -373,7 +373,7 @@ fn main() {
         cppcfg.file("tectonic/xetex-XeTeXFontMgr_FC.cpp");
     }
 
-    let is_big_endian = build_cfg!(target_endian = "big");
+    let is_big_endian = target_cfg!(target_endian = "big");
     if is_big_endian {
         ccfg.define("WORDS_BIGENDIAN", "1");
         cppcfg.define("WORDS_BIGENDIAN", "1");

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,8 @@
 ///
 /// TODO: this surely needs to become much smarter and more flexible.
 use cc;
-use cfg_support::{CfgBuilder, CfgTarget};
 use pkg_config;
+use tectonic_cfg_support::*;
 use vcpkg;
 
 use std::env;
@@ -351,8 +351,7 @@ fn main() {
 
     // Platform-specific adjustments:
 
-    let target_info = CfgTarget::new();
-    let is_mac_os = target_info.all(&[CfgBuilder::new().target_os("macos").build()]);
+    let is_mac_os = build_cfg!(target_os = "macos");
 
     if is_mac_os {
         ccfg.define("XETEX_MAC", Some("1"));
@@ -374,7 +373,7 @@ fn main() {
         cppcfg.file("tectonic/xetex-XeTeXFontMgr_FC.cpp");
     }
 
-    let is_big_endian = target_info.all(&[CfgBuilder::new().target_endian("big").build()]);
+    let is_big_endian = build_cfg!(target_endian = "big");
     if is_big_endian {
         ccfg.define("WORDS_BIGENDIAN", "1");
         cppcfg.define("WORDS_BIGENDIAN", "1");
@@ -398,11 +397,6 @@ fn main() {
 
     // Tell cargo to rerun build.rs only if files in the tectonic/ directory have changed.
     for file in PathBuf::from("tectonic").read_dir().unwrap() {
-        let file = file.unwrap();
-        println!("cargo:rerun-if-changed={}", file.path().display());
-    }
-    // ditto for cfg_support
-    for file in PathBuf::from("cfg_support").read_dir().unwrap() {
         let file = file.unwrap();
         println!("cargo:rerun-if-changed={}", file.path().display());
     }

--- a/cfg_support/Cargo.toml
+++ b/cfg_support/Cargo.toml
@@ -1,3 +1,18 @@
 [package]
-name = "cfg_support"
+name = "tectonic_cfg_support"
 version = "0.0.1"
+authors = [ "Matt Rice <ratmice@gmail.com>" ]
+description = """
+A build.rs support crate that helps deal with CARGO_CFG_TARGET_* variables.
+When cross-compiling, build.rs is built for and runs on the HOST,
+as such cfg!(target_arch = ...) will actually check the HOST, rather than the TARGET.
+
+This crate adds a small wrapper around the cargo environment variables set for the actual target.
+For use in replacing cfg! checks.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"

--- a/cfg_support/Cargo.toml
+++ b/cfg_support/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "cfg_support"
+version = "0.0.1"

--- a/cfg_support/Cargo.toml
+++ b/cfg_support/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "tectonic_cfg_support"
 version = "0.0.1"
-authors = ["Matt Rice <ratmice@gmail.com>"]
+authors = [
+    "Matt Rice <ratmice@gmail.com>",
+    "Peter Williams <peter@newton.cx"
+]
 description = """
 A build.rs support crate that helps deal with CARGO_CFG_TARGET_* variables.
 When cross-compiling, these variables must be used instead of constructs such

--- a/cfg_support/Cargo.toml
+++ b/cfg_support/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "tectonic_cfg_support"
 version = "0.0.1"
-authors = [ "Matt Rice <ratmice@gmail.com>" ]
+authors = ["Matt Rice <ratmice@gmail.com>"]
 description = """
 A build.rs support crate that helps deal with CARGO_CFG_TARGET_* variables.
-When cross-compiling, build.rs is built for and runs on the HOST,
-as such cfg!(target_arch = ...) will actually check the HOST, rather than the TARGET.
-
-This crate adds a small wrapper around the cargo environment variables set for the actual target.
-For use in replacing cfg! checks.
+When cross-compiling, these variables must be used instead of constructs such
+as `cfg!(target_arch = ...)` because the build.rs script must target the host
+architecture.
 """
 homepage = "https://tectonic-typesetting.github.io/"
 documentation = "https://docs.rs/tectonic"
@@ -16,3 +14,6 @@ repository = "https://github.com/tectonic-typesetting/tectonic/"
 readme = "README.md"
 license = "MIT"
 edition = "2018"
+
+[dependencies]
+lazy_static = "^1.4"

--- a/cfg_support/src/lib.rs
+++ b/cfg_support/src/lib.rs
@@ -155,6 +155,13 @@ impl TargetConfiguration {
 //    "modes" prefixed with an expression like `@emit`. They are essentially
 //    different sub-macros but this trick allows us to get everything done
 //    with one named macro_rules! export.
+// 4. Also due to the above, the logical flow of the macro generally goes from
+//    bottom to top, so that's probably the best way to read the code.
+//
+// Some links for reference:
+//
+// - https://users.rust-lang.org/t/top-down-macro-parsing-or-higher-order-macros/8879
+// - https://danielkeep.github.io/tlborm/book/pat-incremental-tt-munchers.html
 #[macro_export]
 macro_rules! target_cfg {
     // "@emit" rules are used for comma-separated lists that have had their

--- a/cfg_support/src/lib.rs
+++ b/cfg_support/src/lib.rs
@@ -1,0 +1,335 @@
+/* When cross compiling, build.rs runs on the host, thus when compiling it
+ * target = host. Use env vars listed in the links below for the actual target.
+ *
+ * https://doc.rust-lang.org/cargo/reference/environment-variables.html
+ * https://doc.rust-lang.org/reference/conditional-compilation.html
+ */
+
+#[derive(Debug)]
+pub struct CfgTarget {
+    pub target_arch: String,
+    pub target_feature: String,
+    pub target_os: String,
+    pub target_family: String,
+    pub target_env: String,
+    pub target_endian: String,
+    pub target_pointer_width: String,
+    pub target_vendor: String,
+}
+
+#[derive(Copy, Clone)]
+pub struct Cfg<'a> {
+    arch: Option<&'a str>,
+    // Not including target_feature here,
+    // it doesn't seem useful for an equality test.
+    //
+    // Usually you'll want to CfgTarget::new().target_feature.contains("....")
+    os: Option<&'a str>,
+    family: Option<&'a str>,
+    env: Option<&'a str>,
+    endian: Option<&'a str>,
+    pointer_width: Option<&'a str>,
+    vendor: Option<&'a str>,
+}
+
+#[derive(Copy, Clone)]
+pub enum CfgBuilder<'a> {
+    Uninitialized,
+    Cond(Cfg<'a>),
+}
+
+fn check_same(target: String, other: Option<&'_ str>) -> bool {
+    Some(target) == other.map(|x: &str| x.to_uppercase())
+}
+fn check_conflict(target: String, other: Option<&'_ str>) -> bool {
+    None == other || check_same(target, other)
+}
+
+impl<'a> Cfg<'a> {
+    pub fn arch_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_arch).into(), self.arch)
+    }
+
+    pub fn os_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_os).into(), self.os)
+    }
+
+    pub fn family_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_family).into(), self.family)
+    }
+
+    pub fn env_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_env).into(), self.env)
+    }
+
+    pub fn endian_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_endian).into(), self.endian)
+    }
+
+    pub fn pointer_width_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_pointer_width).into(), self.pointer_width)
+    }
+
+    pub fn vendor_conflict(&'a self, arg: &CfgTarget) -> bool {
+        check_conflict((&*arg.target_vendor).into(), self.vendor)
+    }
+
+    pub fn check(&'a self, arg: &CfgTarget) -> bool {
+        self.arch_conflict(arg)
+            && self.os_conflict(arg)
+            && self.family_conflict(arg)
+            && self.env_conflict(arg)
+            && self.endian_conflict(arg)
+            && self.pointer_width_conflict(arg)
+            && self.vendor_conflict(arg)
+    }
+}
+
+impl<'a> CfgTarget {
+    pub fn new() -> CfgTarget {
+        fn getenv(var: &'static str) -> String {
+            std::env::var(var)
+                .unwrap_or_else(|_| String::new())
+                .to_uppercase()
+        }
+        CfgTarget {
+            target_arch: getenv("CARGO_CFG_TARGET_ARCH"),
+            target_feature: getenv("CARGO_CFG_TARGET_FEATURE"),
+            target_os: getenv("CARGO_CFG_TARGET_OS"),
+            target_family: getenv("CARGO_CFG_TARGET_FAMILY"),
+            target_env: getenv("CARGO_CFG_TARGET_ENV"),
+            target_endian: getenv("CARGO_CFG_TARGET_ENDIAN"),
+            target_pointer_width: getenv("CARGO_CFG_TARGET_POINTER_WIDTH"),
+            target_vendor: getenv("CARGO_CFG_TARGET_VENDOR"),
+        }
+    }
+    // Same and conflict should differ by the None case.
+
+    pub fn any(&self, args: &'a [Cfg<'a>]) -> bool {
+        assert_eq!(args.is_empty(), false);
+        args.iter().any(|other| other.check(self))
+    }
+
+    pub fn all(&self, args: &'a [Cfg<'a>]) -> bool {
+        assert_eq!(args.is_empty(), false);
+        args.iter().all(|other| other.check(self))
+    }
+}
+
+impl Default for CfgTarget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a> CfgBuilder<'a> {
+    pub fn new() -> CfgBuilder<'a> {
+        CfgBuilder::Uninitialized
+    }
+
+    fn initialized(&'a mut self) -> &'a mut CfgBuilder {
+        match *self {
+            CfgBuilder::Uninitialized => {
+                *self = CfgBuilder::Cond(Cfg {
+                    arch: None,
+                    os: None,
+                    family: None,
+                    env: None,
+                    endian: None,
+                    pointer_width: None,
+                    vendor: None,
+                });
+                self
+            }
+            _ => self,
+        }
+    }
+
+    pub fn target_arch(&'a mut self, arch: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_arch(Self::initialized(self), arch),
+            CfgBuilder::Cond(it) => {
+                it.arch = Some(arch);
+                self
+            }
+        }
+    }
+
+    pub fn target_os(&'a mut self, os: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_os(Self::initialized(self), os),
+            CfgBuilder::Cond(it) => {
+                it.os = Some(os);
+                self
+            }
+        }
+    }
+
+    pub fn target_family(&'a mut self, family: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_family(Self::initialized(self), family),
+            CfgBuilder::Cond(it) => {
+                it.family = Some(family);
+                self
+            }
+        }
+    }
+
+    pub fn target_env(&'a mut self, env: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_env(Self::initialized(self), env),
+            CfgBuilder::Cond(it) => {
+                it.env = Some(env);
+                self
+            }
+        }
+    }
+
+    pub fn target_endian(&'a mut self, endianess: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_endian(Self::initialized(self), endianess),
+            CfgBuilder::Cond(it) => {
+                it.endian = Some(endianess);
+                self
+            }
+        }
+    }
+
+    pub fn target_pointer_width(&'a mut self, pointer_width: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => {
+                Self::target_pointer_width(Self::initialized(self), pointer_width)
+            }
+            CfgBuilder::Cond(it) => {
+                it.pointer_width = Some(pointer_width);
+                self
+            }
+        }
+    }
+
+    pub fn target_vendor(&'a mut self, vendor: &'a str) -> &mut CfgBuilder<'a> {
+        match self {
+            CfgBuilder::Uninitialized => Self::target_vendor(Self::initialized(self), vendor),
+            CfgBuilder::Cond(it) => {
+                it.vendor = Some(vendor);
+                self
+            }
+        }
+    }
+
+    pub fn build(&self) -> Cfg {
+        match self {
+            CfgBuilder::Uninitialized => panic!("CfgBuilder uninitialized"), // reachable
+            CfgBuilder::Cond(inner) => *inner,
+        }
+    }
+}
+
+impl<'a> Default for CfgBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{CfgBuilder, CfgTarget};
+
+    fn setup_test_env() {
+        /* Dummy values for running the tests outside of build.rs/cargo */
+        std::env::set_var("CARGO_CFG_TARGET_ARCH", "i686");
+        std::env::set_var("CARGO_CFG_TARGET_FEATURE", "avx");
+        std::env::set_var("CARGO_CFG_TARGET_OS", "linux");
+        std::env::set_var("CARGO_CFG_TARGET_FAMILY", "unix");
+        std::env::set_var("CARGO_CFG_TARGET_ENV", "gnu");
+        std::env::set_var("CARGO_CFG_TARGET_ENDIAN", "little");
+        std::env::set_var("CARGO_CFG_TARGET_POINTER_WIDTH", "32");
+        std::env::set_var("CARGO_CFG_TARGET_VENDOR", "unknown");
+    }
+
+    #[test]
+    fn test_any() {
+        setup_test_env();
+
+        let target_info: CfgTarget = CfgTarget::new();
+        let mut cond_a = CfgBuilder::new();
+        let mut cond_b = CfgBuilder::new();
+        let mut cond_c = CfgBuilder::new();
+        let mut cond_d = CfgBuilder::new();
+
+        let cond_ff_1 = cond_a
+            .target_arch("gothic")
+            .target_os("cathederal")
+            .target_endian("big")
+            .build();
+        let cond_ff_2 = cond_b.target_arch("victorian").target_os("home").build();
+        let cond_tt = cond_c.target_arch("i686").target_os("linux").build();
+        let cond_ff_3 = cond_d
+            .target_arch("i686")
+            .target_os("linux")
+            .target_endian("big")
+            .build();
+
+        assert_eq!(target_info.any(&[cond_ff_1]), false);
+        assert_eq!(target_info.any(&[cond_ff_3]), false);
+        assert_eq!(target_info.any(&[cond_tt]), true);
+        assert_eq!(target_info.any(&[cond_ff_1, cond_tt]), true);
+        assert_eq!(target_info.any(&[cond_ff_1, cond_tt]), true);
+        assert_eq!(target_info.any(&[cond_ff_1, cond_tt, cond_ff_2]), true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_build() {
+        setup_test_env();
+        CfgBuilder::new().build();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_any_invalid_input() {
+        setup_test_env();
+        let target_info: CfgTarget = CfgTarget::new();
+        target_info.any(&[]); // I guess?
+    }
+
+    #[test]
+    fn test_all() {
+        setup_test_env();
+        let target_info: CfgTarget = CfgTarget::new();
+        let mut cond_a = CfgBuilder::new();
+        let mut cond_b = CfgBuilder::new();
+        let mut cond_c = CfgBuilder::new();
+        let mut cond_d = CfgBuilder::new();
+
+        let cond_ff_1 = cond_a
+            .target_arch("gothic")
+            .target_os("cathederal")
+            .target_endian("big")
+            .build();
+        let cond_ff_2 = cond_b.target_arch("victorian").target_os("home").build();
+        let cond_tt = cond_c.target_arch("i686").target_os("linux").build();
+        let cond_ff_3 = cond_d
+            .target_arch("i686")
+            .target_os("linux")
+            .target_endian("big")
+            .build();
+
+        assert_eq!(target_info.all(&[cond_ff_1]), false);
+        assert_eq!(target_info.all(&[cond_tt]), true);
+        assert_eq!(target_info.all(&[cond_ff_1]), false);
+        assert_eq!(target_info.all(&[cond_ff_3]), false);
+        assert_eq!(target_info.all(&[cond_ff_1, cond_tt]), false);
+        assert_eq!(target_info.all(&[cond_tt, cond_ff_1]), false);
+        assert_eq!(target_info.all(&[cond_ff_1, cond_tt]), false);
+        assert_eq!(target_info.all(&[cond_ff_1, cond_tt, cond_ff_2]), false);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_all_invalid_input() {
+        setup_test_env();
+        let target_info: CfgTarget = CfgTarget::new();
+        target_info.all(&[]); // I guess?
+    }
+}

--- a/cfg_support/src/lib.rs
+++ b/cfg_support/src/lib.rs
@@ -1,11 +1,42 @@
-/* When cross compiling, build.rs runs on the host, thus when compiling it
- * target = host. Use env vars listed in the links below for the actual target.
- *
- * https://doc.rust-lang.org/cargo/reference/environment-variables.html
- * https://doc.rust-lang.org/reference/conditional-compilation.html
- */
+//! When cross compiling, build.rs runs on the host, thus when compiling it
+//! target = host. Use env vars described in the links below for the actual target.
+//!
+//! * [cargo environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+//! * [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)
+
+/// This is not even close to an exact replica of the cfg! macro.
+/// None of the use cases involving nesting is supported.
+/// Help supporting these cases is welcome if possible.
+/// * `cfg!(all(any(...), ...))`
+/// * `cfg!(not(any(...)))`
+///
+/// Supported cases are:
+/// * `build_cfg!(any(...))
+/// * `build_cfg!(not(target_* = "zzz", ...)`
+/// * `build_cfg!(all(...))`
+#[macro_export]
+macro_rules! build_cfg {
+    () => {};
+    ( $e1:tt = $v1:tt $( , $e2:tt = $v2 : tt )* ) => {
+        CfgTarget::default().check(&CfgBuilder::default().$e1($v1)$(. $e2($v2))*.build())
+    };
+    (any($e1:tt = $v1:tt $( , $e2:tt = $v2:tt )* ) ) => {
+        [bar_cfg!($e1 = $v1)
+          $(, bar_cfg!($e2 = $v2) )* ].iter().any(|x| *x)
+    };
+    (all($e1:tt = $v1:tt $( , $e2:tt = $v2:tt )* ) ) => {
+        [bar_cfg!($e1 = $v1)
+          $(, bar_cfg!($e2 = $v2) )* ].iter().all(|x| *x)
+    };
+    (not($e1:tt = $v1:tt $(, $e2:tt = $v2:tt )* ) ) => {
+        ! build_cfg!($e1 = $v1 $(, $e2 = $v2)* )
+    }
+}
 
 #[derive(Debug)]
+/// Representation of the current compilation target
+/// containing the conditional compilation target_* variables
+/// as derived from CARGO_TARGET_CFG_* environment variables.
 pub struct CfgTarget {
     pub target_arch: String,
     pub target_feature: String,
@@ -18,12 +49,13 @@ pub struct CfgTarget {
 }
 
 #[derive(Copy, Clone)]
+/// A set of target_* variables, to be checked against `CfgTaget`.
 pub struct Cfg<'a> {
     arch: Option<&'a str>,
     // Not including target_feature here,
     // it doesn't seem useful for an equality test.
     //
-    // Usually you'll want to CfgTarget::new().target_feature.contains("....")
+    // Usually you'll want to CfgTarget::default().target_feature.contains("....")
     os: Option<&'a str>,
     family: Option<&'a str>,
     env: Option<&'a str>,
@@ -33,7 +65,12 @@ pub struct Cfg<'a> {
 }
 
 #[derive(Copy, Clone)]
+/// Builder for Cfg.
 pub enum CfgBuilder<'a> {
+    // If Uninitialized still matches by the time we get to build() panic!
+    // otherwise CfgBuilder::default().build() matches all targets.
+    // The normal cfg! macros preclude this when called like `cfg!()` with the following:
+    // error: macro requires a cfg-pattern as an argument
     Uninitialized,
     Cond(Cfg<'a>),
 }
@@ -41,52 +78,51 @@ pub enum CfgBuilder<'a> {
 fn check_same(target: String, other: Option<&'_ str>) -> bool {
     Some(target) == other.map(|x: &str| x.to_uppercase())
 }
-fn check_conflict(target: String, other: Option<&'_ str>) -> bool {
+
+fn check_no_conflict(target: String, other: Option<&'_ str>) -> bool {
     None == other || check_same(target, other)
 }
 
 impl<'a> Cfg<'a> {
-    pub fn arch_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_arch).into(), self.arch)
-    }
-
-    pub fn os_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_os).into(), self.os)
-    }
-
-    pub fn family_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_family).into(), self.family)
-    }
-
-    pub fn env_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_env).into(), self.env)
-    }
-
-    pub fn endian_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_endian).into(), self.endian)
-    }
-
-    pub fn pointer_width_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_pointer_width).into(), self.pointer_width)
-    }
-
-    pub fn vendor_conflict(&'a self, arg: &CfgTarget) -> bool {
-        check_conflict((&*arg.target_vendor).into(), self.vendor)
-    }
-
+    /// Return true if `CfgTarget` is not in conflict with `self`.
     pub fn check(&'a self, arg: &CfgTarget) -> bool {
-        self.arch_conflict(arg)
-            && self.os_conflict(arg)
-            && self.family_conflict(arg)
-            && self.env_conflict(arg)
-            && self.endian_conflict(arg)
-            && self.pointer_width_conflict(arg)
-            && self.vendor_conflict(arg)
+        check_no_conflict((&*arg.target_arch).into(), self.arch)
+            && check_no_conflict((&*arg.target_os).into(), self.os)
+            && check_no_conflict((&*arg.target_family).into(), self.family)
+            && check_no_conflict((&*arg.target_env).into(), self.env)
+            && check_no_conflict((&*arg.target_endian).into(), self.endian)
+            && check_no_conflict((&*arg.target_pointer_width).into(), self.pointer_width)
+            && check_no_conflict((&*arg.target_vendor).into(), self.vendor)
     }
 }
 
 impl<'a> CfgTarget {
-    pub fn new() -> CfgTarget {
+    /// Return true if Any of the `args` check true.
+    pub fn any(&self, args: &'a [&Cfg<'a>]) -> bool {
+        // precluded by the cfg! macro from being a question so we panic.
+        assert_eq!(args.is_empty(), false);
+
+        args.iter().any(|other| other.check(self))
+    }
+
+    /// Return `true` if All of the `args` check true.
+    pub fn all(&self, args: &'a [&Cfg<'a>]) -> bool {
+        // precluded by the cfg! macro from being a question so we panic.
+        assert_eq!(args.is_empty(), false);
+
+        args.iter().all(|other| other.check(self))
+    }
+
+    /// Return true if `target` is not in conflict with `self`.
+    pub fn check(&self, target: &'a Cfg<'a>) -> bool {
+        target.check(self)
+    }
+}
+
+impl Default for CfgTarget {
+    /// Builds a CfgTarget from the `CARGO_CFG_TARGET_*`
+    /// [environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+    fn default() -> Self {
         fn getenv(var: &'static str) -> String {
             std::env::var(var)
                 .unwrap_or_else(|_| String::new())
@@ -103,30 +139,9 @@ impl<'a> CfgTarget {
             target_vendor: getenv("CARGO_CFG_TARGET_VENDOR"),
         }
     }
-    // Same and conflict should differ by the None case.
-
-    pub fn any(&self, args: &'a [Cfg<'a>]) -> bool {
-        assert_eq!(args.is_empty(), false);
-        args.iter().any(|other| other.check(self))
-    }
-
-    pub fn all(&self, args: &'a [Cfg<'a>]) -> bool {
-        assert_eq!(args.is_empty(), false);
-        args.iter().all(|other| other.check(self))
-    }
-}
-
-impl Default for CfgTarget {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl<'a> CfgBuilder<'a> {
-    pub fn new() -> CfgBuilder<'a> {
-        CfgBuilder::Uninitialized
-    }
-
     fn initialized(&'a mut self) -> &'a mut CfgBuilder {
         match *self {
             CfgBuilder::Uninitialized => {
@@ -219,7 +234,10 @@ impl<'a> CfgBuilder<'a> {
 
     pub fn build(&self) -> Cfg {
         match self {
-            CfgBuilder::Uninitialized => panic!("CfgBuilder uninitialized"), // reachable
+            // precluded by the cfg! macro from being a question
+            // reachable here via CfgBuilder::default().build() so we want to panic.
+            CfgBuilder::Uninitialized => panic!("CfgBuilder uninitialized"),
+
             CfgBuilder::Cond(inner) => *inner,
         }
     }
@@ -227,7 +245,7 @@ impl<'a> CfgBuilder<'a> {
 
 impl<'a> Default for CfgBuilder<'a> {
     fn default() -> Self {
-        Self::new()
+        CfgBuilder::Uninitialized
     }
 }
 
@@ -251,20 +269,20 @@ mod tests {
     fn test_any() {
         setup_test_env();
 
-        let target_info: CfgTarget = CfgTarget::new();
-        let mut cond_a = CfgBuilder::new();
-        let mut cond_b = CfgBuilder::new();
-        let mut cond_c = CfgBuilder::new();
-        let mut cond_d = CfgBuilder::new();
+        let target_info: CfgTarget = CfgTarget::default();
+        let mut cond_a = CfgBuilder::default();
+        let mut cond_b = CfgBuilder::default();
+        let mut cond_c = CfgBuilder::default();
+        let mut cond_d = CfgBuilder::default();
 
-        let cond_ff_1 = cond_a
+        let cond_ff_1 = &cond_a
             .target_arch("gothic")
             .target_os("cathederal")
             .target_endian("big")
             .build();
-        let cond_ff_2 = cond_b.target_arch("victorian").target_os("home").build();
-        let cond_tt = cond_c.target_arch("i686").target_os("linux").build();
-        let cond_ff_3 = cond_d
+        let cond_ff_2 = &cond_b.target_arch("victorian").target_os("home").build();
+        let cond_tt = &cond_c.target_arch("i686").target_os("linux").build();
+        let cond_ff_3 = &cond_d
             .target_arch("i686")
             .target_os("linux")
             .target_endian("big")
@@ -282,34 +300,34 @@ mod tests {
     #[should_panic]
     fn test_invalid_build() {
         setup_test_env();
-        CfgBuilder::new().build();
+        CfgBuilder::default().build();
     }
 
     #[test]
     #[should_panic]
     fn test_any_invalid_input() {
         setup_test_env();
-        let target_info: CfgTarget = CfgTarget::new();
+        let target_info: CfgTarget = CfgTarget::default();
         target_info.any(&[]); // I guess?
     }
 
     #[test]
     fn test_all() {
         setup_test_env();
-        let target_info: CfgTarget = CfgTarget::new();
-        let mut cond_a = CfgBuilder::new();
-        let mut cond_b = CfgBuilder::new();
-        let mut cond_c = CfgBuilder::new();
-        let mut cond_d = CfgBuilder::new();
+        let target_info: CfgTarget = CfgTarget::default();
+        let mut cond_a = CfgBuilder::default();
+        let mut cond_b = CfgBuilder::default();
+        let mut cond_c = CfgBuilder::default();
+        let mut cond_d = CfgBuilder::default();
 
-        let cond_ff_1 = cond_a
+        let cond_ff_1 = &cond_a
             .target_arch("gothic")
             .target_os("cathederal")
             .target_endian("big")
             .build();
-        let cond_ff_2 = cond_b.target_arch("victorian").target_os("home").build();
-        let cond_tt = cond_c.target_arch("i686").target_os("linux").build();
-        let cond_ff_3 = cond_d
+        let cond_ff_2 = &cond_b.target_arch("victorian").target_os("home").build();
+        let cond_tt = &cond_c.target_arch("i686").target_os("linux").build();
+        let cond_ff_3 = &cond_d
             .target_arch("i686")
             .target_os("linux")
             .target_endian("big")
@@ -329,7 +347,7 @@ mod tests {
     #[should_panic]
     fn test_all_invalid_input() {
         setup_test_env();
-        let target_info: CfgTarget = CfgTarget::new();
+        let target_info: CfgTarget = CfgTarget::default();
         target_info.all(&[]); // I guess?
     }
 }

--- a/cfg_support/src/lib.rs
+++ b/cfg_support/src/lib.rs
@@ -1,126 +1,48 @@
-//! When cross compiling, build.rs runs on the host, thus when compiling it
-//! target = host. Use env vars described in the links below for the actual target.
+// Copyright 2019 the Tectonic Project
+// Licensed under the MIT License.
+
+//! This support crate helps deal with `CARGO_CFG_TARGET_*` variables. When
+//! cross-compiling with a `build.rs` script, these variables must be used
+//! instead of constructs such as `cfg!(target_arch = ...)` because the
+//! build.rs compilation targets the build host architecture, not the final
+//! target architecture.
+//!
+//! For more information, see the documentation on:
 //!
 //! * [cargo environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
 //! * [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html)
 
-/// This is not even close to an exact replica of the cfg! macro.
-/// None of the use cases involving nesting is supported.
-/// Help supporting these cases is welcome if possible.
-/// * `cfg!(all(any(...), ...))`
-/// * `cfg!(not(any(...)))`
+// Debugging help (requires nightly):
+//#![feature(trace_macros)]
+//trace_macros!(true);
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref TARGET_CONFIG: TargetConfiguration = TargetConfiguration::default();
+}
+
+#[derive(Clone, Debug)]
+/// Information about the compilation target.
 ///
-/// Supported cases are:
-/// * `build_cfg!(any(...))
-/// * `build_cfg!(not(target_* = "zzz", ...)`
-/// * `build_cfg!(all(...))`
-#[macro_export]
-macro_rules! build_cfg {
-    () => {};
-    ( $e1:tt = $v1:tt $( , $e2:tt = $v2 : tt )* ) => {
-        CfgTarget::default().check(&CfgBuilder::default().$e1($v1)$(. $e2($v2))*.build())
-    };
-    (any($e1:tt = $v1:tt $( , $e2:tt = $v2:tt )* ) ) => {
-        [bar_cfg!($e1 = $v1)
-          $(, bar_cfg!($e2 = $v2) )* ].iter().any(|x| *x)
-    };
-    (all($e1:tt = $v1:tt $( , $e2:tt = $v2:tt )* ) ) => {
-        [bar_cfg!($e1 = $v1)
-          $(, bar_cfg!($e2 = $v2) )* ].iter().all(|x| *x)
-    };
-    (not($e1:tt = $v1:tt $(, $e2:tt = $v2:tt )* ) ) => {
-        ! build_cfg!($e1 = $v1 $(, $e2 = $v2)* )
-    }
+/// These parameters are derived from the `CARGO_TARGET_CFG_*` environment
+/// variables, which must be used to obtain correct results when
+/// cross-compiling a `build.rs` script. The configuration values are
+/// uppercased when they're loaded, to allow for case-insensitive comparisons
+/// later.
+pub struct TargetConfiguration {
+    pub arch: String,
+    pub feature: String,
+    pub os: String,
+    pub family: String,
+    pub env: String,
+    pub endian: String,
+    pub pointer_width: String,
+    pub vendor: String,
 }
 
-#[derive(Debug)]
-/// Representation of the current compilation target
-/// containing the conditional compilation target_* variables
-/// as derived from CARGO_TARGET_CFG_* environment variables.
-pub struct CfgTarget {
-    pub target_arch: String,
-    pub target_feature: String,
-    pub target_os: String,
-    pub target_family: String,
-    pub target_env: String,
-    pub target_endian: String,
-    pub target_pointer_width: String,
-    pub target_vendor: String,
-}
-
-#[derive(Copy, Clone)]
-/// A set of target_* variables, to be checked against `CfgTaget`.
-pub struct Cfg<'a> {
-    arch: Option<&'a str>,
-    // Not including target_feature here,
-    // it doesn't seem useful for an equality test.
-    //
-    // Usually you'll want to CfgTarget::default().target_feature.contains("....")
-    os: Option<&'a str>,
-    family: Option<&'a str>,
-    env: Option<&'a str>,
-    endian: Option<&'a str>,
-    pointer_width: Option<&'a str>,
-    vendor: Option<&'a str>,
-}
-
-#[derive(Copy, Clone)]
-/// Builder for Cfg.
-pub enum CfgBuilder<'a> {
-    // If Uninitialized still matches by the time we get to build() panic!
-    // otherwise CfgBuilder::default().build() matches all targets.
-    // The normal cfg! macros preclude this when called like `cfg!()` with the following:
-    // error: macro requires a cfg-pattern as an argument
-    Uninitialized,
-    Cond(Cfg<'a>),
-}
-
-fn check_same(target: String, other: Option<&'_ str>) -> bool {
-    Some(target) == other.map(|x: &str| x.to_uppercase())
-}
-
-fn check_no_conflict(target: String, other: Option<&'_ str>) -> bool {
-    None == other || check_same(target, other)
-}
-
-impl<'a> Cfg<'a> {
-    /// Return true if `CfgTarget` is not in conflict with `self`.
-    pub fn check(&'a self, arg: &CfgTarget) -> bool {
-        check_no_conflict((&*arg.target_arch).into(), self.arch)
-            && check_no_conflict((&*arg.target_os).into(), self.os)
-            && check_no_conflict((&*arg.target_family).into(), self.family)
-            && check_no_conflict((&*arg.target_env).into(), self.env)
-            && check_no_conflict((&*arg.target_endian).into(), self.endian)
-            && check_no_conflict((&*arg.target_pointer_width).into(), self.pointer_width)
-            && check_no_conflict((&*arg.target_vendor).into(), self.vendor)
-    }
-}
-
-impl<'a> CfgTarget {
-    /// Return true if Any of the `args` check true.
-    pub fn any(&self, args: &'a [&Cfg<'a>]) -> bool {
-        // precluded by the cfg! macro from being a question so we panic.
-        assert_eq!(args.is_empty(), false);
-
-        args.iter().any(|other| other.check(self))
-    }
-
-    /// Return `true` if All of the `args` check true.
-    pub fn all(&self, args: &'a [&Cfg<'a>]) -> bool {
-        // precluded by the cfg! macro from being a question so we panic.
-        assert_eq!(args.is_empty(), false);
-
-        args.iter().all(|other| other.check(self))
-    }
-
-    /// Return true if `target` is not in conflict with `self`.
-    pub fn check(&self, target: &'a Cfg<'a>) -> bool {
-        target.check(self)
-    }
-}
-
-impl Default for CfgTarget {
-    /// Builds a CfgTarget from the `CARGO_CFG_TARGET_*`
+impl Default for TargetConfiguration {
+    /// Creates a TargetConfiguration from the `CARGO_CFG_TARGET_*`
     /// [environment variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
     fn default() -> Self {
         fn getenv(var: &'static str) -> String {
@@ -128,226 +50,335 @@ impl Default for CfgTarget {
                 .unwrap_or_else(|_| String::new())
                 .to_uppercase()
         }
-        CfgTarget {
-            target_arch: getenv("CARGO_CFG_TARGET_ARCH"),
-            target_feature: getenv("CARGO_CFG_TARGET_FEATURE"),
-            target_os: getenv("CARGO_CFG_TARGET_OS"),
-            target_family: getenv("CARGO_CFG_TARGET_FAMILY"),
-            target_env: getenv("CARGO_CFG_TARGET_ENV"),
-            target_endian: getenv("CARGO_CFG_TARGET_ENDIAN"),
-            target_pointer_width: getenv("CARGO_CFG_TARGET_POINTER_WIDTH"),
-            target_vendor: getenv("CARGO_CFG_TARGET_VENDOR"),
+
+        TargetConfiguration {
+            arch: getenv("CARGO_CFG_TARGET_ARCH"),
+            feature: getenv("CARGO_CFG_TARGET_FEATURE"),
+            os: getenv("CARGO_CFG_TARGET_OS"),
+            family: getenv("CARGO_CFG_TARGET_FAMILY"),
+            env: getenv("CARGO_CFG_TARGET_ENV"),
+            endian: getenv("CARGO_CFG_TARGET_ENDIAN"),
+            pointer_width: getenv("CARGO_CFG_TARGET_POINTER_WIDTH"),
+            vendor: getenv("CARGO_CFG_TARGET_VENDOR"),
         }
     }
 }
 
-impl<'a> CfgBuilder<'a> {
-    fn initialized(&'a mut self) -> &'a mut CfgBuilder {
-        match *self {
-            CfgBuilder::Uninitialized => {
-                *self = CfgBuilder::Cond(Cfg {
-                    arch: None,
-                    os: None,
-                    family: None,
-                    env: None,
-                    endian: None,
-                    pointer_width: None,
-                    vendor: None,
-                });
-                self
-            }
-            _ => self,
-        }
+impl TargetConfiguration {
+    /// Test whether the target architecture exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_arch(&self, arch: &str) -> bool {
+        self.arch == arch.to_uppercase()
     }
 
-    pub fn target_arch(&'a mut self, arch: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_arch(Self::initialized(self), arch),
-            CfgBuilder::Cond(it) => {
-                it.arch = Some(arch);
-                self
-            }
-        }
+    /// Test whether the target OS exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_os(&self, os: &str) -> bool {
+        self.os == os.to_uppercase()
     }
 
-    pub fn target_os(&'a mut self, os: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_os(Self::initialized(self), os),
-            CfgBuilder::Cond(it) => {
-                it.os = Some(os);
-                self
-            }
-        }
+    /// Test whether the target family exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_family(&self, family: &str) -> bool {
+        self.family == family.to_uppercase()
     }
 
-    pub fn target_family(&'a mut self, family: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_family(Self::initialized(self), family),
-            CfgBuilder::Cond(it) => {
-                it.family = Some(family);
-                self
-            }
-        }
+    /// Test whether the target "environment" exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_env(&self, env: &str) -> bool {
+        self.env == env.to_uppercase()
     }
 
-    pub fn target_env(&'a mut self, env: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_env(Self::initialized(self), env),
-            CfgBuilder::Cond(it) => {
-                it.env = Some(env);
-                self
-            }
-        }
+    /// Test whether the target endianness exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_endian(&self, endian: &str) -> bool {
+        self.endian == endian.to_uppercase()
     }
 
-    pub fn target_endian(&'a mut self, endianess: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_endian(Self::initialized(self), endianess),
-            CfgBuilder::Cond(it) => {
-                it.endian = Some(endianess);
-                self
-            }
-        }
+    /// Test whether the target pointer width exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_pointer_width(&self, pointer_width: &str) -> bool {
+        self.pointer_width == pointer_width.to_uppercase()
     }
 
-    pub fn target_pointer_width(&'a mut self, pointer_width: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => {
-                Self::target_pointer_width(Self::initialized(self), pointer_width)
-            }
-            CfgBuilder::Cond(it) => {
-                it.pointer_width = Some(pointer_width);
-                self
-            }
-        }
-    }
-
-    pub fn target_vendor(&'a mut self, vendor: &'a str) -> &mut CfgBuilder<'a> {
-        match self {
-            CfgBuilder::Uninitialized => Self::target_vendor(Self::initialized(self), vendor),
-            CfgBuilder::Cond(it) => {
-                it.vendor = Some(vendor);
-                self
-            }
-        }
-    }
-
-    pub fn build(&self) -> Cfg {
-        match self {
-            // precluded by the cfg! macro from being a question
-            // reachable here via CfgBuilder::default().build() so we want to panic.
-            CfgBuilder::Uninitialized => panic!("CfgBuilder uninitialized"),
-
-            CfgBuilder::Cond(inner) => *inner,
-        }
+    /// Test whether the target vendor exactly matches the argument, in
+    /// case-insensitive fashion.
+    pub fn target_vendor(&self, vendor: &str) -> bool {
+        self.vendor == vendor.to_uppercase()
     }
 }
 
-impl<'a> Default for CfgBuilder<'a> {
-    fn default() -> Self {
-        CfgBuilder::Uninitialized
-    }
+/// Test for characteristics of the target machine.
+///
+/// Unlike the standard `cfg!` macro, this macro will give correct results
+/// when cross-compiling in a build.rs script. It attempts, but is not
+/// guaranteed, to emulate the syntax of the `cfg!` macro. Note, however,
+/// that the result of the macro must be evaluated at runtime, not compile-time.
+///
+/// Supported syntaxes:
+///
+/// ```notest
+/// target_cfg!(target_os = "macos");
+/// target_cfg!(not(target_os = "macos"));
+/// target_cfg!(any(target_os = "macos", target_endian = "big"));
+/// target_cfg!(all(target_os = "macos", target_endian = "big"));
+/// target_cfg!(all(target_os = "macos", not(target_endian = "big")));
+/// ```
+// Here we go with some exciting macro fun!
+//
+// Since each individual test can be evaluated to a boolean on-the-spot, the
+// macro expands out to a big boolean logical expression. Fundamentally, it's
+// not too hard to allow complex syntax because the macro can recurse:
+//
+// ```
+// target_cfg!(not(whatever)) => !(target_cfg!(whatever))
+// target_cfg!(any(c1, c2)) => target_cfg!(c1) || target_cfg!(c2)
+// ```
+//
+// The core implementation challenge here is that we need to parse
+// comma-separated lists where each term might contain all sorts of unexpected
+// content. Within the confines of the macro_rules! formalism, this means that
+// we need to scan through such comma-separated lists and group their tokens
+// before actually evaluating them.
+//
+// Some key points to remember about how this all works:
+//
+// 1. A "token tree" type is either a single token or a series of tokens
+//    delimited by balanced delimiters such as ({[]}). As such, in order to
+//    match an arbitrary token sequence, you need to use repetition
+//    expressions of the form `$($toks:tt)+`.
+// 2. The macro evaluator looks at rules in order and cannot backtrack. That
+//    is, if it is looking at a rule and has matched the first 5 tokens but
+//    the 6th disagrees, there must be a subsequent rule that also matches
+//    those first 5 tokens.
+// 3. Given the above, we use the standard trick of having different macro
+//    "modes" prefixed with an expression like `@emit`. They are essentially
+//    different sub-macros but this trick allows us to get everything done
+//    with one named macro_rules! export.
+#[macro_export]
+macro_rules! target_cfg {
+    // "@emit" rules are used for comma-separated lists that have had their
+    // tokens grouped. The general pattern is: `target_cfg!(@emit $operation
+    // {clause1..} {clause2..} {clause3..})`.
+
+    // Emitting `any(clause1,clause2,...)`: convert to `target_cfg!(clause1) && target_cfg!(clause2) && ...`
+    (
+        @emit
+        all
+        $({$($grouped:tt)+})+
+    ) => {
+        ($(
+            (target_cfg!($($grouped)+))
+        )&&+)
+    };
+
+    // Likewise for `all(clause1,clause2,...)`.
+    (
+        @emit
+        any
+        $({$($grouped:tt)+})+
+    ) => {
+        ($(
+            (target_cfg!($($grouped)+))
+        )||+)
+    };
+
+    // "@clause" rules are used to parse the comma-separated lists. They munch
+    // their inputs token-by-token and finally invoke an "@emit" rule when the
+    // list is all grouped. The general pattern for recording the parser state
+    // is:
+    //
+    // ```
+    // target_cfg!(
+    //    @clause $operation
+    //    [{grouped-clause-1} {grouped-clause-2...}]
+    //    [not-yet-parsed-tokens...]
+    //    current-clause-tokens...
+    // )
+    // ```
+
+    // This rule must come first in this section. It fires when the next token
+    // to parse is a comma. When this happens, we take the tokens in the
+    // current clause and add them to the list of grouped clauses, adding
+    // delimeters so that the grouping can be easily extracted again in the
+    // emission stage.
+    (
+        @clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        [, $($rest:tt)*]
+        $($current:tt)+
+    ) => {
+        target_cfg!(@clause $op [
+            $(
+                {$($grouped)+}
+            )*
+            {$($current)+}
+        ] [
+            $($rest)*
+        ]);
+    };
+
+    // This rule comes next. It fires when the next un-parsed token is *not* a
+    // comma. In this case, we add that token to the list of tokens in the
+    // current clause, then move on to the next one.
+    (
+        @clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        [$tok:tt $($rest:tt)*]
+        $($current:tt)*
+    ) => {
+        target_cfg!(@clause $op [
+            $(
+                {$($grouped)+}
+            )*
+        ] [
+            $($rest)*
+        ] $($current)* $tok);
+    };
+
+    // This rule fires when there are no more tokens to parse in this list. We
+    // finish off the "current" token group, then delegate to the emission
+    // rule.
+    (
+        @clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        []
+        $($current:tt)+
+    ) => {
+        target_cfg!(@emit $op
+            $(
+                {$($grouped)+}
+            )*
+            {$($current)+}
+        );
+    };
+
+    // Finally, these are the "toplevel" syntaxes for specific tests that can
+    // be performed. Any construction not prefixed with one of the magic
+    // tokens must match one of these.
+
+    // `all(clause1, clause2...)` : we must parse this comma-separated list and
+    // partner with `@emit all` to output a bunch of && terms.
+    (
+        all($($tokens:tt)+)
+    ) => {
+        target_cfg!(@clause all [] [$($tokens)+])
+    };
+
+    // Likewise for `any(clause1, clause2...)`
+    (
+        any($($tokens:tt)+)
+    ) => {
+        target_cfg!(@clause any [] [$($tokens)+])
+    };
+
+    // `not(clause)`: compute the inner clause, then just negate it.
+    (
+        not($($tokens:tt)+)
+    ) => {
+        !(target_cfg!($($tokens)+))
+    };
+
+    // `param = value`: test for equality.
+    (
+        $e:tt = $v:expr
+    ) => {
+        $crate::TARGET_CONFIG.$e($v)
+    };
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{CfgBuilder, CfgTarget};
-
+    /// Set up the environment variables for testing. We intentionally choose
+    /// values that don't occur in the real world, except for parameters that
+    /// have heavily constrained options, to avoid accidentally passing
+    /// if/when running the test suite on familiar hardware.
     fn setup_test_env() {
-        /* Dummy values for running the tests outside of build.rs/cargo */
-        std::env::set_var("CARGO_CFG_TARGET_ARCH", "i686");
-        std::env::set_var("CARGO_CFG_TARGET_FEATURE", "avx");
-        std::env::set_var("CARGO_CFG_TARGET_OS", "linux");
-        std::env::set_var("CARGO_CFG_TARGET_FAMILY", "unix");
-        std::env::set_var("CARGO_CFG_TARGET_ENV", "gnu");
+        std::env::set_var("CARGO_CFG_TARGET_ARCH", "testarch");
+        std::env::set_var("CARGO_CFG_TARGET_FEATURE", "testfeat1,testfeat2");
+        std::env::set_var("CARGO_CFG_TARGET_OS", "testos");
+        std::env::set_var("CARGO_CFG_TARGET_FAMILY", "testfamily");
+        std::env::set_var("CARGO_CFG_TARGET_ENV", "testenv");
         std::env::set_var("CARGO_CFG_TARGET_ENDIAN", "little");
         std::env::set_var("CARGO_CFG_TARGET_POINTER_WIDTH", "32");
-        std::env::set_var("CARGO_CFG_TARGET_VENDOR", "unknown");
+        std::env::set_var("CARGO_CFG_TARGET_VENDOR", "testvendor");
     }
 
+    /// No recursion. Check all of the supported tests.
     #[test]
-    fn test_any() {
+    fn test_level0() {
         setup_test_env();
 
-        let target_info: CfgTarget = CfgTarget::default();
-        let mut cond_a = CfgBuilder::default();
-        let mut cond_b = CfgBuilder::default();
-        let mut cond_c = CfgBuilder::default();
-        let mut cond_d = CfgBuilder::default();
+        assert!(target_cfg!(target_arch = "testarch"));
+        assert!(!target_cfg!(target_arch = "wrong"));
 
-        let cond_ff_1 = &cond_a
-            .target_arch("gothic")
-            .target_os("cathederal")
-            .target_endian("big")
-            .build();
-        let cond_ff_2 = &cond_b.target_arch("victorian").target_os("home").build();
-        let cond_tt = &cond_c.target_arch("i686").target_os("linux").build();
-        let cond_ff_3 = &cond_d
-            .target_arch("i686")
-            .target_os("linux")
-            .target_endian("big")
-            .build();
-
-        assert_eq!(target_info.any(&[cond_ff_1]), false);
-        assert_eq!(target_info.any(&[cond_ff_3]), false);
-        assert_eq!(target_info.any(&[cond_tt]), true);
-        assert_eq!(target_info.any(&[cond_ff_1, cond_tt]), true);
-        assert_eq!(target_info.any(&[cond_ff_1, cond_tt]), true);
-        assert_eq!(target_info.any(&[cond_ff_1, cond_tt, cond_ff_2]), true);
+        assert!(target_cfg!(target_os = "testos"));
+        assert!(target_cfg!(target_family = "testfamily"));
+        assert!(target_cfg!(target_env = "testenv"));
+        assert!(target_cfg!(target_endian = "little"));
+        assert!(target_cfg!(target_pointer_width = "32"));
+        assert!(target_cfg!(target_vendor = "testvendor"));
     }
 
+    /// Basic recursion.
     #[test]
-    #[should_panic]
-    fn test_invalid_build() {
+    fn test_level1() {
         setup_test_env();
-        CfgBuilder::default().build();
+
+        assert!(target_cfg!(not(target_arch = "wrong")));
+        assert!(!target_cfg!(not(target_arch = "testarch")));
+
+        assert!(target_cfg!(all(target_arch = "testarch")));
+        assert!(!target_cfg!(all(target_arch = "wrong")));
+        assert!(target_cfg!(all(
+            target_arch = "testarch",
+            target_os = "testos"
+        )));
+        assert!(!target_cfg!(all(
+            target_arch = "testarch",
+            target_os = "wrong"
+        )));
+
+        assert!(target_cfg!(any(target_arch = "testarch")));
+        assert!(!target_cfg!(any(target_arch = "wrong")));
+        assert!(target_cfg!(any(
+            target_arch = "testarch",
+            target_os = "testos"
+        )));
+        assert!(target_cfg!(any(
+            target_arch = "testarch",
+            target_os = "wrong"
+        )));
+        assert!(!target_cfg!(any(
+            target_arch = "wrong1",
+            target_os = "wrong2"
+        )));
     }
 
+    /// Even deeper recursion.
     #[test]
-    #[should_panic]
-    fn test_any_invalid_input() {
+    fn test_level2() {
         setup_test_env();
-        let target_info: CfgTarget = CfgTarget::default();
-        target_info.any(&[]); // I guess?
-    }
 
-    #[test]
-    fn test_all() {
-        setup_test_env();
-        let target_info: CfgTarget = CfgTarget::default();
-        let mut cond_a = CfgBuilder::default();
-        let mut cond_b = CfgBuilder::default();
-        let mut cond_c = CfgBuilder::default();
-        let mut cond_d = CfgBuilder::default();
+        assert!(target_cfg!(all(not(target_arch = "wrong"))));
+        assert!(!target_cfg!(all(not(target_arch = "testarch"))));
 
-        let cond_ff_1 = &cond_a
-            .target_arch("gothic")
-            .target_os("cathederal")
-            .target_endian("big")
-            .build();
-        let cond_ff_2 = &cond_b.target_arch("victorian").target_os("home").build();
-        let cond_tt = &cond_c.target_arch("i686").target_os("linux").build();
-        let cond_ff_3 = &cond_d
-            .target_arch("i686")
-            .target_os("linux")
-            .target_endian("big")
-            .build();
+        assert!(target_cfg!(all(
+            target_arch = "testarch",
+            not(target_os = "wrong")
+        )));
 
-        assert_eq!(target_info.all(&[cond_ff_1]), false);
-        assert_eq!(target_info.all(&[cond_tt]), true);
-        assert_eq!(target_info.all(&[cond_ff_1]), false);
-        assert_eq!(target_info.all(&[cond_ff_3]), false);
-        assert_eq!(target_info.all(&[cond_ff_1, cond_tt]), false);
-        assert_eq!(target_info.all(&[cond_tt, cond_ff_1]), false);
-        assert_eq!(target_info.all(&[cond_ff_1, cond_tt]), false);
-        assert_eq!(target_info.all(&[cond_ff_1, cond_tt, cond_ff_2]), false);
-    }
+        assert!(target_cfg!(all(
+            any(target_arch = "testarch", target_os = "wrong"),
+            target_env = "testenv"
+        )));
 
-    #[test]
-    #[should_panic]
-    fn test_all_invalid_input() {
-        setup_test_env();
-        let target_info: CfgTarget = CfgTarget::default();
-        target_info.all(&[]); // I guess?
+        assert!(target_cfg!(all(
+            any(target_arch = "testarch", target_os = "wrong"),
+            not(target_vendor = "wrong")
+        )));
     }
 }


### PR DESCRIPTION
Here is a first stab at #476

Test coverage in this library isn't complete, It's a little terrible.
It could probably be it's own crate instead of added as a subdir module.  
but i wanted to post for feedback before commiting to any API..

There is still some `#[cfg(...)]` stuff left in build.rs, but those are generally dealing with running host tools.  This doesn't currently implement cargo-feature checking, which seems to require it's own special mechanism.