### PR TITLE
Add a space in bibtex error messages.

### DIFF
--- a/tectonic/bibtex.c
+++ b/tectonic/bibtex.c
@@ -910,7 +910,7 @@ static void already_seen_function_print(hash_loc seen_fn_loc)
 
 static void bib_ln_num_print(void)
 {
-    printf_log("--line %ld of file", (long) bib_line_num);
+    printf_log("--line %ld of file ", (long) bib_line_num);
     print_bib_name();
 }
 


### PR DESCRIPTION
I've confirmed that the texlive sources have a space here.

Before this change, error messages looked like "Illegal end of database file---line 3 of filetest.bib"; this adds a space between "file" and "test.bib".