### PR TITLE
Introduce build_date engine parameter

### DIFF
--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -496,6 +496,7 @@ extern "C" {
         api: *const TectonicBridgeApi,
         dump_name: *const libc::c_char,
         input_file_name: *const libc::c_char,
+        build_date: libc::time_t,
     ) -> libc::c_int;
     fn dvipdfmx_simple_main(
         api: *const TectonicBridgeApi,
@@ -503,6 +504,7 @@ extern "C" {
         pdfname: *const libc::c_char,
         enable_compression: bool,
         deterministic_tags: bool,
+        build_date: libc::time_t,
     ) -> libc::c_int;
     fn bibtex_simple_main(
         api: *const TectonicBridgeApi,

--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -84,7 +84,7 @@ fn get_index(url: &str, status: &mut dyn StatusBackend) -> Result<GzDecoder<Resp
     let res = Client::new().get(&index_url).send()?;
     if !res.status().is_success() {
         return Err(Error::from(ErrorKind::UnexpectedHttpResponse(
-            index_url.clone(),
+            index_url,
             res.status(),
         )))
         .chain_err(|| "couldn\'t fetch".to_string());
@@ -450,7 +450,7 @@ impl CachedITarBundle {
         Ok(CachedITarBundle {
             url: url.to_owned(),
             redirect_url,
-            digest_path: digest_path.to_owned(),
+            digest_path,
             cached_digest,
             checked_digest,
             manifest_path,

--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -52,7 +52,7 @@ tt_get_error_message(void)
  * setjmp aborts and error message extraction. */
 
 int
-tex_simple_main(tt_bridge_api_t *api, char *dump_name, char *input_file_name)
+tex_simple_main(tt_bridge_api_t *api, char *dump_name, char *input_file_name, time_t build_date)
 {
     int rv;
 
@@ -63,14 +63,14 @@ tex_simple_main(tt_bridge_api_t *api, char *dump_name, char *input_file_name)
         return HISTORY_FATAL_ERROR;
     }
 
-    rv = tt_run_engine(dump_name, input_file_name);
+    rv = tt_run_engine(dump_name, input_file_name, build_date);
     tectonic_global_bridge = NULL;
     return rv;
 }
 
 
 int
-dvipdfmx_simple_main(tt_bridge_api_t *api, char *dviname, char *pdfname, bool compress, bool deterministic_tags)
+dvipdfmx_simple_main(tt_bridge_api_t *api, char *dviname, char *pdfname, bool compress, bool deterministic_tags, time_t build_date)
 {
     int rv;
 
@@ -81,7 +81,7 @@ dvipdfmx_simple_main(tt_bridge_api_t *api, char *dviname, char *pdfname, bool co
         return 99;
     }
 
-    rv = dvipdfmx_main(pdfname, dviname, NULL, 0, false, compress, deterministic_tags, false, 0);
+    rv = dvipdfmx_main(pdfname, dviname, NULL, 0, false, compress, deterministic_tags, false, 0, build_date);
     tectonic_global_bridge = NULL;
 
     return rv;

--- a/tectonic/core-bridge.h
+++ b/tectonic/core-bridge.h
@@ -87,8 +87,8 @@ BEGIN_EXTERN_C
  * API that we expose to the Rust side of things. */
 
 const char *tt_get_error_message(void);
-int tex_simple_main(tt_bridge_api_t *api, char *dump_name, char *input_file_name);
-int dvipdfmx_simple_main(tt_bridge_api_t *api, char *dviname, char *pdfname, bool compress, bool deterministic_tags);
+int tex_simple_main(tt_bridge_api_t *api, char *dump_name, char *input_file_name, time_t build_date);
+int dvipdfmx_simple_main(tt_bridge_api_t *api, char *dviname, char *pdfname, bool compress, bool deterministic_tags, time_t build_date);
 int bibtex_simple_main(tt_bridge_api_t *api, char *aux_file_name);
 
 /* The internal, C/C++ interface: */

--- a/tectonic/dpx-dvipdfmx.c
+++ b/tectonic/dpx-dvipdfmx.c
@@ -94,6 +94,8 @@ static int     do_encryption = 0;
 static int     key_bits      = 40;
 static int32_t permission    = 0x003C;
 
+time_t source_date_epoch = (time_t) -1;
+
 /* Page device */
 double paper_width  = 595.0;
 double paper_height = 842.0;
@@ -371,7 +373,8 @@ dvipdfmx_main (
   bool compress,
   bool deterministic_tags,
   bool quiet,
-  unsigned int verbose)
+  unsigned int verbose,
+  time_t build_date)
 {
   bool enable_object_stream = true;
   double dvi2pts;
@@ -425,6 +428,7 @@ dvipdfmx_main (
   font_dpi = 600;
   pdfdecimaldigits = 5;
   image_cache_life = -2;
+  source_date_epoch = build_date;
   pdf_load_fontmap_file("pdftex.map", FONTMAP_RMODE_APPEND);
   pdf_load_fontmap_file("kanjix.map", FONTMAP_RMODE_APPEND);
   pdf_load_fontmap_file("ckx.map", FONTMAP_RMODE_APPEND);

--- a/tectonic/dpx-dvipdfmx.h
+++ b/tectonic/dpx-dvipdfmx.h
@@ -33,6 +33,7 @@
 
 extern int is_xdv;
 extern int translate_origin;
+extern time_t source_date_epoch;
 
 int extractbb(int argc, char *argv[]);
 int dvipdfmx_main(
@@ -44,6 +45,7 @@ int dvipdfmx_main(
   bool compress,
   bool deterministic_tags,
   bool quiet,
-  unsigned int verbose);
+  unsigned int verbose,
+  time_t build_date);
 
 #endif /* _DVIPDFMX_H_ */

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -89,7 +89,6 @@ void pdf_enc_set_verbose (int level)
 static void
 pdf_enc_init (int use_aes, int encrypt_metadata)
 {
-  time_t current_time;
   struct pdf_sec *p = &sec_data;
 
   srand(source_date_epoch); /* For AES IV */
@@ -105,7 +104,6 @@ pdf_enc_compute_id_string (const char *dviname, const char *pdfname)
 {
   struct pdf_sec *p = &sec_data;
   char *date_string, *producer;
-  time_t current_time;
   struct tm *bd_time;
   MD5_CONTEXT     md5;
 

--- a/tectonic/dpx-pdfencrypt.c
+++ b/tectonic/dpx-pdfencrypt.c
@@ -92,10 +92,7 @@ pdf_enc_init (int use_aes, int encrypt_metadata)
   time_t current_time;
   struct pdf_sec *p = &sec_data;
 
-  current_time = get_unique_time_if_given();
-  if (current_time == INVALID_EPOCH_VALUE)
-    current_time = time(NULL);
-  srand(current_time); /* For AES IV */
+  srand(source_date_epoch); /* For AES IV */
   p->setting.use_aes = use_aes;
   p->setting.encrypt_metadata = encrypt_metadata;
 }
@@ -118,13 +115,7 @@ pdf_enc_compute_id_string (const char *dviname, const char *pdfname)
   MD5_init(&md5);
 
   date_string = NEW(15, char);
-  current_time = get_unique_time_if_given();
-  if (current_time == INVALID_EPOCH_VALUE) {
-    time(&current_time);
-    bd_time = localtime(&current_time);
-  } else {
-    bd_time = gmtime(&current_time);
-  }
+  bd_time = gmtime(&source_date_epoch);
   sprintf(date_string, "%04d%02d%02d%02d%02d%02d",
           bd_time->tm_year + 1900, bd_time->tm_mon + 1, bd_time->tm_mday,
           bd_time->tm_hour, bd_time->tm_min, bd_time->tm_sec);

--- a/tectonic/dpx-pdfobj.h
+++ b/tectonic/dpx-pdfobj.h
@@ -192,7 +192,5 @@ size_t pdfobj_escape_str (char *buffer, size_t size, const unsigned char *s, siz
 
 pdf_obj *pdf_new_indirect  (pdf_file *pf, unsigned label, unsigned short generation);
 
-time_t get_unique_time_if_given(void);
-#define INVALID_EPOCH_VALUE ((time_t)-1)
 
 #endif  /* _PDFOBJ_H_ */

--- a/tectonic/xetex-ini.c
+++ b/tectonic/xetex-ini.c
@@ -3902,7 +3902,7 @@ get_strings_started(void)
 
 
 tt_history_t
-tt_run_engine(char *dump_name, char *input_file_name)
+tt_run_engine(char *dump_name, char *input_file_name, time_t build_date)
 {
     int32_t font_k;
 
@@ -4271,7 +4271,8 @@ tt_run_engine(char *dump_name, char *input_file_name)
         INTPAR(month) = 0;
         INTPAR(year) = 0;
     } else {
-        get_date_and_time(&(INTPAR(time)),
+        get_date_and_time(build_date,
+                          &(INTPAR(time)),
                           &(INTPAR(day)),
                           &(INTPAR(month)),
                           &(INTPAR(year)));

--- a/tectonic/xetex-texmfmp.c
+++ b/tectonic/xetex-texmfmp.c
@@ -16,13 +16,11 @@ static char *last_source_name = NULL;
 static int last_lineno;
 
 void
-get_date_and_time (int32_t *minutes,  int32_t *day,
-                   int32_t *month,  int32_t *year)
+get_date_and_time (time_t source_date_epoch,
+                   int32_t *minutes, int32_t *day,
+                   int32_t *month, int32_t *year)
 {
-  struct tm *tmptr;
-
-  time_t myclock = time ((time_t *) 0);
-  tmptr = localtime (&myclock);
+  struct tm *tmptr = localtime (&source_date_epoch);
   *minutes = tmptr->tm_hour * 60 + tmptr->tm_min;
   *day = tmptr->tm_mday;
   *month = tmptr->tm_mon + 1;

--- a/tectonic/xetex-xetexd.h
+++ b/tectonic/xetex-xetexd.h
@@ -343,7 +343,7 @@ typedef struct {
 /* Functions originating in texmfmp.c */
 
 void getmd5sum(int32_t s, bool file);
-void get_date_and_time (int32_t *, int32_t *, int32_t *, int32_t *);
+void get_date_and_time (time_t, int32_t *, int32_t *, int32_t *, int32_t *);
 
 char *gettexstring(str_number);
 bool is_new_source(str_number, int);
@@ -1095,7 +1095,7 @@ cur_length(void) {
 
 
 /* Tectonic related functions */
-tt_history_t tt_run_engine(char *dump_name, char *input_file_name);
+tt_history_t tt_run_engine(char *dump_name, char *input_file_name, time_t build_date);
 
 
 /* formerly xetex.h: */

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -121,7 +121,7 @@ impl TestCase {
                     .with_deterministic_tags(true)
                     .with_date(
                         time::SystemTime::UNIX_EPOCH
-                            .checked_add(time::Duration::from_secs(1456304492))
+                            .checked_add(time::Duration::from_secs(1_456_304_492))
                             .unwrap(),
                     )
                     .process(&mut io, &mut events, &mut status, &xdvname, &pdfname)

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 use std::collections::HashSet;
-use std::env;
 use std::path::Path;
+use std::time;
 
 use tectonic::engines::tex::TexResult;
 use tectonic::engines::NoopIoEventBackend;
@@ -116,13 +116,14 @@ impl TestCase {
                 TexEngine::new().process(&mut io, &mut events, &mut status, "plain.fmt", &texname);
 
             if self.check_pdf && tex_res.definitely_same(&Ok(TexResult::Spotless)) {
-                // While the xdv and log output is deterministic without setting
-                // SOURCE_DATE_EPOCH, xdvipdfmx uses the current date in various places.
-                env::set_var("SOURCE_DATE_EPOCH", "1456304492"); // TODO: default to deterministic behaviour
-
                 XdvipdfmxEngine::new()
                     .with_compression(false)
                     .with_deterministic_tags(true)
+                    .with_date(
+                        time::SystemTime::UNIX_EPOCH
+                            .checked_add(time::Duration::from_secs(1456304492))
+                            .unwrap(),
+                    )
                     .process(&mut io, &mut events, &mut status, &xdvname, &pdfname)
                     .unwrap();
             }


### PR DESCRIPTION
This replaces dvipdfmx's `get_unique_time_if_given` by passing a 'current time' to the engines via the `build_date`config option.