### PR TITLE
Make toml crate optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ version = "0.1.12-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ vcpkg = "0.2.7"
 
 [dependencies]
 app_dirs = "^1.1"
+cfg-if = "0.1"
 structopt = "0.3"
 error-chain = "^0.12"
 flate2 = { version = "^1.0", default-features = false, features = ["zlib"] }
@@ -55,7 +56,7 @@ sha2 = "^0.8"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 tectonic_xdv = { path = "xdv", version = "0.1.9-dev" }
 termcolor = "^1.0"
-toml = "^0.5"
+toml = { version = "^0.5", optional = true }
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
 
 [features]
@@ -63,7 +64,7 @@ default = ["serialization"]
 # Note: we used to have this to couple "serde" and "serde-derive", but we've
 # adopted the newer scheme to avoid having to depend on both -- should maybe
 # just get rid of this feature:
-serialization = ["serde"]
+serialization = ["serde", "toml"]
 
 # freetype-sys = "^0.4"
 # harfbuzz-sys = "^0.1"

--- a/dist/travis.sh
+++ b/dist/travis.sh
@@ -199,6 +199,9 @@ if $is_docker_build ; then
     docker run -v $(pwd):/alpine/home/rust/src ttci-$IMAGE
     travis_fold_end docker_test
 else
+    travis_fold_start cargo_build_no_default_features "cargo build --no-default-features" verbose
+    cargo build --no-default-features --verbose
+    travis_fold_end cargo_build_no_default_features
     travis_fold_start cargo_build "cargo build" verbose
     cargo build --verbose
     travis_fold_end cargo_build

--- a/src/app_dirs.rs
+++ b/src/app_dirs.rs
@@ -12,10 +12,12 @@ const APP_INFO: app_dirs::AppInfo = app_dirs::AppInfo {
     author: "TectonicProject",
 };
 
+#[cfg(feature = "serialization")]
 pub fn user_config() -> Result<PathBuf> {
     Ok(app_dirs::app_root(AppDataType::UserConfig, &APP_INFO)?)
 }
 
+#[cfg(feature = "serialization")]
 pub fn get_user_config() -> Result<PathBuf> {
     Ok(app_dirs::get_app_root(AppDataType::UserConfig, &APP_INFO)?)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,8 +18,39 @@ use std::result::Result as StdResult;
 use std::{convert, ffi, io, num, str};
 use tectonic_xdv;
 use tempfile;
-use toml;
 use zip::result::ZipError;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "toml")] {
+        pub type ReadError = toml::de::Error;
+        pub type WriteError = toml::ser::Error;
+    } else {
+        use std::fmt::{self, Formatter, Display};
+        use std::error;
+
+        #[derive(Debug)]
+        pub enum ReadError {}
+
+        impl Display for ReadError {
+            fn fmt(&self, _fmt: &mut Formatter<'_>) -> fmt::Result {
+                Ok(())
+            }
+        }
+
+        impl error::Error for ReadError { }
+
+        #[derive(Debug)]
+        pub enum WriteError {}
+
+        impl Display for WriteError {
+            fn fmt(&self, _fmt: &mut Formatter<'_>) -> fmt::Result {
+                Ok(())
+            }
+        }
+
+        impl error::Error for WriteError { }
+    }
+}
 
 error_chain! {
     types {
@@ -33,8 +64,8 @@ error_chain! {
         ParseInt(num::ParseIntError);
         Persist(tempfile::PersistError);
         Reqwest(reqwest::Error);
-        TomlDe(toml::de::Error);
-        TomlSer(toml::ser::Error);
+        ConfigRead(ReadError);
+        ConfigWrite(WriteError);
         Utf8(str::Utf8Error);
         Xdv(tectonic_xdv::XdvError);
         Zip(ZipError);


### PR DESCRIPTION
The toml crate is only needed when serialization feature is enabled, so it can be made optional.

i had to create dump errors to put in place of the toml errors in the error-chain setup.

This also tests building with --no-default-features.