### PR TITLE
Zero memory upon allocation in bibtex.

### DIFF
--- a/tectonic/bibtex.c
+++ b/tectonic/bibtex.c
@@ -9,7 +9,7 @@
 #define eof tectonic_eof
 
 /* (Re)Allocate N items of type T using xmalloc/xrealloc.  */
-#define XTALLOC(n, t) (xmalloc ((n) * sizeof (t)))
+#define XTALLOC(n, t) (xcalloc (n, sizeof (t)))
 
 #define BIB_XRETALLOC_NOSET(array_name, array_var, type, size_var, new_size) \
   (array_var) = (type *) xrealloc((array_var), (new_size + 1) * sizeof(type))


### PR DESCRIPTION
This fixes an issue I'm having with memory corruption when calling bibtex multiple times. I have some sample code demonstrating the problem in https://github.com/jneem/tectonic-bibtex-test. Before this patch, running that code reliably produces valgrind warnings (and occasionally crashes). After this patch, it doesn't. 