### PR TITLE
 omit-frame-pointer and profile feature (take 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ name = "tectonic"
 crate-type = ["rlib"]
 
 [build-dependencies]
-cc = "^1.0"
+cc = "^1.0.46"
 pkg-config = "^0.3"  # note: sync dist/docker/*/pkg-config-rs.sh with the version in Cargo.lock
 regex = "^1.3"
 sha2 = "^0.8"
@@ -66,6 +66,9 @@ default = ["serialization"]
 # adopted the newer scheme to avoid having to depend on both -- should maybe
 # just get rid of this feature:
 serialization = ["serde", "toml"]
+
+# developer feature to compile with the necessary flags for profiling tectonic.
+profile = []
 
 # freetype-sys = "^0.4"
 # harfbuzz-sys = "^0.1"

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,6 @@ use tectonic_cfg_support::*;
 use vcpkg;
 
 use std::env;
-use std::ops::Not;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "macos"))]
@@ -204,11 +203,12 @@ fn main() {
         ccfg.flag_if_supported(flag);
     }
 
-    // Negated whitelist of the platforms which work without frame pointers.
-    // To add more platforms, or these together:
-    // target_cfg!(...) || target_cfg!(...).not();
+    // If we want to profile, the default assumption is that we must force the
+    // compiler to include frame pointers. We whitelist platforms that are
+    // known to be able to profile *without* frame pointers: currently, only
+    // Linux/x86_64.
     let profile_target_requires_frame_pointer: bool =
-        target_cfg!(all(target_os = "linux", target_arch = "x86_64")).not();
+        target_cfg!(not(all(target_os = "linux", target_arch = "x86_64")));
 
     const PROFILE_BUILD_ENABLED: bool = cfg!(feature = "profile");
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ use tectonic_cfg_support::*;
 use vcpkg;
 
 use std::env;
+use std::ops::Not;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "macos"))]
@@ -203,11 +204,11 @@ fn main() {
         ccfg.flag_if_supported(flag);
     }
 
-    let profile_target_requires_frame_pointer: bool = target_cfg!(not(any(
-        // Whitelist of platforms which do not require frame pointers.
-        all(target_os = "linux", target_arch = "x86_64"),
-        // Add more platforms here.
-    )));
+    // Negated whitelist of the platforms which work without frame pointers.
+    // To add more platforms, or these together:
+    // target_cfg!(...) || target_cfg!(...).not();
+    let profile_target_requires_frame_pointer: bool =
+        target_cfg!(all(target_os = "linux", target_arch = "x86_64")).not();
 
     const PROFILE_BUILD_ENABLED: bool = cfg!(feature = "profile");
 

--- a/build.rs
+++ b/build.rs
@@ -203,6 +203,23 @@ fn main() {
         ccfg.flag_if_supported(flag);
     }
 
+    let profile_target_requires_frame_pointer: bool = target_cfg!(not(any(
+        // Whitelist of platforms which do not require frame pointers.
+        all(target_os = "linux", target_arch = "x86_64"),
+        // Add more platforms here.
+    )));
+
+    const PROFILE_BUILD_ENABLED: bool = cfg!(feature = "profile");
+
+    let profile_config = |cfg: &mut cc::Build| {
+        if PROFILE_BUILD_ENABLED {
+            cfg.debug(true)
+                .force_frame_pointer(profile_target_requires_frame_pointer);
+        }
+    };
+
+    profile_config(&mut ccfg);
+
     ccfg.file("tectonic/bibtex.c")
         .file("tectonic/core-bridge.c")
         .file("tectonic/core-memory.c")
@@ -333,6 +350,8 @@ fn main() {
     for flag in &cppflags {
         cppcfg.flag_if_supported(flag);
     }
+
+    profile_config(&mut cppcfg);
 
     cppcfg
         .cpp(true)


### PR DESCRIPTION
Take 2 on Pr #473, built on top of #477 so that would need to go in first.

It only required a few minor changes, (bump to released cc-rs),
using let instead of const, and of a closure for profile_config instead of a local fn.

[comparison against PR 477](https://github.com/ratmice/tectonic/compare/cfg_support...ratmice:pr_473-take2?expand=1)