### PR TITLE
.circleci: start investigating integration into the continuous-deployment workflow

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -126,4 +126,4 @@ test_script:
   - cargo test --target %target%
   # TEMPORARY: check out filenames for artifact publication
   - dir target
-  - dir target/*
+  - dir target\*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,15 +44,25 @@ environment:
   #   mingw_target: i686-w64-mingw32
   #   mingw_package_prefix: mingw-w64-i686
 
-# This filter is misleadingly named and applies to both tags and branches. We
-# filter to only build on the `continuous` tag and `vX.Y.Z` tags for
-# continuous deployment -- BUT pull requests still get CI'd. The `continuous`
-# tag is updated by Travis CI on every push to master, and its use allows us
-# to use the same logic to publish artifacts for both continuous deployment
-# and for release tags.
+# This filter is misleadingly named and applies to both tags and branches.
+#
+# The context for our settings is the Tectonic continuous deployment model, in
+# which Travis CI updates a tag named `continuous` for every push to master.
+# Running builds and deployments based on that tag update, rather than
+# directly on pushes to master, allows us to use the same logic to publish
+# artifacts for both continuous deployment and for release tags.
+#
+# So, ideally our CI scripts should run in three circumstances: (1) pull
+# requests, (2) release tags (`vX.Y.Z`), and (3) the `continuous` tag.
+#
+# It seems that AppVeyor won't build pull requests unless you activate builds
+# for the `master` branch, though, so we need to include it here. Farther
+# below we short-circuit and exit for pushes to master that are not PR builds.
+
 branches:
   only:
     - continuous
+    - master
     - /^v[0-9]\..*/
 
 cache:
@@ -63,6 +73,12 @@ cache:
   - target
 
 ## Install Script ##
+
+# As mentioned above: short-circuit if this is a push to master that isn't a
+# PR. Travis CI will update the `continuous` tag and we should trigger a build
+# and deployment off of that instead.
+init:
+- ps: if ($env:APPVEYOR_REPO_BRANCH -eq "master" -and !$env:APPVEYOR_PULL_REQUEST_TITLE) {Exit-AppveyorBuild}
 
 # This is the most important part of the Appveyor configuration. This installs the version of Rust
 # specified by the 'channel' and 'target' environment variables from the build matrix. This uses

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -114,8 +114,8 @@ before_test:
   # Building on msvc toolchain is seen as cross compilation.
   - set PKG_CONFIG_ALLOW_CROSS=1
   # Workaround rust#53454
-  - if "%target_env%" == "gnu" copy /y "C:\msys64\%mingw_subdir%\%mingw_target%\lib\crt2.o" %USERPROFILE%\.rustup\toolchains\%toolchain%\lib\rustlib\%target%\lib\crt2.o"
-  - if "%target_env%" == "gnu" copy /y "C:\msys64\%mingw_subdir%\%mingw_target%\lib\dllcrt2.o" %USERPROFILE%\.rustup\toolchains\%toolchain%\lib\rustlib\%target%\lib\dllcrt2.o"
+  - if "%target_env%" == "gnu" copy /y "C:\msys64\%mingw_subdir%\%mingw_target%\lib\crt2.o" "%USERPROFILE%\.rustup\toolchains\%toolchain%\lib\rustlib\%target%\lib\crt2.o"
+  - if "%target_env%" == "gnu" copy /y "C:\msys64\%mingw_subdir%\%mingw_target%\lib\dllcrt2.o" "%USERPROFILE%\.rustup\toolchains\%toolchain%\lib\rustlib\%target%\lib\dllcrt2.o"
   # Dodge format file locking issue in the test suite
   - set RUST_TEST_THREADS=1
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
 # Appveyor configuration template for Rust using rustup for Rust installation
 # https://github.com/starkat99/appveyor-rust
+#
+# AppVeyor environment variables: https://www.appveyor.com/docs/environment-variables/
 
 ## Operating System (VM environment) ##
 
@@ -42,12 +44,16 @@ environment:
   #   mingw_target: i686-w64-mingw32
   #   mingw_package_prefix: mingw-w64-i686
 
-# Don't CI branches besides master. Pull requests still get CI'd -- but
-# when a PR comes in on a branch in the same repo, this prevents it from
-# being CI'd twice.
+# This filter is misleadingly named and applies to both tags and branches. We
+# filter to only build on the `continuous` tag and `vX.Y.Z` tags for
+# continuous deployment -- BUT pull requests still get CI'd. The `continuous`
+# tag is updated by Travis CI on every push to master, and its use allows us
+# to use the same logic to publish artifacts for both continuous deployment
+# and for release tags.
 branches:
   only:
-    - master
+    - continuous
+    - /^v[0-9]\..*/
 
 cache:
   - '%USERPROFILE%\.cargo\bin'
@@ -102,3 +108,6 @@ before_test:
 # environment variable.
 test_script:
   - cargo test --target %target%
+  # TEMPORARY: check out filenames for artifact publication
+  - dir target
+  - dir target/*

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -126,4 +126,10 @@ test_script:
   - cargo test --target %target%
   # TEMPORARY: check out filenames for artifact publication
   - dir target
-  - dir target\*
+  - dir target\%target%
+  # TODO: munge in version, decide debug vs. release
+  - copy target\%target%\debug\tectonic.exe tectonic-%target%.exe
+
+artifacts:
+  - path: target-%target%.exe
+    name: Tectonic executable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -131,5 +131,5 @@ test_script:
   - copy target\%target%\debug\tectonic.exe tectonic-%target%.exe
 
 artifacts:
-  - path: target-%target%.exe
-    name: Tectonic executable
+  - path: 'target-$(target).exe'
+    name: 'Tectonic executable for $(target)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,11 @@
 # deployment logic that fires when a tag named `vX.Y.Z` is pushed to GitHub.
 # Since Travis CI takes care of the tag creation, we actually ignore pushes to
 # master, and instead just watch for events on the `continuous` tag.
+#
+# Environment variables used by Circle:
+# https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 
-version: 2
+version: 2.1
 
 jobs:
   build:
@@ -38,12 +41,12 @@ jobs:
 
 workflows:
   version: 2
-  pull-request:
+  pull-request-build:
     jobs:
       - build:
           filters:
             branches:
-              ignore: master
+              only: /pull\/[0-9]+/
   continuous-deployment-build:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# Copyright 2018 the Tectonic Project
+# Copyright 2018-2019 the Tectonic Project
 # Licensed under the MIT License
 
 # This CI workflow builds and tests Tectonic on a synthetic PowerPC CPU to
@@ -6,6 +6,14 @@
 # suite because the workflow is so different from our standard one, and Circle
 # has a longer build time limit, which is important in this laughably
 # inefficient approach that we're taking.
+#
+# Here we leverage the continuous deployment framework that's driven by our
+# Travis CI configuration. When commits are merged to master, a tag called
+# `continuous` is deleted and recreated to point to the latest version. This
+# allows us to write tag-driven CD logic that closely parallels the release
+# deployment logic that fires when a tag named `vX.Y.Z` is pushed to GitHub.
+# Since Travis CI takes care of the tag creation, we actually ignore pushes to
+# master, and instead just watch for events on the `continuous` tag.
 
 version: 2
 
@@ -15,8 +23,46 @@ jobs:
       image: circleci/classic:201711-01
     steps:
       # Print a notice aimed at confused pull-requesters:
-      - run: echo "Testing Tectonic on a synthetic big-endian CPU; this will take a while ..."
+      - run: echo "Testing Tectonic on a synthetic big-endian CPU; this will take a while."
+      - run: echo "Sometimes the build stalls and times out; this is likely not your fault."
       - checkout
       - run:
           command: sudo bash .circleci/outer-build.sh $CIRCLE_WORKING_DIRECTORY
           no_output_timeout: 1800
+
+  deploy:
+    machine:
+      image: circleci/classic:201711-01
+    steps:
+      - run: .circleci/deploy.sh
+
+workflows:
+  version: 2
+  pull-request:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: master
+  continuous-deployment-build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: continuous
+            branches:
+              ignore: /.*/
+      - deploy:
+          requires:
+            - build
+  release-build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v[0-9]\..*/
+            branches:
+              ignore: /.*/
+      - deploy:
+          requires:
+            - build

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+# Copyright 2018-2019 the Tectonic Project
+# Licensed under the MIT License
+
+# Work-in-progress as I figure out how CircleCI wires things up!
+
+echo "work dir: $CIRCLE_WORKING_DIRECTORY"
+
+ls -l $CIRCLE_WORKING_DIRECTORY
+
+echo =========================
+
+ls -l $CIRCLE_WORKING_DIRECTORY/*
+
+echo =========================
+
+ls -l $CIRCLE_WORKING_DIRECTORY/*/*


### PR DESCRIPTION
It would be good if the Circle CI tests could upload build artifacts like the ones in Travis are now doing. This is a set of exploratory changes to try to enable that.