### PR TITLE
Set min_crossrefs to default to 2, not 0.

### DIFF
--- a/tectonic/bibtex.c
+++ b/tectonic/bibtex.c
@@ -145,6 +145,7 @@ static jmp_buf error_jmpbuf, recover_jmpbuf;
 #define aux_stack_size 20
 #define MAX_BIB_FILES 20
 #define POOL_SIZE 65000L
+#define MIN_CROSSREFS 2
 #define MAX_STRINGS 35307
 #define MAX_CITES 750
 #define WIZ_FN_SPACE 3000
@@ -7301,6 +7302,7 @@ bibtex_main(const char *aux_file_name)
     max_glob_strs = MAX_GLOB_STRS;
     max_fields = MAX_FIELDS;
     max_cites = MAX_CITES;
+    min_crossrefs = MIN_CROSSREFS;
     wiz_fn_space = WIZ_FN_SPACE;
     lit_stk_size = LIT_STK_SIZE;
 


### PR DESCRIPTION
In the original bibtex.web, the default value for min_crossrefs is 2, not 0. Thia matches that behaviour.

The bibtex distributed with texlive also defaults to min_crossrefs = 2 (and it also makes it configurable at run-time, with a CLI arg, which this patch doesn't do).