### PR TITLE
Improve log formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,11 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byte-unit"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1332,7 @@ name = "tectonic"
 version = "0.1.13-dev"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1801,6 +1807,7 @@ dependencies = [
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+"checksum byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ vcpkg = "0.2.8"
 
 [dependencies]
 app_dirs = "^1.1"
+byte-unit = "^3.0"
 cfg-if = "0.1"
 structopt = "0.3"
 error-chain = "^0.12"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -11,6 +11,7 @@
 //! For an example of how to use this module, see `src/bin/tectonic.rs`, which contains tectonic's main
 //! CLI program.
 
+use byte_unit::Byte;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
@@ -871,15 +872,20 @@ impl ProcessingSession {
             }
 
             if contents.is_empty() {
-                status.note_highlighted("Not writing ", &sname, ": it would be empty.");
+                status.note_highlighted(
+                    "Not writing ",
+                    &format!("`{}`", sname),
+                    ": it would be empty.",
+                );
                 continue;
             }
 
             let real_path = root.join(name);
+            let byte_len = Byte::from_bytes(contents.len() as u128);
             status.note_highlighted(
                 "Writing ",
-                &real_path.to_string_lossy(),
-                &format!(" ({} bytes)", contents.len()),
+                &format!("`{}`", real_path.to_string_lossy()),
+                &format!(" ({})", byte_len.get_appropriate_unit(true).to_string()),
             );
 
             let mut f = File::create(&real_path)?;


### PR DESCRIPTION
Hi!
This pr addresses issue #539 

- Paths and filenames are now quoted in backticks
- File sizes are now expressed in appropriate units (KiB/MiB)

| Before | After |
| --- | --- |
| Writing **file name.pdf** (47203 bytes) | Writing **\`file name.pdf\`** (46.10 KiB) |

When the output has size 0, the "Not writing **\`file name\`**: it would be empty" message also gets backticks.

This adds a new dependency (byte-unit) for expressing file sizes.