### PR TITLE
Add a license to cfg support without the note about third party licenses.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cc = "^1.0.50"
 pkg-config = "^0.3"
 regex = "^1.3"
 sha2 = "^0.8"
-tectonic_cfg_support = { path = "cfg_support", version = "0.0.2-dev" }
+tectonic_cfg_support = { path = "cfg_support", version = "0.0.3-dev" }
 vcpkg = "0.2.8"
 
 [dependencies]

--- a/cfg_support/Cargo.toml
+++ b/cfg_support/Cargo.toml
@@ -3,10 +3,10 @@
 
 [package]
 name = "tectonic_cfg_support"
-version = "0.0.2-dev"
+version = "0.0.3-dev"
 authors = [
     "Matt Rice <ratmice@gmail.com>",
-    "Peter Williams <peter@newton.cx"
+    "Peter Williams <peter@newton.cx>"
 ]
 description = """
 A build.rs support crate that helps deal with CARGO_CFG_TARGET_* variables.

--- a/cfg_support/LICENSE
+++ b/cfg_support/LICENSE
@@ -1,0 +1,19 @@
+Tectonic cfg_support is licensed under the MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This for issue #565, assuming that you agreeable to that of course.