### PR TITLE
Specify target directory implied by the `package` function

### DIFF
--- a/dist/arch/PKGBUILD
+++ b/dist/arch/PKGBUILD
@@ -24,12 +24,12 @@ sha512sums=('837f38346d6b2c07d960d087f7eda1a0ca57735e18a71f956010c59bf9a45628ce4
 
 build() {
 	cd $pkgname-$pkgver
-	cargo build --release
+	cargo build --release --target-dir "./target"
 }
 
 check() {
 	cd $pkgname-$pkgver
-	cargo test --release
+	cargo test --release --target-dir "./target"
 }
 
 package() {


### PR DESCRIPTION
By default, cargo places build artifacts in a `target` directory in the root of the current workspace. This behaviour can be overridden through various means like ENV variables: https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir

If that is the case, installation of the package will fail because the tectonic binary will not be in the path assumed by the `package` function.

We fix this by specifying the path of the `target` directory directly for the `build` and `check` functions.