### PR TITLE
Prevent segfault on latex compilation error

### DIFF
--- a/tectonic/xetex-errors.c
+++ b/tectonic/xetex-errors.c
@@ -45,6 +45,7 @@ post_error_message(int need_to_print_it)
 
     history = HISTORY_FATAL_ERROR;
     close_files_and_terminate();
+    tt_cleanup();
     ttstub_output_flush(rust_stdout);
 }
 
@@ -102,6 +103,7 @@ fatal_error(const char* s)
     print_cstr("Emergency stop");
     print_nl_cstr(s);
     close_files_and_terminate();
+    tt_cleanup();
     ttstub_output_flush(rust_stdout);
     _tt_abort("%s", s);
 }

--- a/tectonic/xetex-ini.c
+++ b/tectonic/xetex-ini.c
@@ -3900,6 +3900,89 @@ get_strings_started(void)
 }
 /*:1001*/
 
+void
+tt_cleanup(void) {
+    /*
+        Cleanup of all intermediate buffers.
+        Conceptually, final_cleanup() and close_files_and_terminate() also 
+        belong here, but that requires a more thorough refactor as presently
+        it would result in a segfault.
+    */
+
+    pdf_files_close();
+    free(TEX_format_default);
+    free(font_used);
+    deinitialize_shipout_variables();
+
+    destroy_font_manager();
+
+    for (int font_k = 0; font_k < font_max; font_k++) {
+        if (font_layout_engine[font_k] != NULL) {
+            release_font_engine(font_layout_engine[font_k], font_area[font_k]);
+            font_layout_engine[font_k] = NULL;
+        }
+    }
+
+    // Free the big allocated arrays
+    free(buffer);
+    free(nest);
+    free(save_stack);
+    free(input_stack);
+    free(input_file);
+    free(line_stack);
+    free(eof_seen);
+    free(grp_stack);
+    free(if_stack);
+    free(source_filename_stack);
+    free(full_source_filename_stack);
+    free(param_stack);
+    free(hyph_word);
+    free(hyph_list);
+    free(hyph_link);
+
+    // initialize_more_variables @ 3277
+    free(native_text);
+
+    // Free arrays allocated in load_fmt_file
+    free(yhash);
+    free(eqtb);
+    free(mem);
+    free(str_start);
+    free(str_pool);
+    free(font_info);
+
+    free(font_mapping);
+    free(font_layout_engine);
+    free(font_flags);
+    free(font_letter_space);
+    free(font_check);
+    free(font_size);
+    free(font_dsize);
+    free(font_params);
+    free(font_name);
+    free(font_area);
+    free(font_bc);
+    free(font_ec);
+    free(font_glue);
+    free(hyphen_char);
+    free(skew_char);
+    free(bchar_label);
+    free(font_bchar);
+    free(font_false_bchar);
+    free(char_base);
+    free(width_base);
+    free(height_base);
+    free(depth_base);
+    free(italic_base);
+    free(lig_kern_base);
+    free(kern_base);
+    free(exten_base);
+    free(param_base);
+
+    trie_trl = mfree(trie_trl);
+    trie_tro = mfree(trie_tro);
+    trie_trc = mfree(trie_trc);
+}
 
 tt_history_t
 tt_run_engine(char *dump_name, char *input_file_name, time_t build_date)
@@ -4369,78 +4452,8 @@ tt_run_engine(char *dump_name, char *input_file_name, time_t build_date)
     main_control();
     final_cleanup();
     close_files_and_terminate();
-    pdf_files_close();
-    free(TEX_format_default);
-    free(font_used);
-    deinitialize_shipout_variables();
 
-    destroy_font_manager();
+    tt_cleanup();
 
-    for (font_k = 0; font_k < font_max; font_k++) {
-        if (font_layout_engine[font_k] != NULL) {
-            release_font_engine(font_layout_engine[font_k], font_area[font_k]);
-            font_layout_engine[font_k] = NULL;
-        }
-    }
-
-    // Free the big allocated arrays
-    free(buffer);
-    free(nest);
-    free(save_stack);
-    free(input_stack);
-    free(input_file);
-    free(line_stack);
-    free(eof_seen);
-    free(grp_stack);
-    free(if_stack);
-    free(source_filename_stack);
-    free(full_source_filename_stack);
-    free(param_stack);
-    free(hyph_word);
-    free(hyph_list);
-    free(hyph_link);
-
-    // initialize_more_variables @ 3277
-    free(native_text);
-
-    // Free arrays allocated in load_fmt_file
-    free(yhash);
-    free(eqtb);
-    free(mem);
-    free(str_start);
-    free(str_pool);
-    free(font_info);
-
-    free(font_mapping);
-    free(font_layout_engine);
-    free(font_flags);
-    free(font_letter_space);
-    free(font_check);
-    free(font_size);
-    free(font_dsize);
-    free(font_params);
-    free(font_name);
-    free(font_area);
-    free(font_bc);
-    free(font_ec);
-    free(font_glue);
-    free(hyphen_char);
-    free(skew_char);
-    free(bchar_label);
-    free(font_bchar);
-    free(font_false_bchar);
-    free(char_base);
-    free(width_base);
-    free(height_base);
-    free(depth_base);
-    free(italic_base);
-    free(lig_kern_base);
-    free(kern_base);
-    free(exten_base);
-    free(param_base);
-
-    trie_trl = mfree(trie_trl);
-    trie_tro = mfree(trie_tro);
-    trie_trc = mfree(trie_trc);
     return history;
 }

--- a/tectonic/xetex-xetexd.h
+++ b/tectonic/xetex-xetexd.h
@@ -1095,6 +1095,7 @@ cur_length(void) {
 
 
 /* Tectonic related functions */
+void tt_cleanup(void);
 tt_history_t tt_run_engine(char *dump_name, char *input_file_name, time_t build_date);
 
 


### PR DESCRIPTION
This is a followup of sorts to #574, and it turns out the async environment was totally unnecessary. In fact, this snippet is all that is necessary to trigger the segfault (the DejaVu Sans font needs to be installed):
```rust
use tectonic::latex_to_pdf;

fn main(){
        for _ in 0..2 {
            latex_to_pdf(r"\documentclass{article}
\usepackage{fontspec}
\setmainfont{DejaVu Sans}

\begin{document}
\invalidcommand{}
\end{document}");
        }
}
```

This is a legacy issue, of sorts. Since XeTeX is meant to be used as an executable binary, it does not clean up its intermediate compilation data in case of a fatal failure: no further compilations will be tried and the OS will clear up the process' memory. However, tectonic uses the XeTeX as a library, and some variables get abandoned/leaked or its memory locations become invalid in case of a compilation failure. This resulted in segfaults on the font handling code when accessing structures that had been partially invalidated, and in memory leaks when compilation failed but no invalid memory accesses were made.

This tiny refactor tries to force the cleanup code on failures, preventing segfaults and memory leaks.