### PR TITLE
[WIP] Capture warnings into diagnostic objects

### DIFF
--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -110,6 +110,24 @@ bibtex_simple_main(tt_bridge_api_t *api, char *aux_file_name)
 
 #define TGB tectonic_global_bridge
 
+tt_warn_t
+ttstub_warn_begin(void)
+{
+    return TGB->warn_begin();
+}
+
+void
+ttstub_warn_finish(tt_warn_t warning)
+{
+    TGB->warn_finish(TGB->context, warning);
+}
+
+void
+ttstub_warn_append(tt_warn_t warning, char const *text)
+{
+    TGB->warn_append(warning, text);
+}
+
 PRINTF_FUNC(1,2) void
 ttstub_issue_warning(const char *format, ...)
 {

--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -110,22 +110,22 @@ bibtex_simple_main(tt_bridge_api_t *api, char *aux_file_name)
 
 #define TGB tectonic_global_bridge
 
-tt_warn_t
+diagnostic_t
 ttstub_warn_begin(void)
 {
     return TGB->warn_begin();
 }
 
 void
-ttstub_warn_finish(tt_warn_t warning)
+ttstub_diag_finish(diagnostic_t warning)
 {
-    TGB->warn_finish(TGB->context, warning);
+    TGB->diag_finish(TGB->context, warning);
 }
 
 void
-ttstub_warn_append(tt_warn_t warning, char const *text)
+ttstub_diag_append(diagnostic_t warning, char const *text)
 {
-    TGB->warn_append(warning, text);
+    TGB->diag_append(warning, text);
 }
 
 PRINTF_FUNC(1,2) void

--- a/tectonic/core-bridge.c
+++ b/tectonic/core-bridge.c
@@ -116,6 +116,12 @@ ttstub_warn_begin(void)
     return TGB->warn_begin();
 }
 
+diagnostic_t
+ttstub_error_begin(void)
+{
+    return TGB->error_begin();
+}
+
 void
 ttstub_diag_finish(diagnostic_t warning)
 {

--- a/tectonic/core-bridge.h
+++ b/tectonic/core-bridge.h
@@ -50,16 +50,16 @@ typedef enum
 
 typedef void *rust_output_handle_t;
 typedef void *rust_input_handle_t;
-typedef void *tt_warn_t;
+typedef void *diagnostic_t;
 
 /* Bridge API. Keep synchronized with src/engines/mod.rs. */
 
 typedef struct tt_bridge_api_t {
     void *context;
 
-    tt_warn_t (*warn_begin)(void);
-    void (*warn_finish)(void *context, tt_warn_t warning);
-    void (*warn_append)(tt_warn_t warning, char const *text);
+    diagnostic_t (*warn_begin)(void);
+    void (*diag_finish)(void *context, diagnostic_t warning);
+    void (*diag_append)(diagnostic_t warning, char const *text);
 
     void (*issue_warning)(void *context, char const *text);
     void (*issue_error)(void *context, char const *text);
@@ -103,9 +103,9 @@ NORETURN PRINTF_FUNC(1,2) int _tt_abort(const char *format, ...);
  * will one day eliminate all of the global state and get rid of all of
  * these. */
 
-tt_warn_t ttstub_warn_begin(void);
-void ttstub_warn_finish(tt_warn_t warning);
-void ttstub_warn_append(tt_warn_t warning, char const *text);
+diagnostic_t ttstub_warn_begin(void);
+void ttstub_diag_finish(diagnostic_t warning);
+void ttstub_diag_append(diagnostic_t warning, char const *text);
 
 PRINTF_FUNC(1,2) void ttstub_issue_warning(const char *format, ...);
 PRINTF_FUNC(1,2) void ttstub_issue_error(const char *format, ...);

--- a/tectonic/core-bridge.h
+++ b/tectonic/core-bridge.h
@@ -58,6 +58,7 @@ typedef struct tt_bridge_api_t {
     void *context;
 
     diagnostic_t (*warn_begin)(void);
+    diagnostic_t (*error_begin)(void);
     void (*diag_finish)(void *context, diagnostic_t warning);
     void (*diag_append)(diagnostic_t warning, char const *text);
 
@@ -104,6 +105,7 @@ NORETURN PRINTF_FUNC(1,2) int _tt_abort(const char *format, ...);
  * these. */
 
 diagnostic_t ttstub_warn_begin(void);
+diagnostic_t ttstub_error_begin(void);
 void ttstub_diag_finish(diagnostic_t warning);
 void ttstub_diag_append(diagnostic_t warning, char const *text);
 

--- a/tectonic/core-bridge.h
+++ b/tectonic/core-bridge.h
@@ -50,12 +50,16 @@ typedef enum
 
 typedef void *rust_output_handle_t;
 typedef void *rust_input_handle_t;
-
+typedef void *tt_warn_t;
 
 /* Bridge API. Keep synchronized with src/engines/mod.rs. */
 
 typedef struct tt_bridge_api_t {
     void *context;
+
+    tt_warn_t (*warn_begin)(void);
+    void (*warn_finish)(void *context, tt_warn_t warning);
+    void (*warn_append)(tt_warn_t warning, char const *text);
 
     void (*issue_warning)(void *context, char const *text);
     void (*issue_error)(void *context, char const *text);
@@ -98,6 +102,10 @@ NORETURN PRINTF_FUNC(1,2) int _tt_abort(const char *format, ...);
 /* Global symbols that route through the global API variable. Hopefully we
  * will one day eliminate all of the global state and get rid of all of
  * these. */
+
+tt_warn_t ttstub_warn_begin(void);
+void ttstub_warn_finish(tt_warn_t warning);
+void ttstub_warn_append(tt_warn_t warning, char const *text);
 
 PRINTF_FUNC(1,2) void ttstub_issue_warning(const char *format, ...);
 PRINTF_FUNC(1,2) void ttstub_issue_error(const char *format, ...);

--- a/tectonic/xetex-io.c
+++ b/tectonic/xetex-io.c
@@ -166,9 +166,9 @@ buffer_overflow(void)
 static void
 conversion_error(int errcode)
 {
-    tt_warn_t warning;
+    diagnostic_t warning;
     warning = ttstub_warn_begin();
-    capture_to_warning(warning);
+    capture_to_diagnostic(warning);
 
     begin_diagnostic();
     print_nl('U');
@@ -177,8 +177,8 @@ conversion_error(int errcode)
     print_c_string(") discarding any remaining text");
     end_diagnostic(1);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 }
 
 

--- a/tectonic/xetex-io.c
+++ b/tectonic/xetex-io.c
@@ -166,12 +166,19 @@ buffer_overflow(void)
 static void
 conversion_error(int errcode)
 {
+    tt_warn_t warning;
+    warning = ttstub_warn_begin();
+    capture_to_warning(warning);
+
     begin_diagnostic();
     print_nl('U');
     print_c_string("nicode conversion failed (ICU error code = ");
     print_int(errcode);
     print_c_string(") discarding any remaining text");
     end_diagnostic(1);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
 }
 
 

--- a/tectonic/xetex-output.c
+++ b/tectonic/xetex-output.c
@@ -8,24 +8,24 @@
 #include "xetex-synctex.h"
 #include "core-bridge.h"
 
-static tt_warn_t current_warning = 0;
+static diagnostic_t current_diagnostic = 0;
 
 void
-capture_to_warning(tt_warn_t warning)
+capture_to_diagnostic(diagnostic_t diagnostic)
 {
-    if (current_warning && warning) {
+    if (current_diagnostic && diagnostic) {
         /* Should this be an error? */
         ttstub_issue_warning("multiple warnings attempting to capture output");
     }
-    current_warning = warning;
+    current_diagnostic = diagnostic;
 }
 
 static void
 warn_char(int c)
 {
-    if (current_warning) {
+    if (current_diagnostic) {
         char bytes[2] = { c, 0 };
-        ttstub_warn_append(current_warning, bytes);
+        ttstub_diag_append(current_diagnostic, bytes);
     }
 }
 

--- a/tectonic/xetex-output.c
+++ b/tectonic/xetex-output.c
@@ -8,22 +8,45 @@
 #include "xetex-synctex.h"
 #include "core-bridge.h"
 
+static tt_warn_t current_warning = 0;
+
+void
+capture_to_warning(tt_warn_t warning)
+{
+    if (current_warning && warning) {
+        /* Should this be an error? */
+        ttstub_issue_warning("multiple warnings attempting to capture output");
+    }
+    current_warning = warning;
+}
+
+static void
+warn_char(int c)
+{
+    if (current_warning) {
+        char bytes[2] = { c, 0 };
+        ttstub_warn_append(current_warning, bytes);
+    }
+}
 
 void
 print_ln(void)
 {
     switch (selector) {
     case SELECTOR_TERM_AND_LOG:
+        warn_char('\n');
         ttstub_output_putc(rust_stdout, '\n');
         ttstub_output_putc(log_file, '\n');
         term_offset = 0;
         file_offset = 0;
         break;
     case SELECTOR_LOG_ONLY:
+        warn_char('\n');
         ttstub_output_putc(log_file, '\n');
         file_offset = 0;
         break;
     case SELECTOR_TERM_ONLY:
+        warn_char('\n');
         ttstub_output_putc(rust_stdout, '\n');
         term_offset = 0;
         break;
@@ -43,6 +66,7 @@ print_raw_char(UTF16_code s, bool incr_offset)
 {
     switch (selector) {
     case SELECTOR_TERM_AND_LOG:
+        warn_char(s);
         ttstub_output_putc(rust_stdout, s);
         ttstub_output_putc(log_file, s);
         if (incr_offset) {
@@ -59,6 +83,7 @@ print_raw_char(UTF16_code s, bool incr_offset)
         }
         break;
     case SELECTOR_LOG_ONLY:
+        warn_char(s);
         ttstub_output_putc(log_file, s);
         if (incr_offset)
             file_offset++;
@@ -66,6 +91,7 @@ print_raw_char(UTF16_code s, bool incr_offset)
             print_ln();
         break;
     case SELECTOR_TERM_ONLY:
+        warn_char(s);
         ttstub_output_putc(rust_stdout, s);
         if (incr_offset)
             term_offset++;

--- a/tectonic/xetex-xetex0.c
+++ b/tectonic/xetex-xetex0.c
@@ -10964,9 +10964,9 @@ new_native_character(internal_font_number f, UnicodeScalar c)
 
 void font_feature_warning(const void *featureNameP, int32_t featLen, const void *settingNameP, int32_t setLen)
 {
-    tt_warn_t warning;
+    diagnostic_t warning;
     warning = ttstub_warn_begin();
-    capture_to_warning(warning);
+    capture_to_diagnostic(warning);
 
     begin_diagnostic();
     print_nl_cstr("Unknown ");
@@ -10983,15 +10983,15 @@ void font_feature_warning(const void *featureNameP, int32_t featLen, const void 
     print_cstr("'.");
     end_diagnostic(false);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 }
 
 void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int32_t warningType)
 {
-    tt_warn_t warning;
+    diagnostic_t warning;
     warning = ttstub_warn_begin();
-    capture_to_warning(warning);
+    capture_to_diagnostic(warning);
 
     begin_diagnostic();
     if (warningType == 0)
@@ -11020,15 +11020,15 @@ void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int3
     }
     end_diagnostic(false);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 }
 
 void graphite_warning(void)
 {
-    tt_warn_t warning;
+    diagnostic_t warning;
     warning = ttstub_warn_begin();
-    capture_to_warning(warning);
+    capture_to_diagnostic(warning);
 
     begin_diagnostic();
     print_nl_cstr("Font `");
@@ -11039,8 +11039,8 @@ void graphite_warning(void)
     print_cstr("' does not support Graphite. Trying OpenType layout instead.");
     end_diagnostic(false);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 }
 
 
@@ -11241,9 +11241,9 @@ void do_locale_linebreaks(int32_t s, int32_t len)
 
 void bad_utf8_warning(void)
 {
-    tt_warn_t warning;
+    diagnostic_t warning;
     warning = ttstub_warn_begin();
-    capture_to_warning(warning);
+    capture_to_diagnostic(warning);
 
     begin_diagnostic();
     print_nl_cstr("Invalid UTF-8 byte or sequence");
@@ -11858,7 +11858,7 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
     b16x4 i;
     int32_t pp, ppp = TEX_NULL;
     int32_t total_chars, k;
-    tt_warn_t warning;
+    diagnostic_t warning;
 
     warning = 0;
     last_badness = 0;
@@ -12156,7 +12156,7 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                 if (last_badness > INTPAR(hbadness)) {
                     print_ln();
                     warning = ttstub_warn_begin();
-                    capture_to_warning(warning);
+                    capture_to_diagnostic(warning);
                     if (last_badness > 100)
                         print_nl_cstr("Underfull");
                     else
@@ -12200,7 +12200,7 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                 }
                 print_ln();
                 warning = ttstub_warn_begin();
-                capture_to_warning(warning);
+                capture_to_diagnostic(warning);
                 print_nl_cstr("Overfull \\hbox (");
                 print_scaled(-(int32_t) x - total_shrink[NORMAL]);
                 print_cstr("pt too wide");
@@ -12213,7 +12213,7 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                 if (last_badness > INTPAR(hbadness)) {
                     print_ln();
                     warning = ttstub_warn_begin();
-                    capture_to_warning(warning);
+                    capture_to_diagnostic(warning);
                     print_nl_cstr("Tight \\hbox (badness ");
                     print_int(last_badness);
                     goto common_ending;
@@ -12247,8 +12247,8 @@ common_ending:
     show_box(r);
     end_diagnostic(true);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 
 exit:
     if (INTPAR(texxet) > 0) {
@@ -12275,7 +12275,7 @@ exit:
             {
                 print_ln();
                 warning = ttstub_warn_begin();
-                capture_to_warning(warning);
+                capture_to_diagnostic(warning);
                 print_nl_cstr("\\endL or \\endR problem (");
                 print_int(LR_problems / 10000);
                 print_cstr(" missing, ");
@@ -12306,7 +12306,7 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
     scaled_t s;
     int32_t g;
     glue_ord o;
-    tt_warn_t warning;
+    diagnostic_t warning;
 
     warning = 0;
     last_badness = 0;
@@ -12429,7 +12429,7 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
                     print_ln();
 
                     warning = ttstub_warn_begin();
-                    capture_to_warning(warning);
+                    capture_to_diagnostic(warning);
 
                     if (last_badness > 100)
                         print_nl_cstr("Underfull");
@@ -12468,7 +12468,7 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
                 print_ln();
 
                 warning = ttstub_warn_begin();
-                capture_to_warning(warning);
+                capture_to_diagnostic(warning);
 
                 print_nl_cstr("Overfull \\vbox (");
                 print_scaled(-(int32_t) x - total_shrink[NORMAL]);
@@ -12483,7 +12483,7 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
                     print_ln();
 
                     warning = ttstub_warn_begin();
-                    capture_to_warning(warning);
+                    capture_to_diagnostic(warning);
 
                     print_nl_cstr("Tight \\vbox (badness ");
                     print_int(last_badness);
@@ -12512,8 +12512,8 @@ common_ending:
     show_box(r);
     end_diagnostic(true);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
 
 exit:
     return r;
@@ -16094,7 +16094,7 @@ void show_whatever(void)
     unsigned char /*or_code */ m;
     int32_t l;
     int32_t n;
-    tt_warn_t warning;
+    diagnostic_t warning;
 
     warning = 0;
 
@@ -16102,7 +16102,7 @@ void show_whatever(void)
     case 3:
         {
             warning = ttstub_warn_begin();
-            capture_to_warning(warning);
+            capture_to_diagnostic(warning);
 
             begin_diagnostic();
             show_activities();
@@ -16122,7 +16122,7 @@ void show_whatever(void)
                     p = mem[cur_ptr + 1].b32.s1;
             }
             warning = ttstub_warn_begin();
-            capture_to_warning(warning);
+            capture_to_diagnostic(warning);
 
             begin_diagnostic();
             print_nl_cstr("> \\box");
@@ -16149,7 +16149,7 @@ void show_whatever(void)
     case 4:
         {
             warning = ttstub_warn_begin();
-            capture_to_warning(warning);
+            capture_to_diagnostic(warning);
 
             begin_diagnostic();
             show_save_groups();
@@ -16158,7 +16158,7 @@ void show_whatever(void)
     case 6:
         {
             warning = ttstub_warn_begin();
-            capture_to_warning(warning);
+            capture_to_diagnostic(warning);
 
             begin_diagnostic();
             print_nl_cstr("");
@@ -16210,8 +16210,8 @@ void show_whatever(void)
     }
     end_diagnostic(true);
 
-    capture_to_warning(0);
-    ttstub_warn_finish(warning);
+    capture_to_diagnostic(0);
+    ttstub_diag_finish(warning);
     /* Should this subsequent block be included in the warning? */
 
     {

--- a/tectonic/xetex-xetex0.c
+++ b/tectonic/xetex-xetex0.c
@@ -10964,6 +10964,10 @@ new_native_character(internal_font_number f, UnicodeScalar c)
 
 void font_feature_warning(const void *featureNameP, int32_t featLen, const void *settingNameP, int32_t setLen)
 {
+    tt_warn_t warning;
+    warning = ttstub_warn_begin();
+    capture_to_warning(warning);
+
     begin_diagnostic();
     print_nl_cstr("Unknown ");
     if (setLen > 0) {
@@ -10978,10 +10982,17 @@ void font_feature_warning(const void *featureNameP, int32_t featLen, const void 
         print_raw_char(name_of_file[i], true);
     print_cstr("'.");
     end_diagnostic(false);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
 }
 
 void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int32_t warningType)
 {
+    tt_warn_t warning;
+    warning = ttstub_warn_begin();
+    capture_to_warning(warning);
+
     begin_diagnostic();
     if (warningType == 0)
         print_nl_cstr("Loaded mapping `");
@@ -11008,10 +11019,17 @@ void font_mapping_warning(const void *mappingNameP, int32_t mappingNameLen, int3
         break;
     }
     end_diagnostic(false);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
 }
 
 void graphite_warning(void)
 {
+    tt_warn_t warning;
+    warning = ttstub_warn_begin();
+    capture_to_warning(warning);
+
     begin_diagnostic();
     print_nl_cstr("Font `");
 
@@ -11020,6 +11038,9 @@ void graphite_warning(void)
 
     print_cstr("' does not support Graphite. Trying OpenType layout instead.");
     end_diagnostic(false);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
 }
 
 
@@ -11220,6 +11241,10 @@ void do_locale_linebreaks(int32_t s, int32_t len)
 
 void bad_utf8_warning(void)
 {
+    tt_warn_t warning;
+    warning = ttstub_warn_begin();
+    capture_to_warning(warning);
+
     begin_diagnostic();
     print_nl_cstr("Invalid UTF-8 byte or sequence");
     if (cur_input.name == 0)
@@ -12281,7 +12306,9 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
     scaled_t s;
     int32_t g;
     glue_ord o;
+    tt_warn_t warning;
 
+    warning = 0;
     last_badness = 0;
     r = get_node(BOX_NODE_SIZE);
     NODE_type(r) = VLIST_NODE;
@@ -12400,6 +12427,10 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
                 last_badness = badness(x, total_stretch[NORMAL]);
                 if (last_badness > INTPAR(vbadness)) {
                     print_ln();
+
+                    warning = ttstub_warn_begin();
+                    capture_to_warning(warning);
+
                     if (last_badness > 100)
                         print_nl_cstr("Underfull");
                     else
@@ -12435,6 +12466,10 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
             if ((-(int32_t) x - total_shrink[NORMAL] > DIMENPAR(vfuzz))
                 || (INTPAR(vbadness) < 100)) {
                 print_ln();
+
+                warning = ttstub_warn_begin();
+                capture_to_warning(warning);
+
                 print_nl_cstr("Overfull \\vbox (");
                 print_scaled(-(int32_t) x - total_shrink[NORMAL]);
                 print_cstr("pt too high");
@@ -12446,6 +12481,10 @@ int32_t vpackage(int32_t p, scaled_t h, small_number m, scaled_t l)
                 last_badness = badness(-(int32_t) x, total_shrink[NORMAL]);
                 if (last_badness > INTPAR(vbadness)) {
                     print_ln();
+
+                    warning = ttstub_warn_begin();
+                    capture_to_warning(warning);
+
                     print_nl_cstr("Tight \\vbox (badness ");
                     print_int(last_badness);
                     goto common_ending;
@@ -12472,6 +12511,9 @@ common_ending:
     begin_diagnostic();
     show_box(r);
     end_diagnostic(true);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
 
 exit:
     return r;
@@ -16052,10 +16094,16 @@ void show_whatever(void)
     unsigned char /*or_code */ m;
     int32_t l;
     int32_t n;
+    tt_warn_t warning;
+
+    warning = 0;
 
     switch (cur_chr) {
     case 3:
         {
+            warning = ttstub_warn_begin();
+            capture_to_warning(warning);
+
             begin_diagnostic();
             show_activities();
         }
@@ -16073,6 +16121,9 @@ void show_whatever(void)
                 else
                     p = mem[cur_ptr + 1].b32.s1;
             }
+            warning = ttstub_warn_begin();
+            capture_to_warning(warning);
+
             begin_diagnostic();
             print_nl_cstr("> \\box");
             print_int(cur_val);
@@ -16097,12 +16148,18 @@ void show_whatever(void)
         break;
     case 4:
         {
+            warning = ttstub_warn_begin();
+            capture_to_warning(warning);
+
             begin_diagnostic();
             show_save_groups();
         }
         break;
     case 6:
         {
+            warning = ttstub_warn_begin();
+            capture_to_warning(warning);
+
             begin_diagnostic();
             print_nl_cstr("");
             print_ln();
@@ -16152,6 +16209,11 @@ void show_whatever(void)
         break;
     }
     end_diagnostic(true);
+
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
+    /* Should this subsequent block be included in the warning? */
+
     {
         if (file_line_error_style_p)
             print_file_line();

--- a/tectonic/xetex-xetex0.c
+++ b/tectonic/xetex-xetex0.c
@@ -11833,7 +11833,9 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
     b16x4 i;
     int32_t pp, ppp = TEX_NULL;
     int32_t total_chars, k;
+    tt_warn_t warning;
 
+    warning = 0;
     last_badness = 0;
     r = get_node(BOX_NODE_SIZE);
     NODE_type(r) = HLIST_NODE;
@@ -12128,6 +12130,8 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                 last_badness = badness(x, total_stretch[NORMAL]);
                 if (last_badness > INTPAR(hbadness)) {
                     print_ln();
+                    warning = ttstub_warn_begin();
+                    capture_to_warning(warning);
                     if (last_badness > 100)
                         print_nl_cstr("Underfull");
                     else
@@ -12170,6 +12174,8 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                     mem[mem[q].b32.s1 + 1].b32.s1 = DIMENPAR(overfull_rule);
                 }
                 print_ln();
+                warning = ttstub_warn_begin();
+                capture_to_warning(warning);
                 print_nl_cstr("Overfull \\hbox (");
                 print_scaled(-(int32_t) x - total_shrink[NORMAL]);
                 print_cstr("pt too wide");
@@ -12181,6 +12187,8 @@ int32_t hpack(int32_t p, scaled_t w, small_number m)
                 last_badness = badness(-(int32_t) x, total_shrink[NORMAL]);
                 if (last_badness > INTPAR(hbadness)) {
                     print_ln();
+                    warning = ttstub_warn_begin();
+                    capture_to_warning(warning);
                     print_nl_cstr("Tight \\hbox (badness ");
                     print_int(last_badness);
                     goto common_ending;
@@ -12214,6 +12222,9 @@ common_ending:
     show_box(r);
     end_diagnostic(true);
 
+    capture_to_warning(0);
+    ttstub_warn_finish(warning);
+
 exit:
     if (INTPAR(texxet) > 0) {
         /*1499: */
@@ -12238,6 +12249,8 @@ exit:
         if (LR_problems > 0) {
             {
                 print_ln();
+                warning = ttstub_warn_begin();
+                capture_to_warning(warning);
                 print_nl_cstr("\\endL or \\endR problem (");
                 print_int(LR_problems / 10000);
                 print_cstr(" missing, ");

--- a/tectonic/xetex-xetexd.h
+++ b/tectonic/xetex-xetexd.h
@@ -1023,6 +1023,7 @@ void flush_math(void);
 
 /* xetex-output */
 
+void capture_to_warning(tt_warn_t warning);
 void print_ln(void);
 void print_raw_char(UTF16_code s, bool incr_offset);
 void print_char(int32_t s);

--- a/tectonic/xetex-xetexd.h
+++ b/tectonic/xetex-xetexd.h
@@ -1023,7 +1023,7 @@ void flush_math(void);
 
 /* xetex-output */
 
-void capture_to_warning(tt_warn_t warning);
+void capture_to_diagnostic(diagnostic_t warning);
 void print_ln(void);
 void print_raw_char(UTF16_code s, bool incr_offset);
 void print_char(int32_t s);


### PR DESCRIPTION
This is meant to resolve #577. The general design of this is have each warning/error be reported via a `Diagnostic` object (`diagnostic_t` on the C side) -- doing this will allow extra information to be added later (e.g. location of error). I've also added a sort of hack in `xetex-output.c` to be able to capture print messages into a diagnostic. The main thing left now is to wrap all the places where warnings/errors are emitted with

```c
diagnostic_t warning = ttstub_warn_begin(); // or ttstub_error_begin()
capture_to_diagnostic(warning);
```
and 
```c
capture_to_diagnostic(0);
ttstub_diag_finish(warning);
```