### PR TITLE
tests: attempt to gather code coverage info in the executable tests

### DIFF
--- a/dist/azure-coverage.yml
+++ b/dist/azure-coverage.yml
@@ -28,17 +28,16 @@ steps:
     cargo install --force cargo-kcov
   displayName: Set up code coverage
 
+# As of Rust 1.44, test executables land in target/debug/deps/ instead of
+# target/debug/, which messes up current cargo-kcov (0.5.2) because it tries to
+# search for those executables. Work around with `cp`. One of the `tectonic-*`
+# binaries is the debug executable, which is hard-linked to
+# `target/debug/tectonic`. kcov will erroneously try to run this as a test if we
+# copy it, so we have to make not to do that, which we accomplish with a search
+# based on the hardlink count. Hacky and fragile but this should get us going.
+# Hopefully kcov will get fixed where this will become unneccessary anyway.
 - bash: |
     set -xeuo pipefail
-    # As of Rust 1.44, test executables land in target/debug/deps/ instead of
-    # target/debug/, which messes up current cargo-kcov (0.5.2) because it tries
-    # to search for those executables. Work around with `cp`. One of the
-    # `tectonic-*` binaries is the debug executable, which is hard-linked to
-    # `target/debug/tectonic`. kcov will erroneously try to run this as a test
-    # if we copy it, so we have to make not to do that, which we accomplish with
-    # a search based on the hardlink count. Hacky and fragile but this should
-    # get us going. Hopefully kcov will get fixed where this will become
-    # unneccessary anyway.
     cargo test --no-run
     find target/debug/deps/tectonic-???????????????? -links 2 -print -delete
     cp -vp target/debug/deps/*-???????????????? target/debug/
@@ -53,6 +52,27 @@ steps:
 
 - bash: cargo kcov --no-clean-rebuild
   displayName: cargo kcov
+
+# Our "executable" test executes the actual Tectonic binary. In order to collect
+# coverage information about what happens in those executions, we have special
+# support in the test harness to wrap the invocations in `kcov` calls.
+- bash: |
+    set -xeuo pipefail
+    export TECTONIC_EXETEST_KCOV_RUNNER="kcov --exclude-pattern=$HOME/.cargo --verify"
+    cargo test --test executable
+  displayName: Special-case executable tests
+
+# Now, merge all of the coverage reports. `cargo kcov` does this automatically,
+# but it uses an explicit list of coverage runs, so there's no way to get it to
+# include our special executable tests. We just glob everything, which means we
+# have to delete the preexisting merged report.
+- bash: |
+    set -xeou pipefail
+    cd target/cov
+    rm -rf amber.png bcov.css data glass.png index.html index.json \
+      kcov-merged merged-kcov-output
+    kcov --merge . *
+  displayName: Merge coverage reports
 
 - bash: |
     set -xeuo pipefail

--- a/dist/azure-coverage.yml
+++ b/dist/azure-coverage.yml
@@ -50,7 +50,10 @@ steps:
     git show HEAD
   displayName: Make release commit
 
-- bash: cargo kcov --no-clean-rebuild
+- bash: |
+    set -xeuo pipefail
+    p="$(pwd)"
+    cargo kcov --no-clean-rebuild -- --include-pattern="$p/src,$p/tectonic,$p/xdv"
   displayName: cargo kcov
 
 # Our "executable" test executes the actual Tectonic binary. In order to collect
@@ -58,7 +61,8 @@ steps:
 # support in the test harness to wrap the invocations in `kcov` calls.
 - bash: |
     set -xeuo pipefail
-    export TECTONIC_EXETEST_KCOV_RUNNER="kcov --exclude-pattern=$HOME/.cargo --verify"
+    p="$(pwd)"
+    export TECTONIC_EXETEST_KCOV_RUNNER="kcov --include-pattern=$p/src,$p/tectonic,$p/xdv"
     cargo test --test executable
   displayName: Special-case executable tests
 

--- a/dist/azure-coverage.yml
+++ b/dist/azure-coverage.yml
@@ -69,7 +69,7 @@ steps:
 - bash: |
     set -xeou pipefail
     cd target/cov
-    rm -rf amber.png bcov.css data glass.png index.html index.json \
+    rm -rf amber.png bcov.css data glass.png index.html index.js* \
       kcov-merged merged-kcov-output
     kcov --merge . *
   displayName: Merge coverage reports


### PR DESCRIPTION
It turns out that our tests of the built `tectonic` executable weren't gathering code coverage information about the code paths exercised in those tests. I *think* that it's not so hard to hack in some support to gather that information, so let's give it a try.

CC @ralismark @Mrmaxmeier 

xref: #636 assert-rs/assert_cmd#9