### PR TITLE
tectonic/dpx-cidtype0.c: attempt to fix loop condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tokio = "0.1.22"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "ff1d20fd9a72d72d51a549c27b669cd6040fb7d9"
+rev = "c9027488970352953a59505234775b367d4cfd2a"
 
 [package.metadata.vcpkg.target]
 x86_64-apple-darwin = { install = ["freetype","harfbuzz[icu,graphite2]"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tokio = "0.1.22"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "c9027488970352953a59505234775b367d4cfd2a"
+rev = "76a7e9248fb3c57350b559966dcaa2d52a5e4458"
 
 [package.metadata.vcpkg.target]
 x86_64-apple-darwin = { install = ["freetype","harfbuzz[icu,graphite2]"] }

--- a/tectonic/dpx-cidtype0.c
+++ b/tectonic/dpx-cidtype0.c
@@ -208,7 +208,7 @@ add_CIDVMetrics (sfnt *sfont, pdf_obj *fontdict,
         vertOriginX   = PDFUNIT(hmtx[gid].advance*0.5);
         vertOriginY   = defaultVertOriginY;
         for (i = 0;
-             i < vorg->numVertOriginYMetrics && gid > vorg->vertOriginYMetrics[i].glyphIndex;
+             i < vorg->numVertOriginYMetrics && gid >= vorg->vertOriginYMetrics[i].glyphIndex;
              i++) {
             if (gid == vorg->vertOriginYMetrics[i].glyphIndex)
                 vertOriginY = PDFUNIT(vorg->vertOriginYMetrics[i].vertOriginY);


### PR DESCRIPTION
The `if` statement inside the loop body could never succeed. Presuming that the `vertOriginYMetrics` are a sorted list, it looks like we need a `>=` condition.

Closes #639.