### PR TITLE
also emit cargo metadata after tectonic's own when using vcpkg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -164,8 +164,9 @@ impl DepState {
 
             DepState::VcPkg(_) => {
                 for dep in VCPKG_LIBS {
-                    vcpkg::find_package(dep)
-                        .unwrap_or_else(|e| panic!("failed to load package {} from vcpkg: {}", dep, e));
+                    vcpkg::find_package(dep).unwrap_or_else(|e| {
+                        panic!("failed to load package {} from vcpkg: {}", dep, e)
+                    });
                 }
                 if target.contains("-linux-") {
                     // add icudata to the end of the list of libs as vcpkg-rs

--- a/build.rs
+++ b/build.rs
@@ -73,7 +73,9 @@ impl DepState {
         let mut include_paths = vec![];
 
         for dep in VCPKG_LIBS {
-            let library = vcpkg::find_package(dep)
+            let library = vcpkg::Config::new()
+                .cargo_metadata(false)
+                .find_package(dep)
                 .unwrap_or_else(|e| panic!("failed to load package {} from vcpkg: {}", dep, e));
             include_paths.extend(library.include_paths.iter().cloned());
         }
@@ -161,6 +163,10 @@ impl DepState {
             }
 
             DepState::VcPkg(_) => {
+                for dep in VCPKG_LIBS {
+                    vcpkg::find_package(dep)
+                        .unwrap_or_else(|e| panic!("failed to load package {} from vcpkg: {}", dep, e));
+                }
                 if target.contains("-linux-") {
                     // add icudata to the end of the list of libs as vcpkg-rs
                     // does not order individual libraries as a single pass


### PR DESCRIPTION
This changes building with the vcpkg dep backend to emit the cargo metadata after tectonic's own in the same way that it does when using pkg-config.