### PR TITLE
Don't print an empty "error:" line in the CLI

### DIFF
--- a/src/bin/tectonic.rs
+++ b/src/bin/tectonic.rs
@@ -261,12 +261,12 @@ fn main() {
         "this is a BETA release; ask questions and report bugs at https://tectonic.newton.cx/"
     );
 
-    // Now that we've got colorized output, we're to pass off to the inner
-    // function ... all so that we can print out the word "error:" in red.
-    // This code parallels various bits of the `error_chain` crate.
+    // Now that we've got colorized output, pass off to the inner function ...
+    // all so that we can print out the word "error:" in red. This code
+    // parallels various bits of the `error_chain` crate.
 
     if let Err(ref e) = inner(args, config, &mut *status) {
-        tt_error!(status, ""; e);
+        status.report_error(e);
         process::exit(1)
     }
 }

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -63,7 +63,24 @@ pub enum MessageKind {
 
 pub trait StatusBackend {
     /// Report a message to the status backend.
+    ///
+    /// If `err` is not None, it represents an error that somehow caused the
+    /// current message to be reported. It should be displayed in some
+    /// appropriate fashion.
     fn report(&mut self, kind: MessageKind, args: Arguments, err: Option<&Error>);
+
+    /// Report an error to the status backend.
+    ///
+    /// Unlike the basic `report` function, in this case there is no additional
+    /// contextual information provided. The default implementation delegates to
+    /// `report()` with a generic lead-in message of "an error occurred".
+    fn report_error(&mut self, err: &Error) {
+        self.report(
+            MessageKind::Error,
+            format_args!("an error occurred"),
+            Some(err),
+        )
+    }
 
     /// Issue a note-level status, idealy highlighting a particular phrase.
     ///

--- a/src/status/plain.rs
+++ b/src/status/plain.rs
@@ -41,6 +41,20 @@ impl StatusBackend for PlainStatusBackend {
         }
     }
 
+    fn report_error(&mut self, err: &Error) {
+        let mut prefix = "error";
+
+        for item in err.iter() {
+            eprintln!("{}: {}", prefix, item);
+            prefix = "caused by";
+        }
+
+        if let Some(backtrace) = err.backtrace() {
+            eprintln!("debugging: backtrace follows:");
+            eprintln!("{:?}", backtrace);
+        }
+    }
+
     fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
         if self.chatter > ChatterLevel::Minimal {
             self.report(


### PR DESCRIPTION
This change in behavior was introduced in #636 with the genericization of the status backend. Add a new `report_error` method to recover the old behavior.

Closes #665.