### PR TITLE
Fix Windows/MSVC build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tokio = "0.1.22"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "527c0e04332db88a7906e469dca1d9f0a35726fc"
+rev = "b7056e9f1f34f18b6648b1f1d9c4e9d31f04e91c"
 
 [package.metadata.vcpkg.target]
 x86_64-apple-darwin = { install = ["freetype","harfbuzz[icu,graphite2]"] }

--- a/dist/azure-ci-cd.yml
+++ b/dist/azure-ci-cd.yml
@@ -80,15 +80,12 @@ parameters:
       TARGET: x86_64-apple-darwin
       TOOLCHAIN: stable
 
-  # Temporarily disabled due to vcpkg brokenness that looks like it
-  # will take a little while to resolve. Tracking issue:
-  # https://github.com/tectonic-typesetting/tectonic/issues/668
-  # - name: windows
-  #   vmImage: windows-2019
-  #   params: {}
-  #   vars:
-  #     TARGET: x86_64-pc-windows-msvc
-  #     TOOLCHAIN: stable-x86_64-pc-windows-msvc
+  - name: windows
+    vmImage: windows-2019
+    params: {}
+    vars:
+      TARGET: x86_64-pc-windows-msvc
+      TOOLCHAIN: stable-x86_64-pc-windows-msvc
 
 - name: crossBuilds
   type: object

--- a/tectonic/xetex-texmfmp.c
+++ b/tectonic/xetex-texmfmp.c
@@ -10,7 +10,10 @@
 #include "xetex-ext.h"
 
 #include <time.h> /* For `struct tm'.  Moved here for Visual Studio 2005.  */
+#ifndef _MSC_VER
 #include <sys/time.h>
+#define HAVE_GETTIMEOFDAY
+#endif
 
 static char *last_source_name = NULL;
 static int last_lineno;
@@ -124,10 +127,18 @@ get_date_and_time (time_t source_date_epoch,
 void
 get_seconds_and_micros (int32_t *seconds,  int32_t *micros)
 {
+#ifdef HAVE_GETTIMEOFDAY
   struct timeval tv;
   gettimeofday(&tv, NULL);
   *seconds = tv.tv_sec;
   *micros  = tv.tv_usec;
+#else
+  /* This is what we use on Windows/MSVC. Less than ideal.
+   * We should replace this with a Rust-backed cross-platform API. */
+  time_t myclock = time((time_t *) NULL);
+  *seconds = myclock;
+  *micros  = 0;
+#endif
 }
 
 


### PR DESCRIPTION
Sigh, turning off vcpkg hid a build problem on Windows/MSVC (namely, no `sys/time.h`). It might be a simple fix, but I want to see if I can get something going in the CI to catch potential issues, since it looks like it will be a while before vcpkg is working again.