### PR TITLE
Fix arch linux makedepends

### DIFF
--- a/dist/arch/PKGBUILD.in
+++ b/dist/arch/PKGBUILD.in
@@ -17,7 +17,7 @@ pkgdesc='Modernized, complete, self-contained TeX/LaTeX engine, powered by XeTeX
 url=https://tectonic-typesetting.github.io/
 license=('MIT')
 depends=('fontconfig' 'harfbuzz-icu' 'openssl')
-makedepends=('rust')
+makedepends=('rust' 'gcc' 'pkg-config')
 source=("$pkgname-$pkgver.tar.gz::https://crates.io/api/v1/crates/$pkgname/$pkgver/download")
 sha512sums=('@sha512@')
 


### PR DESCRIPTION
#690 fails without these dependencies.

I set them in Dockerfile manually, but I think this pr is the right way.

`gcc` is required for `proc-macro2`.
`pkg-config` is required for `rust-openssl`.