### PR TITLE
Create a bridge crate for graphite2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "tectonic_bridge_flate",
  "tectonic_bridge_graphite2",
  "tectonic_cfg_support",
+ "tectonic_dep_support",
  "tectonic_xdv",
  "tempfile",
  "termcolor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "sha2",
  "structopt",
  "tectonic_bridge_flate",
+ "tectonic_bridge_graphite2",
  "tectonic_cfg_support",
  "tectonic_xdv",
  "tempfile",
@@ -1764,10 +1765,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tectonic_bridge_graphite2"
+version = "0.0.0-dev.0"
+dependencies = [
+ "tectonic_dep_support",
+]
+
+[[package]]
 name = "tectonic_cfg_support"
 version = "0.0.0-dev.0"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tectonic_dep_support"
+version = "0.0.0-dev.0"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pkg-config = "^0.3"
 regex = "^1.4"
 sha2 = "^0.9"
 tectonic_cfg_support = { path = "crates/cfg_support", version = "0.0.0-dev.0" }
+tectonic_dep_support = { path = "crates/dep_support", version = "0.0.0-dev.0" }
 vcpkg = "0.2.11"
 cbindgen = "0.16.0"
 
@@ -104,5 +105,6 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfi
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
 tectonic_bridge_graphite2 = "f135da463a65e731f05bafdd840edaa90137ec12"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
+tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"
 tectonic_xdv = "c91f2ef37858d1a0a724a5c3ddc2f7ea46373c77"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ codecov = { repository = "tectonic-typesetting/tectonic", service = "github" }
 [workspace]
 members = [
   "crates/bridge_flate",
+  "crates/bridge_graphite2",
+  "crates/cfg_support",
+  "crates/dep_support",
   "crates/xdv",
 ]
 
@@ -63,6 +66,7 @@ reqwest = "^0.9"
 sha2 = "^0.9"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 tectonic_bridge_flate = { path = "crates/bridge_flate", version = "0.0.0-dev.0" }
+tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0-dev.0" }
 tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
 termcolor = "^1.1"
 toml = { version = "^0.5", optional = true }
@@ -98,6 +102,7 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfi
 
 [package.metadata.internal_dep_versions]
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
+tectonic_bridge_graphite2 = "f135da463a65e731f05bafdd840edaa90137ec12"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_xdv = "c91f2ef37858d1a0a724a5c3ddc2f7ea46373c77"
 

--- a/build.rs
+++ b/build.rs
@@ -12,12 +12,11 @@ use std::{
 use tectonic_cfg_support::*;
 
 #[cfg(not(target_os = "macos"))]
-const PKGCONFIG_LIBS: &str =
-    "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng";
+const PKGCONFIG_LIBS: &str = "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng";
 
 // No fontconfig on MacOS:
 #[cfg(target_os = "macos")]
-const PKGCONFIG_LIBS: &str = "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 graphite2 libpng";
+const PKGCONFIG_LIBS: &str = "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng";
 
 /// Build-script state when using pkg-config as the backend.
 #[derive(Debug)]
@@ -27,10 +26,10 @@ struct PkgConfigState {
 
 // Need a way to check that the vcpkg harfbuzz port has graphite2 and icu options enabled.
 #[cfg(not(target_os = "macos"))]
-const VCPKG_LIBS: &[&str] = &["fontconfig", "harfbuzz", "freetype", "graphite2"];
+const VCPKG_LIBS: &[&str] = &["fontconfig", "harfbuzz", "freetype"];
 
 #[cfg(target_os = "macos")]
-const VCPKG_LIBS: &[&str] = &["harfbuzz", "freetype", "graphite2"];
+const VCPKG_LIBS: &[&str] = &["harfbuzz", "freetype"];
 
 /// Build-script state when using vcpkg as the backend.
 #[derive(Clone, Debug)]
@@ -227,6 +226,7 @@ fn main() {
     // Include paths exported by our internal dependencies.
 
     let flate_include_dir = env::var("DEP_TECTONIC_BRIDGE_FLATE_INCLUDE").unwrap();
+    let graphite2_include_dir = env::var("DEP_GRAPHITE2_INCLUDE").unwrap();
 
     // Actually I'm not 100% sure that I can't compile the C and C++ code
     // into one library, but who cares?
@@ -387,6 +387,7 @@ fn main() {
         .file("tectonic/xetex-xetex0.c")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&graphite2_include_dir)
         .include(&flate_include_dir);
 
     let cppflags = [
@@ -437,6 +438,7 @@ fn main() {
         .file("tectonic/xetex-XeTeXOTMath.cpp")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&graphite2_include_dir)
         .include(&flate_include_dir);
 
     dep_state.foreach_include_path(|p| {

--- a/build.rs
+++ b/build.rs
@@ -2,186 +2,38 @@
 // Copyright 2016-2020 the Tectonic Project
 // Licensed under the MIT License.
 
-/// The Tectonic build script. Not only do we have internal C/C++ code, we
-/// also depend on several external C/C++ libraries, so there's a lot to do
-/// here. It would be great to streamline things.
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+//! The Tectonic build script. Not only do we have internal C/C++ code, we
+//! also depend on several external C/C++ libraries, so there's a lot to do
+//! here. It would be great to streamline things.
+
+use std::{env, path::PathBuf};
 use tectonic_cfg_support::*;
+use tectonic_dep_support::{Backend, Configuration, Dependency, Spec};
 
-#[cfg(not(target_os = "macos"))]
-const PKGCONFIG_LIBS: &str = "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng";
+struct TectonicRestSpec;
 
-// No fontconfig on MacOS:
-#[cfg(target_os = "macos")]
-const PKGCONFIG_LIBS: &str = "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng";
-
-/// Build-script state when using pkg-config as the backend.
-#[derive(Debug)]
-struct PkgConfigState {
-    libs: pkg_config::Library,
-}
-
-// Need a way to check that the vcpkg harfbuzz port has graphite2 and icu options enabled.
-#[cfg(not(target_os = "macos"))]
-const VCPKG_LIBS: &[&str] = &["fontconfig", "harfbuzz", "freetype"];
-
-#[cfg(target_os = "macos")]
-const VCPKG_LIBS: &[&str] = &["harfbuzz", "freetype"];
-
-/// Build-script state when using vcpkg as the backend.
-#[derive(Clone, Debug)]
-struct VcPkgState {
-    include_paths: Vec<PathBuf>,
-}
-
-/// State for discovering and managing our dependencies, which may vary
-/// depending on the framework that we're using to discover them.
-///
-/// The basic gameplan is that we probe our dependencies to check that they're
-/// available and pull out the C/C++ include directories; then we emit info
-/// for building our C/C++ libraries; then we emit info for our dependencies.
-/// Building stuff pretty much always requires some level of hackery, though,
-/// so we don't try to be purist about the details.
-#[derive(Debug)]
-enum DepState {
-    /// pkg-config
-    PkgConfig(PkgConfigState),
-
-    /// vcpkg
-    VcPkg(VcPkgState),
-}
-
-impl DepState {
-    /// Probe for our dependent libraries using pkg-config.
-    fn new_pkg_config() -> Self {
-        let statik = env::var("TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC").is_ok();
-
-        let libs = pkg_config::Config::new()
-            .cargo_metadata(false)
-            .statik(statik)
-            .probe(PKGCONFIG_LIBS)
-            .unwrap();
-        DepState::PkgConfig(PkgConfigState { libs })
+impl Spec for TectonicRestSpec {
+    #[cfg(not(target_os = "macos"))]
+    fn get_pkgconfig_spec(&self) -> &str {
+        "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng"
     }
 
-    /// Probe for our dependent libraries using vcpkg.
-    fn new_vcpkg() -> Self {
-        let mut include_paths = vec![];
-
-        for dep in VCPKG_LIBS {
-            let library = vcpkg::Config::new()
-                .cargo_metadata(false)
-                .find_package(dep)
-                .unwrap_or_else(|e| panic!("failed to load package {} from vcpkg: {}", dep, e));
-            include_paths.extend(library.include_paths.iter().cloned());
-        }
-
-        DepState::VcPkg(VcPkgState { include_paths })
+    // No fontconfig on macOS.
+    #[cfg(target_os = "macos")]
+    fn get_pkgconfig_spec(&self) -> &str {
+        "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng"
     }
 
-    /// Invoke a callback for each C/C++ include directory injected by our
-    /// dependencies.
-    fn foreach_include_path<F>(&self, mut f: F)
-    where
-        F: FnMut(&Path),
-    {
-        match self {
-            DepState::PkgConfig(ref s) => {
-                for p in &s.libs.include_paths {
-                    f(p);
-                }
-            }
-
-            DepState::VcPkg(ref s) => {
-                for p in &s.include_paths {
-                    f(p);
-                }
-            }
-        }
+    // Would be nice to have a way to check that the vcpkg harfbuzz port has
+    // graphite2 and icu options enabled.
+    #[cfg(not(target_os = "macos"))]
+    fn get_vcpkg_spec(&self) -> &[&str] {
+        &["fontconfig", "harfbuzz", "freetype"]
     }
 
-    /// This function is called after we've emitted the cargo compilation info
-    /// for our own libraries. Now we can emit any special information
-    /// relating to our dependencies, which may depend on the dep-finding
-    /// backend or the target.
-    fn emit_late_extras(&self, target: &str) {
-        match self {
-            DepState::PkgConfig(ref state) => {
-                if env::var("TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC").is_ok() {
-                    // pkg-config will prevent "system libraries" from being
-                    // linked statically even when PKG_CONFIG_ALL_STATIC=1,
-                    // but its definition of a system library isn't always
-                    // perfect. For Debian cross builds, we'd like to make
-                    // binaries that are dynamically linked with things like
-                    // libc and libm but not libharfbuzz, etc. In this mode we
-                    // override pkg-config's logic by emitting the metadata
-                    // ourselves.
-                    for link_path in &state.libs.link_paths {
-                        println!("cargo:rustc-link-search=native={}", link_path.display());
-                    }
-
-                    for fw_path in &state.libs.framework_paths {
-                        println!("cargo:rustc-link-search=framework={}", fw_path.display());
-                    }
-
-                    for libbase in &state.libs.libs {
-                        let do_static = match libbase.as_ref() {
-                            "c" | "m" | "dl" | "pthread" => false,
-                            _ => {
-                                // Frustratingly, graphite2 seems to have
-                                // issues with static builds; e.g. static
-                                // graphite2 is not available on Debian. So
-                                // let's jump through the hoops of testing
-                                // whether the static archive seems findable.
-                                let libname = format!("lib{}.a", libbase);
-                                state
-                                    .libs
-                                    .link_paths
-                                    .iter()
-                                    .any(|d| d.join(&libname).exists())
-                            }
-                        };
-
-                        let mode = if do_static { "static=" } else { "" };
-                        println!("cargo:rustc-link-lib={}{}", mode, libbase);
-                    }
-
-                    for fw in &state.libs.frameworks {
-                        println!("cargo:rustc-link-lib=framework={}", fw);
-                    }
-                } else {
-                    // Just let pkg-config do its thing.
-                    pkg_config::Config::new()
-                        .cargo_metadata(true)
-                        .probe(PKGCONFIG_LIBS)
-                        .unwrap();
-                }
-            }
-
-            DepState::VcPkg(_) => {
-                for dep in VCPKG_LIBS {
-                    vcpkg::find_package(dep).unwrap_or_else(|e| {
-                        panic!("failed to load package {} from vcpkg: {}", dep, e)
-                    });
-                }
-                if target.contains("-linux-") {
-                    // add icudata to the end of the list of libs as vcpkg-rs
-                    // does not order individual libraries as a single pass
-                    // linker requires.
-                    println!("cargo:rustc-link-lib=icudata");
-                }
-            }
-        }
-    }
-}
-
-/// The default dependency-finding backend is pkg-config.
-impl Default for DepState {
-    fn default() -> Self {
-        DepState::new_pkg_config()
+    #[cfg(target_os = "macos")]
+    fn get_vcpkg_spec(&self) -> &[&str] {
+        &["harfbuzz", "freetype"]
     }
 }
 
@@ -192,6 +44,7 @@ fn main() {
     // Generate bindings for the C/C++ code to interface with backend Rust code.
     // As a heuristic we trigger rebuilds on changes to src/engines/mod.rs since
     // most of `core-bindgen.h` comes from this file.
+
     let mut cbindgen_header_path: PathBuf = env::var("OUT_DIR").unwrap().into();
     cbindgen_header_path.push("core-bindgen.h");
 
@@ -207,29 +60,19 @@ fn main() {
 
     println!("cargo:rustc-env=TARGET={}", target);
 
-    // OK, how are we finding our dependencies?
+    // Find our dependencies that aren't provided by any bridge or -sys crates.
 
-    println!("cargo:rerun-if-env-changed=TECTONIC_DEP_BACKEND");
-    println!("cargo:rerun-if-env-changed=TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC");
-
-    let dep_state = if let Ok(dep_backend_str) = env::var("TECTONIC_DEP_BACKEND") {
-        match dep_backend_str.as_ref() {
-            "pkg-config" => DepState::new_pkg_config(),
-            "vcpkg" => DepState::new_vcpkg(),
-            "default" => DepState::default(),
-            other => panic!("unrecognized TECTONIC_DEP_BACKEND setting {:?}", other),
-        }
-    } else {
-        DepState::default()
-    };
+    let dep_cfg = Configuration::default();
+    let dep = Dependency::probe(TectonicRestSpec, &dep_cfg);
 
     // Include paths exported by our internal dependencies.
 
     let flate_include_dir = env::var("DEP_TECTONIC_BRIDGE_FLATE_INCLUDE").unwrap();
     let graphite2_include_dir = env::var("DEP_GRAPHITE2_INCLUDE").unwrap();
 
-    // Actually I'm not 100% sure that I can't compile the C and C++ code
-    // into one library, but who cares?
+    // Specify the C/C++ support libraries. Actually I'm not 100% sure that I
+    // can't compile the C and C++ code into one library, but it's no a big deal
+    // -- it all gets linked together in the end.
 
     let mut ccfg = cc::Build::new();
     let mut cppcfg = cc::Build::new();
@@ -280,6 +123,7 @@ fn main() {
     // compiler to include frame pointers. We whitelist platforms that are
     // known to be able to profile *without* frame pointers: currently, only
     // Linux/x86_64.
+
     let profile_target_requires_frame_pointer: bool =
         target_cfg!(not(all(target_os = "linux", target_arch = "x86_64")));
 
@@ -441,7 +285,7 @@ fn main() {
         .include(&graphite2_include_dir)
         .include(&flate_include_dir);
 
-    dep_state.foreach_include_path(|p| {
+    dep.foreach_include_path(|p| {
         ccfg.include(p);
         cppcfg.include(p);
     });
@@ -490,7 +334,17 @@ fn main() {
     ccfg.compile("libtectonic_c.a");
     cppcfg.compile("libtectonic_cpp.a");
 
-    dep_state.emit_late_extras(&target);
+    dep.emit();
+
+    // vcpkg-rs is not guaranteed to emit libraries in the order required by a
+    // single-pass linker, so we might need to make sure that's done right.
+
+    if dep_cfg.backend == Backend::Vcpkg && target.contains("-linux-") {
+        // add icudata to the end of the list of libs as vcpkg-rs
+        // does not order individual libraries as a single pass
+        // linker requires.
+        println!("cargo:rustc-link-lib=icudata");
+    }
 
     // Tell cargo to rerun build.rs only if files in the tectonic/ directory have changed.
     for file in PathBuf::from("tectonic").read_dir().unwrap() {

--- a/crates/bridge_graphite2/CHANGELOG.md
+++ b/crates/bridge_graphite2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_graphite2/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/bridge_graphite2/Cargo.toml
+++ b/crates/bridge_graphite2/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+# See README.md for discussion of features (or lack thereof) in this crate.
+
+[package]
+name = "tectonic_bridge_graphite2"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+Expose the graphite2 library to Rust/Cargo.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_bridge_graphite2"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+links = "graphite2"
+
+[build-dependencies]
+tectonic_dep_support = { path = "../dep_support" }

--- a/crates/bridge_graphite2/Cargo.toml
+++ b/crates/bridge_graphite2/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 links = "graphite2"
 
 [build-dependencies]
-tectonic_dep_support = { path = "../dep_support" }
+tectonic_dep_support = { path = "../dep_support", version = "0.0.0-dev.0" }
 
 [package.metadata.internal_dep_versions]
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/crates/bridge_graphite2/Cargo.toml
+++ b/crates/bridge_graphite2/Cargo.toml
@@ -20,3 +20,6 @@ links = "graphite2"
 
 [build-dependencies]
 tectonic_dep_support = { path = "../dep_support" }
+
+[package.metadata.internal_dep_versions]
+tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/crates/bridge_graphite2/README.md
+++ b/crates/bridge_graphite2/README.md
@@ -1,0 +1,42 @@
+# The `tectonic_bridge_graphite2` crate
+
+[![](http://meritbadge.herokuapp.com/tectonic_bridge_graphite2)](https://crates.io/crates/tectonic_bridge_graphite2)
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It exposes the *C* API
+of the [graphite2] “smart font” system within the Rust/Cargo build framework,
+**with no Rust bindings**. This is why it is not named `graphite2-sys`.
+
+[graphite2]: https://graphite.sil.org/
+
+- [API documentation](https://docs.rs/tectonic_bridge_graphite2/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+The intention is that eventually this crate will provide the option of
+“vendoring” the graphite2 library, so that the Tectonic C code can use the
+library without it needing to be installed on the system. However, this has not
+yet been implemented.
+
+If your project depends on this crate, Cargo will export for your build script
+an environment variable named `DEP_GRAPHITE2_INCLUDE`, which will be the name of
+a directory containing the `graphite2` directory which in turn contains the
+graphite2 C headers.
+
+You will need to ensure that your Rust code actually references this crate in
+order for the linker to include linked libraries. A `use` statement will
+suffice:
+
+```rust
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
+use tectonic_bridge_graphite2;
+```
+
+
+## Cargo features
+
+At the moment this crate does not provide any [Cargo features][features]. It is
+intended that eventually it will, to allow control over whether the graphite2
+library is vendored or not.
+
+[features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/crates/bridge_graphite2/build.rs
+++ b/crates/bridge_graphite2/build.rs
@@ -1,0 +1,34 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! graphite2 build script. For now, we always find it externally. One day, we'd
+//! like to be able to vendor it.
+
+use tectonic_dep_support::{Configuration, Dependency, Spec};
+
+struct Graphite2Spec;
+
+impl Spec for Graphite2Spec {
+    fn get_pkgconfig_spec(&self) -> &str {
+        "graphite2"
+    }
+
+    fn get_vcpkg_spec(&self) -> &[&str] {
+        &["graphite2"]
+    }
+}
+
+fn main() {
+    let cfg = Configuration::default();
+    let dep = Dependency::probe(Graphite2Spec, &cfg);
+
+    // This is the key. What we print here will be propagated into depending
+    // crates' build scripts as the enviroment variable DEP_GRAPHITE2_INCLUDE,
+    // allowing them to find the headers internally. If/when we start vendoring
+    // graphite2, this can become $OUT_DIR.
+    dep.foreach_include_path(|p| {
+        println!("cargo:include={}", p.to_str().unwrap());
+    });
+
+    dep.emit();
+}

--- a/crates/bridge_graphite2/src/lib.rs
+++ b/crates/bridge_graphite2/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! Nothing.

--- a/crates/dep_support/CHANGELOG.md
+++ b/crates/dep_support/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/dep_support/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/dep_support/Cargo.toml
+++ b/crates/dep_support/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+[package]
+name = "tectonic_dep_support"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+Support for finding third-party libraries using either pkg-config or vcpkg.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_dep_support"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+pkg-config = "^0.3"
+vcpkg = "^0.2.11"

--- a/crates/dep_support/README.md
+++ b/crates/dep_support/README.md
@@ -1,0 +1,15 @@
+# The `tectonic_dep_support` crate
+
+[![](http://meritbadge.herokuapp.com/tectonic_dep_support)](https://crates.io/crates/tectonic_dep_support)
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It provides build-time
+utilities for finding external library dependencies, allowing either
+[pkg-config] or [vcpkg] to be used as the dep-finding backend, and providing
+whatever fiddly features are needed to enable the Tectonic build process.
+
+- [API documentation](https://docs.rs/tectonic_dep_support/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
+[vcpkg]: https://vcpkg.readthedocs.io/

--- a/crates/dep_support/src/lib.rs
+++ b/crates/dep_support/src/lib.rs
@@ -1,0 +1,243 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+#![deny(missing_docs)]
+
+//! Support for locating third-party libraries (“dependencies”) when building
+//! Tectonic. The main point of interest is that both pkg-config and vcpkg are
+//! supported as dep-finding backends. This crate does *not* deal with the
+//! choice of whether to provide a library externally or through vendoring.
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+/// Supported depedency-finding backends.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Backend {
+    /// pkg-config
+    PkgConfig,
+
+    /// vcpkg
+    Vcpkg,
+}
+
+impl Default for Backend {
+    fn default() -> Self {
+        Backend::PkgConfig
+    }
+}
+
+/// Dep-finding configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Configuration {
+    /// The dep-finding backend being used.
+    pub backend: Backend,
+
+    semi_static_mode: bool,
+}
+
+impl Default for Configuration {
+    /// This default function will fetch settings from the environment. Is that a no-no?
+    fn default() -> Self {
+        println!("cargo:rerun-if-env-changed=TECTONIC_DEP_BACKEND");
+        println!("cargo:rerun-if-env-changed=TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC");
+
+        // This should use FromStr or whatever, but meh.
+        let backend = if let Ok(dep_backend_str) = env::var("TECTONIC_DEP_BACKEND") {
+            match dep_backend_str.as_ref() {
+                "pkg-config" => Backend::PkgConfig,
+                "vcpkg" => Backend::Vcpkg,
+                "default" => Backend::default(),
+                other => panic!("unrecognized TECTONIC_DEP_BACKEND setting {:?}", other),
+            }
+        } else {
+            Backend::default()
+        };
+
+        let semi_static_mode = env::var("TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC").is_ok();
+
+        Configuration {
+            backend,
+            semi_static_mode,
+        }
+    }
+}
+
+/// Information specifying a dependency.
+pub trait Spec {
+    /// Get the pkg-config specification used to check for this dependency. This
+    /// text will be passed into `pkg_config::Config::probe()`.
+    fn get_pkgconfig_spec(&self) -> &str;
+
+    /// Get the vcpkg packages used to check for this dependency. These will be
+    /// passed into `vcpkg::Config::find_package()`.
+    fn get_vcpkg_spec(&self) -> &[&str];
+}
+
+/// Build-script state when using pkg-config as the backend.
+#[derive(Debug)]
+struct PkgConfigState {
+    libs: pkg_config::Library,
+}
+
+/// Build-script state when using vcpkg as the backend.
+#[derive(Clone, Debug)]
+struct VcPkgState {
+    include_paths: Vec<PathBuf>,
+}
+
+/// State for discovering and managing a dependency, which may vary
+/// depending on the framework that we're using to discover them.
+#[derive(Debug)]
+enum DepState {
+    /// pkg-config
+    PkgConfig(PkgConfigState),
+
+    /// vcpkg
+    VcPkg(VcPkgState),
+}
+
+impl DepState {
+    /// Probe the dependency.
+    fn new<T: Spec>(spec: &T, config: &Configuration) -> Self {
+        match config.backend {
+            Backend::PkgConfig => DepState::new_from_pkg_config(spec, config),
+            Backend::Vcpkg => DepState::new_from_vcpkg(spec, config),
+        }
+    }
+
+    /// Probe using pkg-config.
+    fn new_from_pkg_config<T: Spec>(spec: &T, config: &Configuration) -> Self {
+        let libs = pkg_config::Config::new()
+            .cargo_metadata(false)
+            .statik(config.semi_static_mode)
+            .probe(spec.get_pkgconfig_spec())
+            .unwrap();
+
+        DepState::PkgConfig(PkgConfigState { libs })
+    }
+
+    /// Probe using vcpkg.
+    fn new_from_vcpkg<T: Spec>(spec: &T, _config: &Configuration) -> Self {
+        let mut include_paths = vec![];
+
+        for dep in spec.get_vcpkg_spec() {
+            let library = vcpkg::Config::new()
+                .cargo_metadata(false)
+                .find_package(dep)
+                .unwrap_or_else(|e| panic!("failed to load package {} from vcpkg: {}", dep, e));
+            include_paths.extend(library.include_paths.iter().cloned());
+        }
+
+        DepState::VcPkg(VcPkgState { include_paths })
+    }
+}
+
+/// A dependency.
+pub struct Dependency<'a, T: Spec> {
+    config: &'a Configuration,
+    spec: T,
+    state: DepState,
+}
+
+impl<'a, T: Spec> Dependency<'a, T> {
+    /// Probe the dependency.
+    pub fn probe(spec: T, config: &'a Configuration) -> Self {
+        let state = DepState::new(&spec, config);
+
+        Dependency {
+            config,
+            spec,
+            state,
+        }
+    }
+
+    /// Invoke a callback for each C/C++ include directory injected by our
+    /// dependencies.
+    pub fn foreach_include_path<F>(&self, mut f: F)
+    where
+        F: FnMut(&Path),
+    {
+        match self.state {
+            DepState::PkgConfig(ref s) => {
+                for p in &s.libs.include_paths {
+                    f(p);
+                }
+            }
+
+            DepState::VcPkg(ref s) => {
+                for p in &s.include_paths {
+                    f(p);
+                }
+            }
+        }
+    }
+
+    /// Emit build information about this dependency. This should be called
+    /// after all information for in-crate builds is emitted.
+    pub fn emit(&self) {
+        match self.state {
+            DepState::PkgConfig(ref state) => {
+                if self.config.semi_static_mode {
+                    // pkg-config will prevent "system libraries" from being
+                    // linked statically even when PKG_CONFIG_ALL_STATIC=1,
+                    // but its definition of a system library isn't always
+                    // perfect. For Debian cross builds, we'd like to make
+                    // binaries that are dynamically linked with things like
+                    // libc and libm but not libharfbuzz, etc. In this mode we
+                    // override pkg-config's logic by emitting the metadata
+                    // ourselves.
+                    for link_path in &state.libs.link_paths {
+                        println!("cargo:rustc-link-search=native={}", link_path.display());
+                    }
+
+                    for fw_path in &state.libs.framework_paths {
+                        println!("cargo:rustc-link-search=framework={}", fw_path.display());
+                    }
+
+                    for libbase in &state.libs.libs {
+                        let do_static = match libbase.as_ref() {
+                            "c" | "m" | "dl" | "pthread" => false,
+                            _ => {
+                                // Frustratingly, graphite2 seems to have
+                                // issues with static builds; e.g. static
+                                // graphite2 is not available on Debian. So
+                                // let's jump through the hoops of testing
+                                // whether the static archive seems findable.
+                                let libname = format!("lib{}.a", libbase);
+                                state
+                                    .libs
+                                    .link_paths
+                                    .iter()
+                                    .any(|d| d.join(&libname).exists())
+                            }
+                        };
+
+                        let mode = if do_static { "static=" } else { "" };
+                        println!("cargo:rustc-link-lib={}{}", mode, libbase);
+                    }
+
+                    for fw in &state.libs.frameworks {
+                        println!("cargo:rustc-link-lib=framework={}", fw);
+                    }
+                } else {
+                    // Just let pkg-config do its thing.
+                    pkg_config::Config::new()
+                        .cargo_metadata(true)
+                        .probe(self.spec.get_pkgconfig_spec())
+                        .unwrap();
+                }
+            }
+
+            DepState::VcPkg(_) => {
+                for dep in self.spec.get_vcpkg_spec() {
+                    vcpkg::find_package(dep).unwrap_or_else(|e| {
+                        panic!("failed to load package {} from vcpkg: {}", dep, e)
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,10 @@ mod linkage {
     // API.
     #[allow(unused_imports)]
     use tectonic_bridge_flate::flate2;
+
+    #[allow(unused_imports)]
+    #[allow(clippy::single_component_path_imports)]
+    use tectonic_bridge_graphite2;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add a "bridge" crate for graphite2. Unlike the flate2 bridge crate, here we need to use our existing dep-finding tools since there's no preexisting `graphite2-sys`, so break that code into its own support crate as well.

Note that we intentionally do *not* call this a `graphite2-sys` crate since we don't export any Rust types for graphite2. All we do is link to it and propagate the information about where to find the C headers. This will position us to vendor the library one day, though.

- [x] Remove duplicated dep-finding code from `/build.rs` once the new build is shaken down.