### PR TITLE
Support CARGO_TARGET_DIR in PKGBUILD

### DIFF
--- a/dist/arch/PKGBUILD.src.in
+++ b/dist/arch/PKGBUILD.src.in
@@ -24,16 +24,16 @@ sha512sums=('@source_sha512@')
 
 build() {
 	cd $pkgname-$pkgver
-	cargo build --release --target-dir "./target"
+	cargo build --release
 }
 
 check() {
 	cd $pkgname-$pkgver
-	cargo test --release --target-dir "./target"
+	cargo test --release
 }
 
 package() {
 	cd $pkgname-$pkgver
-	install -Dm755 target/release/tectonic "$pkgdir"/usr/bin/tectonic
+	install -Dm755 ${CARGO_TARGET_DIR:-target}/release/tectonic "$pkgdir"/usr/bin/tectonic
 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
The src PKGBUILD previously forced a target directory of `./target`, presumably so that installation could copy the `tectonic` binary from `target`. It's preferable to let the target directory vary with `CARGO_TARGET_DIR` and then reach into `CARGO_TARGET_DIR` if defined when installing, because a shared target directory enables less cache duplication across rust programs and can decrease build time if dependencies are already cached.