### PR TITLE
Add a FreeType2 bridge crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "sha2",
  "structopt",
  "tectonic_bridge_flate",
+ "tectonic_bridge_freetype2",
  "tectonic_bridge_graphite2",
  "tectonic_cfg_support",
  "tectonic_dep_support",
@@ -1772,6 +1773,13 @@ dependencies = [
  "cbindgen",
  "flate2",
  "libc",
+]
+
+[[package]]
+name = "tectonic_bridge_freetype2"
+version = "0.0.0-dev.0"
+dependencies = [
+ "tectonic_dep_support",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ codecov = { repository = "tectonic-typesetting/tectonic", service = "github" }
 [workspace]
 members = [
   "crates/bridge_flate",
+  "crates/bridge_freetype2",
   "crates/bridge_graphite2",
   "crates/cfg_support",
   "crates/dep_support",
@@ -70,6 +71,7 @@ reqwest = "^0.9"
 sha2 = "^0.9"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 tectonic_bridge_flate = { path = "crates/bridge_flate", version = "0.0.0-dev.0" }
+tectonic_bridge_freetype2 = { path = "crates/bridge_freetype2", version = "0.0.0-dev.0" }
 tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
@@ -110,10 +112,10 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfi
 [package.metadata.internal_dep_versions]
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
 tectonic_bridge_graphite2 = "f135da463a65e731f05bafdd840edaa90137ec12"
+tectonic_bridge_freetype2 = "thiscommit:2021-01-09:voo7ohK2"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"
 tectonic_errors = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
 tectonic_io_base = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
 tectonic_status_base = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
 tectonic_xdv = "c91f2ef37858d1a0a724a5c3ddc2f7ea46373c77"
-

--- a/build.rs
+++ b/build.rs
@@ -15,25 +15,25 @@ struct TectonicRestSpec;
 impl Spec for TectonicRestSpec {
     #[cfg(not(target_os = "macos"))]
     fn get_pkgconfig_spec(&self) -> &str {
-        "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng"
+        "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc libpng"
     }
 
     // No fontconfig on macOS.
     #[cfg(target_os = "macos")]
     fn get_pkgconfig_spec(&self) -> &str {
-        "harfbuzz >= 1.4 harfbuzz-icu icu-uc freetype2 libpng"
+        "harfbuzz >= 1.4 harfbuzz-icu icu-uc libpng"
     }
 
     // Would be nice to have a way to check that the vcpkg harfbuzz port has
     // graphite2 and icu options enabled.
     #[cfg(not(target_os = "macos"))]
     fn get_vcpkg_spec(&self) -> &[&str] {
-        &["fontconfig", "harfbuzz", "freetype"]
+        &["fontconfig", "harfbuzz"]
     }
 
     #[cfg(target_os = "macos")]
     fn get_vcpkg_spec(&self) -> &[&str] {
-        &["harfbuzz", "freetype"]
+        &["harfbuzz"]
     }
 }
 
@@ -68,6 +68,7 @@ fn main() {
     // Include paths exported by our internal dependencies.
 
     let flate_include_dir = env::var("DEP_TECTONIC_BRIDGE_FLATE_INCLUDE").unwrap();
+    let freetype2_include_dir = env::var("DEP_FREETYPE2_INCLUDE").unwrap();
     let graphite2_include_dir = env::var("DEP_GRAPHITE2_INCLUDE").unwrap();
 
     // Specify the C/C++ support libraries. Actually I'm not 100% sure that I
@@ -231,6 +232,7 @@ fn main() {
         .file("tectonic/xetex-xetex0.c")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
         .include(&flate_include_dir);
 
@@ -282,6 +284,7 @@ fn main() {
         .file("tectonic/xetex-XeTeXOTMath.cpp")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
         .include(&flate_include_dir);
 

--- a/crates/bridge_freetype2/CHANGELOG.md
+++ b/crates/bridge_freetype2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_freetype2/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/bridge_freetype2/Cargo.toml
+++ b/crates/bridge_freetype2/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+# See README.md for discussion of features (or lack thereof) in this crate.
+
+[package]
+name = "tectonic_bridge_freetype2"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+Expose the FreeType2 library C APIs to Rust/Cargo.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_bridge_freetype2"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+links = "freetype2"
+
+[build-dependencies]
+tectonic_dep_support = { path = "../dep_support", version = "0.0.0-dev.0" }
+
+[package.metadata.internal_dep_versions]
+tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/crates/bridge_freetype2/README.md
+++ b/crates/bridge_freetype2/README.md
@@ -1,0 +1,53 @@
+# The `tectonic_bridge_freetype2` crate
+
+[![](http://meritbadge.herokuapp.com/tectonic_bridge_freetype2)](https://crates.io/crates/tectonic_bridge_freetype2)
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It exposes the *C* API
+of the [FreeType] font rendering engine within the Rust/Cargo build framework,
+**with no Rust bindings**.
+
+[FreeType]: https://www.freetype.org/
+
+- [API documentation](https://docs.rs/tectonic_bridge_freetype2/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+There are a variety of other low-level FreeType-related crates available, including:
+
+- [freetype-sys](https://crates.io/crates/freetype-sys)
+- [embedded-freetype-sys](https://crates.io/crates/embedded-freetype-sys)
+- [serve-freetype-sys](https://crates.io/crates/servo-freetype-sys)
+
+This package is distinctive because:
+
+- It uses Tectonic’s dependency-finding framework, which supports both
+  [pkg-config] and [vcpkg].
+- It ensures that FreeType’s C API is exposed to Cargo.
+
+[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
+[vcpkg]: https://vcpkg.readthedocs.io/
+
+Ideally, one day this crate will be superseded by one of the above crates.
+
+If your project depends on this crate, Cargo will export for your build script
+an environment variable named `DEP_FREETYPE2_INCLUDE`, which will be the name of
+a directory containing the `ft2build.h` header.
+
+You will need to ensure that your Rust code actually references this crate in
+order for the linker to include linked libraries. A `use` statement will
+suffice:
+
+```rust
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
+use tectonic_bridge_freetype2;
+```
+
+
+## Cargo features
+
+At the moment this crate does not provide any [Cargo features][features]. It is
+intended that eventually it will, to allow control over whether the FreeType
+library is vendored or not.
+
+[features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/crates/bridge_freetype2/build.rs
+++ b/crates/bridge_freetype2/build.rs
@@ -1,0 +1,36 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! FreeType2 build script. For now, we always find it externally. One day, we'd
+//! like to be able to vendor it. When that day comes, we should leverage
+//! existing work done in the other freetype-sys crates, preferably just using
+//! them directly instead of duplicating effort.
+
+use tectonic_dep_support::{Configuration, Dependency, Spec};
+
+struct Freetype2Spec;
+
+impl Spec for Freetype2Spec {
+    fn get_pkgconfig_spec(&self) -> &str {
+        "freetype2"
+    }
+
+    fn get_vcpkg_spec(&self) -> &[&str] {
+        &["freetype"]
+    }
+}
+
+fn main() {
+    let cfg = Configuration::default();
+    let dep = Dependency::probe(Freetype2Spec, &cfg);
+
+    // This is the key. What we print here will be propagated into depending
+    // crates' build scripts as the enviroment variable DEP_FREETYPE2_INCLUDE,
+    // allowing them to find the headers internally. If/when we start vendoring
+    // FreeType, this can become $OUT_DIR.
+    dep.foreach_include_path(|p| {
+        println!("cargo:include={}", p.to_str().unwrap());
+    });
+
+    dep.emit();
+}

--- a/crates/bridge_freetype2/src/lib.rs
+++ b/crates/bridge_freetype2/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! No Rust code. This crate exists to export the FreeType2 *C* API into the
+//! Cargo framework.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,12 +163,16 @@ pub fn latex_to_pdf<T: AsRef<str>>(latex: T) -> Result<Vec<u8>> {
     }
 }
 
+/// Import something from our bridge crates so that we ensure that we actually
+/// link with them, to pull in the symbols defined in the C APIs.
 mod linkage {
-    // Import something from tectonic_bridge_flate so that we ensure that we
-    // actually link with the crate, to pull in the symbols defined in the C
-    // API.
     #[allow(unused_imports)]
-    use tectonic_bridge_flate::flate2;
+    #[allow(clippy::single_component_path_imports)]
+    use tectonic_bridge_flate;
+
+    #[allow(unused_imports)]
+    #[allow(clippy::single_component_path_imports)]
+    use tectonic_bridge_freetype2;
 
     #[allow(unused_imports)]
     #[allow(clippy::single_component_path_imports)]

--- a/tectonic/xetex-core.h
+++ b/tectonic/xetex-core.h
@@ -1,5 +1,5 @@
 /* tectonic/xetex-core.h: core XeTeX types and #includes.
-   Copyright 2016 the Tectonic Project
+   Copyright 2016-2020 the Tectonic Project
    Licensed under the MIT License.
 */
 
@@ -11,6 +11,7 @@
 #include "core-memory.h"
 #include "core-strutils.h"
 
+/* ICU */
 #include <unicode/utypes.h>
 #include <unicode/platform.h> // defines U_IS_BIG_ENDIAN for us
 
@@ -90,8 +91,6 @@ typedef enum {
 #include <ApplicationServices/ApplicationServices.h>
 typedef CTFontDescriptorRef PlatformFontRef;
 #else
-#include <ft2build.h>
-#include FT_FREETYPE_H
 typedef FcPattern* PlatformFontRef;
 #endif
 


### PR DESCRIPTION
As expected, we can't use the various preexisting freetype-sys crates (there are several) because they don't plug into our build framework the way that we need. For now.