### PR TITLE
crates/bridge_icu: add ICU bridge crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "tectonic_bridge_flate",
  "tectonic_bridge_freetype2",
  "tectonic_bridge_graphite2",
+ "tectonic_bridge_icu",
  "tectonic_cfg_support",
  "tectonic_dep_support",
  "tectonic_errors",
@@ -1784,6 +1785,13 @@ dependencies = [
 
 [[package]]
 name = "tectonic_bridge_graphite2"
+version = "0.0.0-dev.0"
+dependencies = [
+ "tectonic_dep_support",
+]
+
+[[package]]
+name = "tectonic_bridge_icu"
 version = "0.0.0-dev.0"
 dependencies = [
  "tectonic_dep_support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "crates/bridge_flate",
   "crates/bridge_freetype2",
   "crates/bridge_graphite2",
+  "crates/bridge_icu",
   "crates/cfg_support",
   "crates/dep_support",
   "crates/errors",
@@ -73,6 +74,7 @@ serde = { version = "^1.0", features = ["derive"], optional = true }
 tectonic_bridge_flate = { path = "crates/bridge_flate", version = "0.0.0-dev.0" }
 tectonic_bridge_freetype2 = { path = "crates/bridge_freetype2", version = "0.0.0-dev.0" }
 tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0-dev.0" }
+tectonic_bridge_icu = { path = "crates/bridge_icu", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "crates/status_base", version = "0.0.0-dev.0" }
@@ -113,6 +115,7 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfi
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
 tectonic_bridge_graphite2 = "f135da463a65e731f05bafdd840edaa90137ec12"
 tectonic_bridge_freetype2 = "thiscommit:2021-01-09:voo7ohK2"
+tectonic_bridge_icu = "thiscommit:2021-01-09:diehoh1E"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"
 tectonic_errors = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"

--- a/build.rs
+++ b/build.rs
@@ -15,13 +15,13 @@ struct TectonicRestSpec;
 impl Spec for TectonicRestSpec {
     #[cfg(not(target_os = "macos"))]
     fn get_pkgconfig_spec(&self) -> &str {
-        "fontconfig harfbuzz >= 1.4 harfbuzz-icu icu-uc libpng"
+        "fontconfig harfbuzz >= 1.4 harfbuzz-icu libpng"
     }
 
     // No fontconfig on macOS.
     #[cfg(target_os = "macos")]
     fn get_pkgconfig_spec(&self) -> &str {
-        "harfbuzz >= 1.4 harfbuzz-icu icu-uc libpng"
+        "harfbuzz >= 1.4 harfbuzz-icu libpng"
     }
 
     // Would be nice to have a way to check that the vcpkg harfbuzz port has
@@ -70,6 +70,7 @@ fn main() {
     let flate_include_dir = env::var("DEP_TECTONIC_BRIDGE_FLATE_INCLUDE").unwrap();
     let freetype2_include_dir = env::var("DEP_FREETYPE2_INCLUDE").unwrap();
     let graphite2_include_dir = env::var("DEP_GRAPHITE2_INCLUDE").unwrap();
+    let icu_include_dir = env::var("DEP_ICUUC_INCLUDE").unwrap();
 
     // Specify the C/C++ support libraries. Actually I'm not 100% sure that I
     // can't compile the C and C++ code into one library, but it's no a big deal
@@ -234,6 +235,7 @@ fn main() {
         .include(".")
         .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
+        .include(&icu_include_dir)
         .include(&flate_include_dir);
 
     let cppflags = [
@@ -286,6 +288,7 @@ fn main() {
         .include(".")
         .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
+        .include(&icu_include_dir)
         .include(&flate_include_dir);
 
     dep.foreach_include_path(|p| {

--- a/crates/bridge_icu/CHANGELOG.md
+++ b/crates/bridge_icu/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_icu/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/bridge_icu/Cargo.toml
+++ b/crates/bridge_icu/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+# See README.md for discussion of features (or lack thereof) in this crate.
+
+[package]
+name = "tectonic_bridge_icu"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+Expose a subset of the ICU Unicode APIs to Rust/Cargo.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_bridge_icu"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+links = "icuuc"
+
+[build-dependencies]
+tectonic_dep_support = { path = "../dep_support", version = "0.0.0-dev.0" }
+
+[package.metadata.internal_dep_versions]
+tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/crates/bridge_icu/README.md
+++ b/crates/bridge_icu/README.md
@@ -1,0 +1,50 @@
+# The `tectonic_bridge_icu` crate
+
+[![](http://meritbadge.herokuapp.com/tectonic_bridge_icu)](https://crates.io/crates/tectonic_bridge_icu)
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It exposes the *C* API
+of the [ICU4C] Unicode library the Rust/Cargo build framework, **with no Rust
+bindings**.
+
+[ICU4C]: https://unicode-org.github.io/icu/userguide/icu4c-readme.html
+
+- [API documentation](https://docs.rs/tectonic_bridge_icu/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+There are a variety of other low-level ICU-related crates available, with
+[rust_icu](https://crates.io/crates/rust_icu) perhaps taking the most systematic
+approach. This package is distinctive because:
+
+- It uses Tectonic’s dependency-finding framework, which supports both
+  [pkg-config] and [vcpkg].
+- It ensures the ICU C API is exposed to Cargo.
+- Because it does not need to provide Rust bindings, it avoids a good deal of
+  grief relating to bindgen, symbol versioning, etc.
+
+[pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
+[vcpkg]: https://vcpkg.readthedocs.io/
+
+Ideally, though, one day this crate will be superseded by a true Rust “sys
+crate”.
+
+If your project depends on this crate, Cargo will export for your build script
+an environment variable named `DEP_ICUUC_INCLUDE`, which will be the name of
+a directory containing the `unicode` headers.
+
+You will need to ensure that your Rust code actually references this crate in
+order for the linker to include linked libraries. A `use` statement will
+suffice:
+
+```rust
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
+use tectonic_bridge_icu;
+```
+
+
+## Cargo features
+
+At the moment this crate does not provide any [Cargo features][features].
+
+[features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/crates/bridge_icu/build.rs
+++ b/crates/bridge_icu/build.rs
@@ -1,0 +1,36 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! ICU build script.
+//!
+//! We find it externally, and probably will continue to do so for as long as
+//! this crate is needed. Vendoring the ICU library is almost certainly not
+//! something that one should do.
+
+use tectonic_dep_support::{Configuration, Dependency, Spec};
+
+struct IcuSpec;
+
+impl Spec for IcuSpec {
+    fn get_pkgconfig_spec(&self) -> &str {
+        "icu-uc"
+    }
+
+    fn get_vcpkg_spec(&self) -> &[&str] {
+        &["icu"]
+    }
+}
+
+fn main() {
+    let cfg = Configuration::default();
+    let dep = Dependency::probe(IcuSpec, &cfg);
+
+    // This is the key. What we print here will be propagated into depending
+    // crates' build scripts as the enviroment variable DEP_ICUUC_INCLUDE,
+    // allowing them to find the headers internally.
+    dep.foreach_include_path(|p| {
+        println!("cargo:include={}", p.to_str().unwrap());
+    });
+
+    dep.emit();
+}

--- a/crates/bridge_icu/src/lib.rs
+++ b/crates/bridge_icu/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! No Rust code. This crate exists to export the ICU *C* API into the
+//! Cargo framework.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,10 @@ mod linkage {
     #[allow(unused_imports)]
     #[allow(clippy::single_component_path_imports)]
     use tectonic_bridge_graphite2;
+
+    #[allow(unused_imports)]
+    #[allow(clippy::single_component_path_imports)]
+    use tectonic_bridge_icu;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I was hoping to use `rust_icu_sys` here, since it prints out a Cargo line that we can use to find its C headers, but the currently released version requires nightly, has a build bug on my machine, and would add `bindgen` as a build-time dependency.