### PR TITLE
crates/bridge_harfbuzz: add this

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
  "tectonic_bridge_flate",
  "tectonic_bridge_freetype2",
  "tectonic_bridge_graphite2",
+ "tectonic_bridge_harfbuzz",
  "tectonic_bridge_icu",
  "tectonic_cfg_support",
  "tectonic_dep_support",
@@ -1785,6 +1786,13 @@ dependencies = [
 
 [[package]]
 name = "tectonic_bridge_graphite2"
+version = "0.0.0-dev.0"
+dependencies = [
+ "tectonic_dep_support",
+]
+
+[[package]]
+name = "tectonic_bridge_harfbuzz"
 version = "0.0.0-dev.0"
 dependencies = [
  "tectonic_dep_support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "crates/bridge_flate",
   "crates/bridge_freetype2",
   "crates/bridge_graphite2",
+  "crates/bridge_harfbuzz",
   "crates/bridge_icu",
   "crates/cfg_support",
   "crates/dep_support",
@@ -74,6 +75,7 @@ serde = { version = "^1.0", features = ["derive"], optional = true }
 tectonic_bridge_flate = { path = "crates/bridge_flate", version = "0.0.0-dev.0" }
 tectonic_bridge_freetype2 = { path = "crates/bridge_freetype2", version = "0.0.0-dev.0" }
 tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0-dev.0" }
+tectonic_bridge_harfbuzz = { path = "crates/bridge_harfbuzz", version = "0.0.0-dev.0" }
 tectonic_bridge_icu = { path = "crates/bridge_icu", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
@@ -115,6 +117,7 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfi
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
 tectonic_bridge_graphite2 = "f135da463a65e731f05bafdd840edaa90137ec12"
 tectonic_bridge_freetype2 = "thiscommit:2021-01-09:voo7ohK2"
+tectonic_bridge_harfbuzz = "thiscommit:2021-01-09:Aer8ohng"
 tectonic_bridge_icu = "thiscommit:2021-01-09:diehoh1E"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/build.rs
+++ b/build.rs
@@ -15,25 +15,25 @@ struct TectonicRestSpec;
 impl Spec for TectonicRestSpec {
     #[cfg(not(target_os = "macos"))]
     fn get_pkgconfig_spec(&self) -> &str {
-        "fontconfig harfbuzz >= 1.4 harfbuzz-icu libpng"
+        "fontconfig libpng"
     }
 
     // No fontconfig on macOS.
     #[cfg(target_os = "macos")]
     fn get_pkgconfig_spec(&self) -> &str {
-        "harfbuzz >= 1.4 harfbuzz-icu libpng"
+        "libpng"
     }
 
     // Would be nice to have a way to check that the vcpkg harfbuzz port has
     // graphite2 and icu options enabled.
     #[cfg(not(target_os = "macos"))]
     fn get_vcpkg_spec(&self) -> &[&str] {
-        &["fontconfig", "harfbuzz"]
+        &["fontconfig"]
     }
 
     #[cfg(target_os = "macos")]
     fn get_vcpkg_spec(&self) -> &[&str] {
-        &["harfbuzz"]
+        &[]
     }
 }
 
@@ -70,6 +70,7 @@ fn main() {
     let flate_include_dir = env::var("DEP_TECTONIC_BRIDGE_FLATE_INCLUDE").unwrap();
     let freetype2_include_dir = env::var("DEP_FREETYPE2_INCLUDE").unwrap();
     let graphite2_include_dir = env::var("DEP_GRAPHITE2_INCLUDE").unwrap();
+    let harfbuzz_include_dir = env::var("DEP_HARFBUZZ_INCLUDE").unwrap();
     let icu_include_dir = env::var("DEP_ICUUC_INCLUDE").unwrap();
 
     // Specify the C/C++ support libraries. Actually I'm not 100% sure that I
@@ -233,6 +234,7 @@ fn main() {
         .file("tectonic/xetex-xetex0.c")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&harfbuzz_include_dir)
         .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
         .include(&icu_include_dir)
@@ -286,6 +288,7 @@ fn main() {
         .file("tectonic/xetex-XeTeXOTMath.cpp")
         .include(env::var("OUT_DIR").unwrap())
         .include(".")
+        .include(&harfbuzz_include_dir)
         .include(&freetype2_include_dir)
         .include(&graphite2_include_dir)
         .include(&icu_include_dir)

--- a/crates/bridge_freetype2/build.rs
+++ b/crates/bridge_freetype2/build.rs
@@ -25,7 +25,7 @@ fn main() {
     let dep = Dependency::probe(Freetype2Spec, &cfg);
 
     // This is the key. What we print here will be propagated into depending
-    // crates' build scripts as the enviroment variable DEP_FREETYPE2_INCLUDE,
+    // crates' build scripts as the environment variable DEP_FREETYPE2_INCLUDE,
     // allowing them to find the headers internally. If/when we start vendoring
     // FreeType, this can become $OUT_DIR.
     dep.foreach_include_path(|p| {

--- a/crates/bridge_graphite2/build.rs
+++ b/crates/bridge_graphite2/build.rs
@@ -23,7 +23,7 @@ fn main() {
     let dep = Dependency::probe(Graphite2Spec, &cfg);
 
     // This is the key. What we print here will be propagated into depending
-    // crates' build scripts as the enviroment variable DEP_GRAPHITE2_INCLUDE,
+    // crates' build scripts as the environment variable DEP_GRAPHITE2_INCLUDE,
     // allowing them to find the headers internally. If/when we start vendoring
     // graphite2, this can become $OUT_DIR.
     dep.foreach_include_path(|p| {

--- a/crates/bridge_harfbuzz/CHANGELOG.md
+++ b/crates/bridge_harfbuzz/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_harfbuzz/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/bridge_harfbuzz/Cargo.toml
+++ b/crates/bridge_harfbuzz/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+# See README.md for discussion of features (or lack thereof) in this crate.
+
+[package]
+name = "tectonic_bridge_harfbuzz"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+Expose a subset of the ICU Unicode APIs to Rust/Cargo.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_bridge_harfbuzz"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+links = "harfbuzz"
+
+[build-dependencies]
+tectonic_dep_support = { path = "../dep_support", version = "0.0.0-dev.0" }
+
+[package.metadata.internal_dep_versions]
+tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"

--- a/crates/bridge_harfbuzz/README.md
+++ b/crates/bridge_harfbuzz/README.md
@@ -1,0 +1,41 @@
+# The `tectonic_bridge_harfbuzz` crate
+
+[![](http://meritbadge.herokuapp.com/tectonic_bridge_harfbuzz)](https://crates.io/crates/tectonic_bridge_harfbuzz)
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It exposes the *C* API
+of the [Harfbuzz] text shaping library the Rust/Cargo build framework, **with no
+Rust bindings**.
+
+[Harfbuzz]: https://harfbuzz.github.io/
+
+- [API documentation](https://docs.rs/tectonic_bridge_harfbuzz/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+While there are a variety of other Harfbuzz-related crates in the Rust
+ecosystem, Tectonic has specialized needs (e.g. support for the [graphite2]
+smart font library). Hence this specialized crate.
+
+[graphite2]: https://graphite.sil.org/
+
+If your project depends on this crate, Cargo will export for your build script
+an environment variable named `DEP_HARFBUZZ_INCLUDE`, which will be the name of
+a directory containing the `harfbuzz/` header directory.
+
+You will need to ensure that your Rust code actually references this crate in
+order for the linker to include linked libraries. A `use` statement will
+suffice:
+
+```rust
+#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
+use tectonic_bridge_harfbuzz;
+```
+
+
+## Cargo features
+
+At the moment this crate does not provide any [Cargo features][features]. That
+will change!
+
+[features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/crates/bridge_harfbuzz/build.rs
+++ b/crates/bridge_harfbuzz/build.rs
@@ -1,32 +1,28 @@
 // Copyright 2020 the Tectonic Project
 // Licensed under the MIT License.
 
-//! ICU build script.
-//!
-//! We find it externally, and probably will continue to do so for as long as
-//! this crate is needed. Vendoring the ICU library is almost certainly not
-//! something that one should do.
+//! Harfbuzz build script.
 
 use tectonic_dep_support::{Configuration, Dependency, Spec};
 
-struct IcuSpec;
+struct HarfbuzzSpec;
 
-impl Spec for IcuSpec {
+impl Spec for HarfbuzzSpec {
     fn get_pkgconfig_spec(&self) -> &str {
-        "icu-uc"
+        "harfbuzz >= 1.4 harfbuzz-icu"
     }
 
     fn get_vcpkg_spec(&self) -> &[&str] {
-        &["icu"]
+        &["harfbuzz"]
     }
 }
 
 fn main() {
     let cfg = Configuration::default();
-    let dep = Dependency::probe(IcuSpec, &cfg);
+    let dep = Dependency::probe(HarfbuzzSpec, &cfg);
 
     // This is the key. What we print here will be propagated into depending
-    // crates' build scripts as the environment variable DEP_ICUUC_INCLUDE,
+    // crates' build scripts as the envirnoment variable DEP_HARFBUZZ_INCLUDE,
     // allowing them to find the headers internally.
     dep.foreach_include_path(|p| {
         println!("cargo:include={}", p.to_str().unwrap());

--- a/crates/bridge_harfbuzz/src/lib.rs
+++ b/crates/bridge_harfbuzz/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! No Rust code. This crate exists to export the Harfbuzz *C/C++* API into the
+//! Cargo framework.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,10 @@ mod linkage {
 
     #[allow(unused_imports)]
     #[allow(clippy::single_component_path_imports)]
+    use tectonic_bridge_harfbuzz;
+
+    #[allow(unused_imports)]
+    #[allow(clippy::single_component_path_imports)]
     use tectonic_bridge_icu;
 }
 


### PR DESCRIPTION
Last in the current push. Now that we have bridges for all of these system libraries, we can start pushing backwards and making it possible to vendor them.