### PR TITLE
tectonic: avoid deprecated harfbuzz apis

### DIFF
--- a/tectonic/xetex-XeTeXFontInst.cpp
+++ b/tectonic/xetex-XeTeXFontInst.cpp
@@ -106,19 +106,19 @@ XeTeXFontInst::~XeTeXFontInst()
 }
 
 /* HarfBuzz font functions */
-
 static hb_bool_t
-_get_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t vs, hb_codepoint_t *gid, void*)
+_get_nominal_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t *gid, void*)
 {
     FT_Face face = (FT_Face) font_data;
-    *gid = 0;
+    *gid = FT_Get_Char_Index (face, ch);
+    return *gid != 0;
+}
 
-    if (vs)
-        *gid = FT_Face_GetCharVariantIndex (face, ch, vs);
-
-    if (*gid == 0)
-        *gid = FT_Get_Char_Index (face, ch);
-
+static hb_bool_t
+_get_variation_glyph(hb_font_t*, void *font_data, hb_codepoint_t ch, hb_codepoint_t vs, hb_codepoint_t *gid, void*)
+{
+    FT_Face face = (FT_Face) font_data;
+    *gid = FT_Face_GetCharVariantIndex (face, ch, vs);
     return *gid != 0;
 }
 
@@ -265,7 +265,8 @@ _get_font_funcs(void)
 {
     static hb_font_funcs_t* funcs = hb_font_funcs_create();
 
-    hb_font_funcs_set_glyph_func                (funcs, _get_glyph, NULL, NULL);
+    hb_font_funcs_set_nominal_glyph_func        (funcs, _get_nominal_glyph, NULL, NULL);
+    hb_font_funcs_set_variation_glyph_func      (funcs, _get_variation_glyph, NULL, NULL);
     hb_font_funcs_set_glyph_h_advance_func      (funcs, _get_glyph_h_advance, NULL, NULL);
     hb_font_funcs_set_glyph_v_advance_func      (funcs, _get_glyph_v_advance, NULL, NULL);
     hb_font_funcs_set_glyph_h_origin_func       (funcs, _get_glyph_h_origin, NULL, NULL);

--- a/tectonic/xetex-XeTeXLayoutInterface.cpp
+++ b/tectonic/xetex-XeTeXLayoutInterface.cpp
@@ -395,7 +395,7 @@ countFeatures(XeTeXFont font, hb_tag_t script, hb_tag_t language)
         unsigned int scriptIndex, langIndex = 0;
         hb_tag_t tableTag = i == 0 ? HB_OT_TAG_GSUB : HB_OT_TAG_GPOS;
         if (hb_ot_layout_table_find_script(face, tableTag, script, &scriptIndex)) {
-            if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
+            if (hb_ot_layout_script_select_language(face, tableTag, scriptIndex, 1, &language, &langIndex) || language == 0) {
                 rval += hb_ot_layout_language_get_feature_tags(face, tableTag, scriptIndex, langIndex, 0, NULL, NULL);
             }
         }
@@ -415,7 +415,7 @@ getIndFeature(XeTeXFont font, hb_tag_t script, hb_tag_t language, unsigned int i
         unsigned int scriptIndex, langIndex = 0;
         hb_tag_t tableTag = i == 0 ? HB_OT_TAG_GSUB : HB_OT_TAG_GPOS;
         if (hb_ot_layout_table_find_script(face, tableTag, script, &scriptIndex)) {
-            if (hb_ot_layout_script_find_language(face, tableTag, scriptIndex, language, &langIndex) || language == 0) {
+            if (hb_ot_layout_script_select_language(face, tableTag, scriptIndex, 1, &language, &langIndex) || language == 0) {
                 unsigned int featCount = hb_ot_layout_language_get_feature_tags(face, tableTag, scriptIndex, langIndex, 0, NULL, NULL);
                 hb_tag_t* featList = (hb_tag_t*) xcalloc(featCount, sizeof(hb_tag_t*));
                 hb_ot_layout_language_get_feature_tags(face, tableTag, scriptIndex, langIndex, 0, &featCount, featList);
@@ -1013,9 +1013,10 @@ static int grTextLen;
 bool
 initGraphiteBreaking(XeTeXLayoutEngine engine, const uint16_t* txtPtr, int txtLen)
 {
-    hb_face_t* hbFace = hb_font_get_face(engine->font->getHbFont());
+    hb_font_t* hbFont = engine->font->getHbFont();
+    hb_face_t* hbFace = hb_font_get_face(hbFont);
     gr_face* grFace = hb_graphite2_face_get_gr_face(hbFace);
-    gr_font* grFont = hb_graphite2_font_get_gr_font(engine->font->getHbFont());
+    gr_font* grFont = gr_make_font(hb_font_get_ptem(hbFont), grFace);
     if (grFace != NULL && grFont != NULL) {
         if (grSegment != NULL) {
             gr_seg_destroy(grSegment);


### PR DESCRIPTION
This is @Mrmaxmeier's #454 rebased onto current master. Now that we can vendor Harfbuzz, it's time to finally kill these warnings!

(Although if we do vendor harfbuzz, we get a new deprecation warning from it using a deprecated Graphite2 API call :-()