### PR TITLE
Allow choice of reqwest or curl for HTTP backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,12 +64,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
@@ -96,6 +90,12 @@ checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -134,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cbindgen"
@@ -240,40 +246,12 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01199925a18b00193570e3d70cfe57dcb647eb167c29851983e76fc39e2fee39"
+checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
 dependencies = [
- "bytes 1.0.0",
+ "bytes 1.0.1",
  "memchr",
-]
-
-[[package]]
-name = "cookie"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
-dependencies = [
- "time",
- "url 1.7.2",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
-dependencies = [
- "cookie",
- "failure",
- "idna 0.1.5",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time",
- "try_from",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -324,7 +302,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
@@ -350,7 +328,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -450,12 +428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,28 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,7 +466,7 @@ checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -561,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -573,12 +523,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -603,6 +547,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +569,42 @@ checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
  "futures",
  "num_cpus",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+
+[[package]]
+name = "futures-task"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -633,13 +628,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -658,12 +653,32 @@ dependencies = [
  "bytes 0.4.12",
  "fnv",
  "futures",
- "http",
+ "http 0.1.21",
  "indexmap",
  "log",
  "slab",
  "string",
  "tokio-io",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.3",
+ "indexmap",
+ "slab",
+ "tokio 1.0.1",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -678,11 +693,11 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 dependencies = [
- "base64",
+ "base64 0.10.1",
  "bitflags",
  "bytes 0.4.12",
  "headers-core",
- "http",
+ "http 0.1.21",
  "mime",
  "sha-1",
  "time",
@@ -695,7 +710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 dependencies = [
  "bytes 0.4.12",
- "http",
+ "http 0.1.21",
 ]
 
 [[package]]
@@ -728,6 +743,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,8 +761,18 @@ checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
  "futures",
- "http",
+ "http 0.1.21",
  "tokio-buf",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.1",
+ "http 0.2.3",
 ]
 
 [[package]]
@@ -744,6 +780,12 @@ name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
@@ -754,9 +796,9 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "futures-cpupool",
- "h2",
- "http",
- "http-body",
+ "h2 0.1.26",
+ "http 0.1.21",
+ "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa",
@@ -764,7 +806,7 @@ dependencies = [
  "net2",
  "rustc_version",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -772,20 +814,44 @@ dependencies = [
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer",
- "want",
+ "want 0.2.0",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.0",
+ "http 0.2.3",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.4",
+ "socket2",
+ "tokio 1.0.1",
+ "tower-service",
+ "tracing",
+ "want 0.3.0",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.4.12",
- "futures",
- "hyper",
+ "bytes 1.0.1",
+ "hyper 0.14.2",
  "native-tls",
- "tokio-io",
+ "tokio 1.0.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -793,17 +859,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -822,7 +877,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -834,6 +889,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -860,6 +921,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "js-sys"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -906,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -948,7 +1018,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -958,23 +1028,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -990,10 +1050,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1004,7 +1077,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -1017,6 +1090,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1094,6 +1177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1222,12 @@ name = "object"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+
+[[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -1178,7 +1276,7 @@ version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1205,7 +1303,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec",
  "winapi 0.3.9",
@@ -1213,15 +1311,61 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+dependencies = [
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+dependencies = [
+ "pin-project-internal 1.0.4",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1284,19 +1428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "publicsuffix"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
-dependencies = [
- "error-chain",
- "idna 0.2.0",
- "lazy_static",
- "regex",
- "url 2.2.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,158 +1438,42 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+checksum = "c24fcd450d3fa2b592732565aa4f17a27a61c65ece4726353e000939b0edee34"
 dependencies = [
- "autocfg 0.1.7",
  "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1466,6 +1481,15 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -1496,35 +1520,35 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.24"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
- "base64",
- "bytes 0.4.12",
- "cookie",
- "cookie_store",
+ "base64 0.13.0",
+ "bytes 1.0.1",
  "encoding_rs",
- "flate2",
- "futures",
- "http",
- "hyper",
+ "futures-core",
+ "futures-util",
+ "http 0.2.3",
+ "http-body 0.4.0",
+ "hyper 0.14.2",
  "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
  "serde",
- "serde_json",
  "serde_urlencoded",
- "time",
- "tokio",
- "tokio-executor",
- "tokio-io",
- "tokio-threadpool",
- "tokio-timer",
- "url 1.7.2",
- "uuid",
+ "tokio 1.0.1",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "winreg",
 ]
 
@@ -1614,18 +1638,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "9bdd36f49e35b61d49efd8aa7fc068fd295961fd2286d0b2ee9a4c7a14e99cc3"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "552954ce79a059ddd5fd68c271592374bd15cab2274970380c000118aeffe1cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1645,14 +1669,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url 1.7.2",
 ]
 
 [[package]]
@@ -1688,9 +1712,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
@@ -1753,24 +1777,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 
@@ -1790,7 +1802,7 @@ dependencies = [
  "fs2",
  "futures",
  "headers",
- "hyper",
+ "hyper 0.12.35",
  "lazy_static",
  "libc",
  "md-5",
@@ -1814,9 +1826,9 @@ dependencies = [
  "tectonic_xdv",
  "tempfile",
  "termcolor",
- "tokio",
+ "tokio 0.1.22",
  "toml",
- "url 2.2.0",
+ "url",
  "vcpkg",
  "zip",
 ]
@@ -1889,7 +1901,6 @@ version = "0.0.0-dev.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curl",
- "headers",
  "reqwest",
  "tectonic_errors",
  "tectonic_status_base",
@@ -1924,14 +1935,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -1976,21 +1987,20 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -2017,7 +2027,7 @@ checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
  "futures",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -2031,6 +2041,21 @@ dependencies = [
  "tokio-timer",
  "tokio-udp",
  "tokio-uds",
+]
+
+[[package]]
+name = "tokio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
+ "libc",
+ "memchr",
+ "mio 0.7.7",
+ "num_cpus",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2098,6 +2123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.0.1",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,13 +2142,24 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot",
  "slab",
  "tokio-executor",
  "tokio-io",
  "tokio-sync",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -2135,7 +2181,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -2178,7 +2224,7 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "log",
- "mio",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -2195,11 +2241,26 @@ dependencies = [
  "iovec",
  "libc",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ae4751faa60b9f96dd8344d74592e5a17c0c9a220413dbc6942d14139bbfcc"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio 1.0.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2212,34 +2273,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "try_from"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
 name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -2279,25 +2358,14 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2305,15 +2373,6 @@ name = "utf8-width"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
-]
 
 [[package]]
 name = "vcpkg"
@@ -2356,16 +2415,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+name = "want"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+
+[[package]]
+name = "web-sys"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2412,9 +2553,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.39+curl-7.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1665,6 +1696,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1886,8 @@ dependencies = [
 name = "tectonic_geturl"
 version = "0.0.0-dev.0"
 dependencies = [
+ "cfg-if 1.0.0",
+ "curl",
  "headers",
  "reqwest",
  "tectonic_errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "toml",
+ "url 2.2.0",
  "vcpkg",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,6 @@ dependencies = [
  "open",
  "pkg-config",
  "regex",
- "reqwest",
  "serde",
  "sha2",
  "structopt",
@@ -1767,6 +1766,7 @@ dependencies = [
  "tectonic_cfg_support",
  "tectonic_dep_support",
  "tectonic_errors",
+ "tectonic_geturl",
  "tectonic_io_base",
  "tectonic_status_base",
  "tectonic_xdv",
@@ -1838,6 +1838,16 @@ name = "tectonic_errors"
 version = "0.0.0-dev.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "tectonic_geturl"
+version = "0.0.0-dev.0"
+dependencies = [
+ "headers",
+ "reqwest",
+ "tectonic_errors",
+ "tectonic_status_base",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "crates/cfg_support",
   "crates/dep_support",
   "crates/errors",
+  "crates/geturl",
   "crates/io_base",
   "crates/status_base",
   "crates/xdv",
@@ -63,12 +64,10 @@ cfg-if = "1.0"
 error-chain = "^0.12"
 flate2 = { version = "^1.0.19", default-features = false, features = ["zlib"] }
 fs2 = "^0.4"
-headers = "^0.2"
 lazy_static = "^1.4"
 libc = "^0.2"
 md-5 = "^0.9"
 open = "1.4.0"
-reqwest = "^0.9"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 sha2 = "^0.9"
 structopt = "0.3"
@@ -78,6 +77,7 @@ tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0
 tectonic_bridge_harfbuzz = { path = "crates/bridge_harfbuzz", version = "0.0.0-dev.0" }
 tectonic_bridge_icu = { path = "crates/bridge_icu", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
+tectonic_geturl = { path = "crates/geturl", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "crates/status_base", version = "0.0.0-dev.0" }
 tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
@@ -125,6 +125,7 @@ tectonic_bridge_icu = "thiscommit:2021-01-09:diehoh1E"
 tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"
 tectonic_errors = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
+tectonic_geturl = "thiscommit:2021-01-10:eiv5ohMe"
 tectonic_io_base = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
 tectonic_status_base = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"
 tectonic_xdv = "c91f2ef37858d1a0a724a5c3ddc2f7ea46373c77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0
 tectonic_bridge_harfbuzz = { path = "crates/bridge_harfbuzz", version = "0.0.0-dev.0" }
 tectonic_bridge_icu = { path = "crates/bridge_icu", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
-tectonic_geturl = { path = "crates/geturl", version = "0.0.0-dev.0" }
+tectonic_geturl = { path = "crates/geturl", version = "0.0.0-dev.0", default-features = false }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "crates/status_base", version = "0.0.0-dev.0" }
 tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
@@ -87,13 +87,16 @@ toml = { version = "^0.5", optional = true }
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
 
 [features]
-default = ["serialization"]
+default = ["geturl-reqwest", "serialization"]
+
 # Note: we used to have this to couple "serde" and "serde-derive", but we've
 # adopted the newer scheme to avoid having to depend on both -- should maybe
 # just get rid of this feature:
 serialization = ["serde", "toml"]
 
 external-harfbuzz = ["tectonic_bridge_harfbuzz/external-harfbuzz"]
+
+geturl-reqwest = ["tectonic_geturl/reqwest"]
 
 # developer feature to compile with the necessary flags for profiling tectonic.
 profile = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
 tempfile = "^3.1"
 termcolor = "^1.1"
 toml = { version = "^0.5", optional = true }
+url = "^2.0"
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ serialization = ["serde", "toml"]
 
 external-harfbuzz = ["tectonic_bridge_harfbuzz/external-harfbuzz"]
 
+geturl-curl = ["tectonic_geturl/curl"]
 geturl-reqwest = ["tectonic_geturl/reqwest"]
 
 # developer feature to compile with the necessary flags for profiling tectonic.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ external library can be detected with either [pkg-config] or [vcpkg]. See the
 [vcpkg]: https://vcpkg.readthedocs.io/
 [howto-build]: https://tectonic-typesetting.github.io/book/latest/#update-link-when-published
 
+##### `geturl-reqwest` (enabled by default)
+
+Use the [reqwest] crate to implement HTTP requests. This is the default
+selection.
+
+[reqwest]: https://docs.rs/reqwest/
+
 ##### `serialization` (enabled by default)
 
 This feature enables (de)serialization using the [serde](https://serde.rs/)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ external library can be detected with either [pkg-config] or [vcpkg]. See the
 [vcpkg]: https://vcpkg.readthedocs.io/
 [howto-build]: https://tectonic-typesetting.github.io/book/latest/#update-link-when-published
 
+##### `geturl-curl`
+
+Use the [curl] crate to implement HTTP requests. In order for this to take
+effect, you must use `--no-default-features` because `geturl-reqwest` is a
+default feature and it takes precedence.
+
+[reqwest]: https://docs.rs/curl/
+
 ##### `geturl-reqwest` (enabled by default)
 
 Use the [reqwest] crate to implement HTTP requests. This is the default

--- a/crates/geturl/CHANGELOG.md
+++ b/crates/geturl/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/geturl/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/geturl/Cargo.toml
+++ b/crates/geturl/Cargo.toml
@@ -18,8 +18,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "^1.0"
 curl = { version = "^0.4", optional = true }
-headers = "^0.2"
-reqwest = { version = "^0.9", optional = true }
+reqwest = { version = "^0.11", optional = true, features = ["blocking"] }
 tectonic_errors = { path = "../errors", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "../status_base", version = "0.0.0-dev.0" }
 

--- a/crates/geturl/Cargo.toml
+++ b/crates/geturl/Cargo.toml
@@ -16,10 +16,15 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+cfg-if = "^1.0"
+curl = { version = "^0.4", optional = true }
 headers = "^0.2"
-reqwest = "^0.9"
+reqwest = { version = "^0.9", optional = true }
 tectonic_errors = { path = "../errors", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "../status_base", version = "0.0.0-dev.0" }
+
+[features]
+default = ["reqwest"]
 
 [package.metadata.internal_dep_versions]
 tectonic_errors = "e04798bcd9b1c1d68cc0a318a710bb30230a0300"

--- a/crates/geturl/Cargo.toml
+++ b/crates/geturl/Cargo.toml
@@ -1,0 +1,26 @@
+# Copyright 2020 the Tectonic Project
+# Licensed under the MIT License.
+
+[package]
+name = "tectonic_geturl"
+version = "0.0.0-dev.0"  # assigned with cranko (see README)
+authors = ["Peter Williams <peter@newton.cx>"]
+description = """
+A generic interface for HTTP GETs and byte-range requests, with pluggable backends.
+"""
+homepage = "https://tectonic-typesetting.github.io/"
+documentation = "https://docs.rs/tectonic_geturl"
+repository = "https://github.com/tectonic-typesetting/tectonic/"
+readme = "README.md"
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+headers = "^0.2"
+reqwest = "^0.9"
+tectonic_errors = { path = "../errors", version = "0.0.0-dev.0" }
+tectonic_status_base = { path = "../status_base", version = "0.0.0-dev.0" }
+
+[package.metadata.internal_dep_versions]
+tectonic_errors = "e04798bcd9b1c1d68cc0a318a710bb30230a0300"
+tectonic_status_base = "401387acfd98113133db6981c301426431f55ea3"

--- a/crates/geturl/README.md
+++ b/crates/geturl/README.md
@@ -1,0 +1,10 @@
+# The `tectonic_geturl` create
+
+This crate is part of [the Tectonic
+project](https://tectonic-typesetting.github.io/en-US/). It provides an
+interface for fetching URLs using one of several HTTP backends.
+
+[![](http://meritbadge.herokuapp.com/tectonic_geturl)](https://crates.io/crates/tectonic_geturl)
+
+- [API documentation](https://docs.rs/tectonic_geturl/).
+- [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).

--- a/crates/geturl/README.md
+++ b/crates/geturl/README.md
@@ -8,3 +8,17 @@ interface for fetching URLs using one of several HTTP backends.
 
 - [API documentation](https://docs.rs/tectonic_geturl/).
 - [Main Git repository](https://github.com/tectonic-typesetting/tectonic/).
+
+
+## Cargo features
+
+This crate provides the following [Cargo features][features]:
+
+[features]: https://doc.rust-lang.org/cargo/reference/features.html
+
+- **`reqwest`** (enabled by default): use the [reqwest] crate as the backend for
+  performing URL gets.
+
+[reqwest]: https://docs.rs/reqwest/
+
+If no backend is enabled, a “null” backend will be used that will always return errors.

--- a/crates/geturl/README.md
+++ b/crates/geturl/README.md
@@ -16,9 +16,16 @@ This crate provides the following [Cargo features][features]:
 
 [features]: https://doc.rust-lang.org/cargo/reference/features.html
 
-- **`reqwest`** (enabled by default): use the [reqwest] crate as the backend for
+- **`curl`**: use the [curl] crate as a backend for performing URL gets.
+- **`reqwest`** (enabled by default): use the [reqwest] crate as a backend for
   performing URL gets.
 
+[curl]: https://docs.rs/curl/
 [reqwest]: https://docs.rs/reqwest/
 
-If no backend is enabled, a “null” backend will be used that will always return errors.
+There is always a “null” backend available, which will always return errors. If
+more than one backend is enabled, their prioritization is:
+
+- `reqwest` (most preferred)
+- `curl`
+- `null` (least preferred)

--- a/crates/geturl/src/curl.rs
+++ b/crates/geturl/src/curl.rs
@@ -1,0 +1,105 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! A URL-get backend based on the `curl` crate.
+
+use curl::easy::Easy;
+use std::io::Cursor;
+use tectonic_errors::{anyhow::bail, Result};
+use tectonic_status_base::StatusBackend;
+
+use crate::{GetUrlBackend, RangeReader};
+
+const MAX_HTTP_REDIRECTS_ALLOWED: u32 = 10;
+
+fn get_url_generic(
+    handle: &mut Easy,
+    url: &str,
+    range: Option<(u64, usize)>,
+) -> Result<Cursor<Vec<u8>>> {
+    handle.url(url)?;
+    handle.follow_location(true)?;
+    handle.max_redirections(MAX_HTTP_REDIRECTS_ALLOWED)?;
+
+    if let Some((start, length)) = range {
+        let end = start + length as u64 - 1;
+        handle.range(&format!("{}-{}", start, end))?;
+    }
+
+    let mut buf = Vec::new();
+    {
+        let mut transfer = handle.transfer();
+        transfer.write_function(|data| {
+            buf.extend_from_slice(data);
+            Ok(data.len())
+        })?;
+        transfer.perform()?;
+    }
+
+    let code = handle.response_code()?;
+
+    if !(200..300).contains(&code) {
+        bail!(
+            "unsuccessful HTTP GET status code {} for url `{}`",
+            code,
+            url
+        );
+    }
+
+    Ok(Cursor::new(buf))
+}
+
+/// URL-get backend implemented using the `curl` crate.
+#[derive(Debug)]
+pub struct CurlBackend {
+    handle: Easy,
+}
+
+impl Default for CurlBackend {
+    fn default() -> Self {
+        CurlBackend {
+            handle: Easy::new(),
+        }
+    }
+}
+
+impl GetUrlBackend for CurlBackend {
+    type Response = Cursor<Vec<u8>>;
+    type RangeReader = CurlRangeReader;
+
+    fn get_url(&mut self, url: &str, _status: &mut dyn StatusBackend) -> Result<Self::Response> {
+        get_url_generic(&mut self.handle, url, None)
+    }
+
+    fn resolve_url(&mut self, url: &str, _status: &mut dyn StatusBackend) -> Result<String> {
+        Ok(url.into())
+    }
+
+    fn open_range_reader(&self, url: &str) -> Self::RangeReader {
+        CurlRangeReader::new(url)
+    }
+}
+
+/// Curl-based byte-range reader.
+#[derive(Debug)]
+pub struct CurlRangeReader {
+    url: String,
+    handle: Easy,
+}
+
+impl CurlRangeReader {
+    fn new(url: &str) -> CurlRangeReader {
+        CurlRangeReader {
+            url: url.to_owned(),
+            handle: Easy::new(),
+        }
+    }
+}
+
+impl RangeReader for CurlRangeReader {
+    type Response = Cursor<Vec<u8>>;
+
+    fn read_range(&mut self, offset: u64, length: usize) -> Result<Self::Response> {
+        get_url_generic(&mut self.handle, &self.url, Some((offset, length)))
+    }
+}

--- a/crates/geturl/src/lib.rs
+++ b/crates/geturl/src/lib.rs
@@ -53,7 +53,6 @@ pub mod reqwest;
 cfg_if! {
     if #[cfg(feature = "reqwest")] {
         pub use crate::reqwest::ReqwestBackend as DefaultBackend;
-        pub use ::reqwest::Url;
     } else {
         pub use null::NullBackend as DefaultBackend;
     }

--- a/crates/geturl/src/lib.rs
+++ b/crates/geturl/src/lib.rs
@@ -1,0 +1,56 @@
+// Copyright 2020 the Tectonic Project.
+// Licensed under the MIT License.
+
+#![deny(missing_docs)]
+
+//! A simple, pluggable interface for HTTP GETs and range requests.
+//!
+//! The default interface is intentionally exposed as a concrete type, so that
+//! crates relying on this one need not use a lot of dyns and impl Traits. It is
+//! intended that the choice of HTTP backend is a build-time one, not a runtime
+//! one.
+
+use std::io::Read;
+use tectonic_errors::Result;
+use tectonic_status_base::StatusBackend;
+
+/// A trait for reading byte ranges from an HTTP resource.
+pub trait RangeReader {
+    /// The readable type returned by the range request.
+    type Response: Read;
+
+    /// Read the specified range of bytes from this HTTP resource.
+    fn read_range(&mut self, offset: u64, length: usize) -> Result<Self::Response>;
+}
+
+/// A trait for simple HTTP operations needed by the Tectonic backends.
+pub trait GetUrlBackend: Default {
+    /// The readable type returned by URL get requests.
+    type Response: Read;
+
+    /// The range-reader type for URLs that will undergo byte-range reads.
+    type RangeReader: RangeReader;
+
+    /// Starting with an input URL, follow redirections to get a final URL.
+    ///
+    /// But we attempt to detect redirects into CDNs/S3/etc and *stop* following
+    /// before we get that deep.
+    fn resolve_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<String>;
+
+    /// Perform an HTTP GET on a URL, returning a readable result.
+    fn get_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<Self::Response>;
+
+    /// Open a range reader that can perform byte-range reads on the specified URL.
+    fn open_range_reader(&self, url: &str) -> Self::RangeReader;
+}
+
+mod reqwest;
+
+/// The type of the default URL-get backend.
+pub use crate::reqwest::ReqwestBackend as DefaultBackend;
+
+/// The URL type used by the default URL-get backend.
+pub use ::reqwest::Url;
+
+/// The range-reader type exposed by the URL-get backend (for convenience).
+pub type DefaultRangeReader = <DefaultBackend as GetUrlBackend>::RangeReader;

--- a/crates/geturl/src/lib.rs
+++ b/crates/geturl/src/lib.rs
@@ -47,12 +47,17 @@ pub trait GetUrlBackend: Default {
 
 pub mod null;
 
+#[cfg(feature = "curl")]
+pub mod curl;
+
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 
 cfg_if! {
     if #[cfg(feature = "reqwest")] {
         pub use crate::reqwest::ReqwestBackend as DefaultBackend;
+    } else if #[cfg(feature = "curl")] {
+        pub use crate::curl::CurlBackend as DefaultBackend;
     } else {
         pub use null::NullBackend as DefaultBackend;
     }

--- a/crates/geturl/src/lib.rs
+++ b/crates/geturl/src/lib.rs
@@ -10,6 +10,7 @@
 //! intended that the choice of HTTP backend is a build-time one, not a runtime
 //! one.
 
+use cfg_if::cfg_if;
 use std::io::Read;
 use tectonic_errors::Result;
 use tectonic_status_base::StatusBackend;
@@ -44,13 +45,19 @@ pub trait GetUrlBackend: Default {
     fn open_range_reader(&self, url: &str) -> Self::RangeReader;
 }
 
-mod reqwest;
+pub mod null;
 
-/// The type of the default URL-get backend.
-pub use crate::reqwest::ReqwestBackend as DefaultBackend;
+#[cfg(feature = "reqwest")]
+pub mod reqwest;
 
-/// The URL type used by the default URL-get backend.
-pub use ::reqwest::Url;
+cfg_if! {
+    if #[cfg(feature = "reqwest")] {
+        pub use crate::reqwest::ReqwestBackend as DefaultBackend;
+        pub use ::reqwest::Url;
+    } else {
+        pub use null::NullBackend as DefaultBackend;
+    }
+}
 
-/// The range-reader type exposed by the URL-get backend (for convenience).
+/// The range-reader type exposed by the default URL-get backend (for convenience).
 pub type DefaultRangeReader = <DefaultBackend as GetUrlBackend>::RangeReader;

--- a/crates/geturl/src/null.rs
+++ b/crates/geturl/src/null.rs
@@ -48,7 +48,7 @@ impl GetUrlBackend for NullBackend {
 }
 
 /// The "null" URL-get range reader, which always fails.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct NullRangeReader {}
 
 impl RangeReader for NullRangeReader {

--- a/crates/geturl/src/null.rs
+++ b/crates/geturl/src/null.rs
@@ -1,0 +1,60 @@
+// Copyright 2020 the Tectonic Project
+// Licensed under the MIT License.
+
+//! A geturl backend that always fails.
+
+use std::{
+    error::Error,
+    fmt::{Display, Error as FmtError, Formatter},
+    io::Empty,
+    result::Result as StdResult,
+};
+use tectonic_errors::Result;
+use tectonic_status_base::StatusBackend;
+
+use crate::{GetUrlBackend, RangeReader};
+
+/// The error type for the always-failing geturl backend.
+#[derive(Debug)]
+pub struct NoGetUrlBackendError {}
+
+impl Display for NoGetUrlBackendError {
+    fn fmt(&self, f: &mut Formatter) -> StdResult<(), FmtError> {
+        write!(f, "no get-URL backend was enabled")
+    }
+}
+
+impl Error for NoGetUrlBackendError {}
+
+/// The "null" URL-get backend, which always fails.
+#[derive(Debug, Default)]
+pub struct NullBackend {}
+
+impl GetUrlBackend for NullBackend {
+    type Response = Empty;
+    type RangeReader = NullRangeReader;
+
+    fn get_url(&mut self, _url: &str, _status: &mut dyn StatusBackend) -> Result<Empty> {
+        Err((NoGetUrlBackendError {}).into())
+    }
+
+    fn resolve_url(&mut self, _url: &str, _status: &mut dyn StatusBackend) -> Result<String> {
+        Err((NoGetUrlBackendError {}).into())
+    }
+
+    fn open_range_reader(&self, _url: &str) -> Self::RangeReader {
+        NullRangeReader {}
+    }
+}
+
+/// The "null" URL-get range reader, which always fails.
+#[derive(Clone, Debug)]
+pub struct NullRangeReader {}
+
+impl RangeReader for NullRangeReader {
+    type Response = Empty;
+
+    fn read_range(&mut self, _offset: u64, _length: usize) -> Result<Empty> {
+        Err((NoGetUrlBackendError {}).into())
+    }
+}

--- a/crates/geturl/src/reqwest.rs
+++ b/crates/geturl/src/reqwest.rs
@@ -19,7 +19,7 @@ impl GetUrlBackend for ReqwestBackend {
     type Response = Response;
     type RangeReader = ReqwestRangeReader;
 
-    fn get_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<Response> {
+    fn get_url(&mut self, url: &str, _status: &mut dyn StatusBackend) -> Result<Response> {
         let res = Client::new().get(url).send()?;
         if !res.status().is_success() {
             // return UnexpectedHttpResponse(index_url, res.status())
@@ -85,7 +85,7 @@ impl GetUrlBackend for ReqwestBackend {
 /// A simple way to read chunks out of a big seekable byte stream. You could
 /// implement this for io::File pretty trivially but that's not currently
 /// needed.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ReqwestRangeReader {
     url: String,
     client: Client,

--- a/crates/geturl/src/reqwest.rs
+++ b/crates/geturl/src/reqwest.rs
@@ -20,12 +20,10 @@ impl GetUrlBackend for ReqwestBackend {
     type RangeReader = ReqwestRangeReader;
 
     fn get_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<Response> {
-        let index_url = format!("{}.index.gz", url);
-        tt_note!(status, "downloading index {}", index_url);
-        let res = Client::new().get(&index_url).send()?;
+        let res = Client::new().get(url).send()?;
         if !res.status().is_success() {
             // return UnexpectedHttpResponse(index_url, res.status())
-            bail!("unexpected HTTP resonse code for URL {}", url);
+            bail!("unexpected HTTP response code for URL {}", url);
         }
         Ok(res)
     }

--- a/crates/geturl/src/reqwest.rs
+++ b/crates/geturl/src/reqwest.rs
@@ -1,6 +1,8 @@
 // Copyright 2017-2020 the Tectonic Project
 // Licensed under the MIT License.
 
+//! A URL-get backend based on the `reqwest` crate.
+
 use reqwest::{header::HeaderMap, Client, RedirectPolicy, Response, StatusCode};
 use tectonic_errors::{anyhow::bail, Result};
 use tectonic_status_base::{tt_note, StatusBackend};
@@ -9,7 +11,7 @@ use crate::{GetUrlBackend, RangeReader};
 
 const MAX_HTTP_REDIRECTS_ALLOWED: usize = 10;
 
-/// URL-get backed implemented using the `reqwest` crate.
+/// URL-get backend implemented using the `reqwest` crate.
 #[derive(Debug, Default)]
 pub struct ReqwestBackend {}
 
@@ -92,7 +94,7 @@ pub struct ReqwestRangeReader {
 }
 
 impl ReqwestRangeReader {
-    pub fn new(url: &str) -> ReqwestRangeReader {
+    fn new(url: &str) -> ReqwestRangeReader {
         ReqwestRangeReader {
             url: url.to_owned(),
             client: Client::new(),

--- a/crates/geturl/src/reqwest.rs
+++ b/crates/geturl/src/reqwest.rs
@@ -1,0 +1,122 @@
+// Copyright 2017-2020 the Tectonic Project
+// Licensed under the MIT License.
+
+use reqwest::{header::HeaderMap, Client, RedirectPolicy, Response, StatusCode};
+use tectonic_errors::{anyhow::bail, Result};
+use tectonic_status_base::{tt_note, StatusBackend};
+
+use crate::{GetUrlBackend, RangeReader};
+
+const MAX_HTTP_REDIRECTS_ALLOWED: usize = 10;
+
+/// URL-get backed implemented using the `reqwest` crate.
+#[derive(Debug, Default)]
+pub struct ReqwestBackend {}
+
+impl GetUrlBackend for ReqwestBackend {
+    type Response = Response;
+    type RangeReader = ReqwestRangeReader;
+
+    fn get_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<Response> {
+        let index_url = format!("{}.index.gz", url);
+        tt_note!(status, "downloading index {}", index_url);
+        let res = Client::new().get(&index_url).send()?;
+        if !res.status().is_success() {
+            // return UnexpectedHttpResponse(index_url, res.status())
+            bail!("unexpected HTTP resonse code for URL {}", url);
+        }
+        Ok(res)
+    }
+
+    fn resolve_url(&mut self, url: &str, status: &mut dyn StatusBackend) -> Result<String> {
+        tt_note!(status, "connecting to {}", url);
+
+        // First, we actually do a HEAD request on the URL for the data file.
+        // If it's redirected, we update our URL to follow the redirects. If
+        // we didn't do this separately, the index file would have to be the
+        // one with the redirect setup, which would be confusing and annoying.
+        let redirect_policy = RedirectPolicy::custom(|attempt| {
+            // In the process of resolving the file url it might be necessary
+            // to stop at a certain level of redirection. This might be required
+            // because some hosts might redirect to a version of the url where
+            // it isn't possible to select the index file by appending .index.gz.
+            // (This mostly happens because CDNs redirect to the file hash.)
+            if attempt.previous().len() >= MAX_HTTP_REDIRECTS_ALLOWED {
+                attempt.too_many_redirects()
+            } else if let Some(segments) = attempt.url().clone().path_segments() {
+                let follow = segments
+                    .last()
+                    .map(|file| file.contains('.'))
+                    .unwrap_or(true);
+                if follow {
+                    attempt.follow()
+                } else {
+                    attempt.stop()
+                }
+            } else {
+                attempt.follow()
+            }
+        });
+
+        let res = Client::builder()
+            .redirect(redirect_policy)
+            .build()?
+            .head(url)
+            .send()?;
+
+        if !(res.status().is_success() || res.status() == StatusCode::FOUND) {
+            //return UnexpectedHttpResponse(url.to_string(), res.status())
+            bail!("unexpected HTTP resonse code for URL {}", url);
+        }
+
+        let final_url = res.url().clone().into_string();
+        if final_url != url {
+            tt_note!(status, "resolved to {}", final_url);
+        }
+
+        Ok(final_url)
+    }
+
+    fn open_range_reader(&self, url: &str) -> Self::RangeReader {
+        ReqwestRangeReader::new(url)
+    }
+}
+
+/// A simple way to read chunks out of a big seekable byte stream. You could
+/// implement this for io::File pretty trivially but that's not currently
+/// needed.
+#[derive(Clone, Debug)]
+pub struct ReqwestRangeReader {
+    url: String,
+    client: Client,
+}
+
+impl ReqwestRangeReader {
+    pub fn new(url: &str) -> ReqwestRangeReader {
+        ReqwestRangeReader {
+            url: url.to_owned(),
+            client: Client::new(),
+        }
+    }
+}
+
+impl RangeReader for ReqwestRangeReader {
+    type Response = Response;
+
+    fn read_range(&mut self, offset: u64, length: usize) -> Result<Response> {
+        let end_inclusive = offset + length as u64 - 1;
+
+        let mut headers = HeaderMap::new();
+        use headers::HeaderMapExt;
+        headers.typed_insert(headers::Range::bytes(offset..=end_inclusive).unwrap());
+
+        let res = self.client.get(&self.url).headers(headers).send()?;
+
+        if res.status() != StatusCode::PARTIAL_CONTENT {
+            //return UnexpectedHttpResponse(self.url.clone(), res.status())
+            bail!("unexpected HTTP resonse code for URL {}", self.url);
+        }
+
+        Ok(res)
+    }
+}

--- a/dist/azure-build-and-test-pkgconfig.yml
+++ b/dist/azure-build-and-test-pkgconfig.yml
@@ -16,9 +16,15 @@ parameters:
 - name: primaryBuild
   type: boolean
   default: false
-- name: externalDeps
+- name: installAllDeps
   type: boolean
   default: false
+- name: defaultFeatures
+  type: boolean
+  default: true
+- name: explicitFeatures
+  type: string
+  default: ''
 
 steps:
 - template: azure-generic-build-setup.yml
@@ -33,7 +39,7 @@ steps:
       libssl-dev
       openssl
       zlib1g-dev"
-    if [[ $EXTERNAL_DEPS == True ]] ; then
+    if [[ $INSTALL_ALL_DEPS == True ]] ; then
       pkgs="$pkgs libharfbuzz-dev"
     fi
 
@@ -42,7 +48,7 @@ steps:
   displayName: "Install pkg-config dependencies (Ubuntu)"
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
   env:
-    EXTERNAL_DEPS: ${{ parameters.externalDeps }}  # maps to "True" or "False"
+    INSTALL_ALL_DEPS: ${{ parameters.installAllDeps }}  # maps to "True" or "False"
 
 - bash: |
     set -xeuo pipefail
@@ -53,7 +59,7 @@ steps:
       icu4c
       libpng
       openssl"
-    if [[ $EXTERNAL_DEPS == True ]] ; then
+    if [[ $INSTALL_ALL_DEPS == True ]] ; then
       pkgs="$pkgs harfbuzz"
     fi
 
@@ -65,7 +71,7 @@ steps:
   displayName: "Install pkg-config dependencies (macOS)"
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
   env:
-    EXTERNAL_DEPS: ${{ parameters.externalDeps }}
+    INSTALL_ALL_DEPS: ${{ parameters.installAllDeps }}
 
 - bash: |
     echo "##vso[task.prependpath]C:\msys64\usr\bin"
@@ -92,6 +98,7 @@ steps:
 
 - template: azure-generic-build.yml
   parameters:
-      canaryBuild: ${{ parameters.canaryBuild }}
-      primaryBuild: ${{ parameters.primaryBuild }}
-      externalDeps: ${{ parameters.externalDeps }}
+    canaryBuild: ${{ parameters.canaryBuild }}
+    primaryBuild: ${{ parameters.primaryBuild }}
+    defaultFeatures: ${{ parameters.defaultFeatures }}
+    explicitFeatures: ${{ parameters.explicitFeatures }}

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -13,6 +13,9 @@ parameters:
 - name: canaryBuild
   type: boolean
   default: false
+- name: windowsVcpkgWorkaround
+  type: boolean
+  default: false
 
 steps:
 - template: azure-generic-build-setup.yml
@@ -23,18 +26,36 @@ steps:
   displayName: "Install vcpkg dependencies (macOS)"
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
-- bash: |
-    set -xeuo pipefail
-    cargo install cargo-vcpkg
-  displayName: Install cargo-vcpkg
+- ${{ if parameters.windowsVcpkgWorkaround }}:
+  - download: current
 
-- bash: |
-    set -xeuo pipefail
-    cargo vcpkg -v build
-    ls target/vcpkg
-    echo target/vcpkg/installed/*
-    ls target/vcpkg/installed/*/lib
-  displayName: Build vcpkg deps
+  - bash: |
+      set -xeuo pipefail
+      BASH_WORKSPACE="$(Pipeline.Workspace)"
+
+      # work around https://github.com/microsoft/azure-pipelines-tasks/issues/10653
+      # (in an `if` statement for future-proofiness)
+      if [[ $AGENT_OS == Windows_NT ]] ; then
+        BASH_WORKSPACE=$(echo "$BASH_WORKSPACE" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+      fi
+
+      mkdir -p target
+      mv $BASH_WORKSPACE/vcpkg-deps-windows target/vcpkg
+    displayName: Recover vcpkg deps from artifacts
+
+- ${{ if not(parameters.windowsVcpkgWorkaround) }}:
+  - bash: |
+      set -xeuo pipefail
+      cargo install cargo-vcpkg
+    displayName: Install cargo-vcpkg
+
+  - bash: |
+      set -xeuo pipefail
+      cargo vcpkg -v build
+      ls target/vcpkg
+      echo target/vcpkg/installed/*
+      ls target/vcpkg/installed/*/lib
+    displayName: Build vcpkg deps
 
 # Note: setvariable + `set -x` adds spurious single quotes at ends of variable values
 - bash: |

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -75,4 +75,4 @@ steps:
 - template: azure-generic-build.yml
   parameters:
     canaryBuild: ${{ parameters.canaryBuild }}
-    externalDeps: true
+    explicitFeatures: "external-harfbuzz"

--- a/dist/azure-ci-cd.yml
+++ b/dist/azure-ci-cd.yml
@@ -35,7 +35,8 @@ parameters:
     vmImage: ubuntu-20.04
     params:
       canaryBuild: true
-      externalDeps: true
+      installAllDeps: true
+      explicitFeatures: "external-harfbuzz"
     vars:
       TARGET: x86_64-unknown-linux-gnu
       TOOLCHAIN: stable
@@ -44,7 +45,7 @@ parameters:
     vmImage: ubuntu-20.04
     params:
       canaryBuild: true
-      externalDeps: false
+      installAllDeps: false
     vars:
       TARGET: x86_64-unknown-linux-gnu
       TOOLCHAIN: stable
@@ -69,7 +70,7 @@ parameters:
     vmImage: macos-10.15
     params:
       canaryBuild: true
-      externalDeps: false
+      installAllDeps: false
     vars:
       TARGET: x86_64-apple-darwin
       TOOLCHAIN: stable
@@ -78,7 +79,8 @@ parameters:
     vmImage: macos-10.15
     params:
       canaryBuild: true
-      externalDeps: true
+      installAllDeps: true
+      explicitFeatures: "external-harfbuzz"
     vars:
       TARGET: x86_64-apple-darwin
       TOOLCHAIN: stable
@@ -86,7 +88,7 @@ parameters:
   - name: windows_intdeps
     vmImage: windows-2019
     params:
-      externalDeps: false
+      installAllDeps: false
     vars:
       TARGET: x86_64-pc-windows-gnu
       TOOLCHAIN: stable-x86_64-pc-windows-gnu
@@ -95,10 +97,42 @@ parameters:
     vmImage: windows-2019
     params:
       canaryBuild: true
-      externalDeps: true
+      installAllDeps: true
+      explicitFeatures: "external-harfbuzz"
     vars:
       TARGET: x86_64-pc-windows-gnu
       TOOLCHAIN: stable-x86_64-pc-windows-gnu
+
+  - name: linux_ftmtx_none
+    vmImage: ubuntu-20.04
+    params:
+      canaryBuild: true
+      installAllDeps: false
+      defaultFeatures: false
+    vars:
+      TARGET: x86_64-unknown-linux-gnu
+      TOOLCHAIN: stable
+
+  - name: linux_ftmtx_all
+    vmImage: ubuntu-20.04
+    params:
+      canaryBuild: true
+      installAllDeps: true
+      explicitFeatures: _all_
+    vars:
+      TARGET: x86_64-unknown-linux-gnu
+      TOOLCHAIN: stable
+
+  - name: linux_ftmtx_curl
+    vmImage: ubuntu-20.04
+    params:
+      canaryBuild: true
+      installAllDeps: true
+      defaultFeatures: false
+      explicitFeatures: "geturl-curl serialization"
+    vars:
+      TARGET: x86_64-unknown-linux-gnu
+      TOOLCHAIN: stable
 
 - name: vcpkgBuilds
   type: object

--- a/dist/azure-ci-cd.yml
+++ b/dist/azure-ci-cd.yml
@@ -112,7 +112,8 @@ parameters:
 
   - name: windows
     vmImage: windows-2019
-    params: {}
+    params:
+      windowsVcpkgWorkaround: true
     vars:
       TARGET: x86_64-pc-windows-msvc
       TOOLCHAIN: stable-x86_64-pc-windows-msvc
@@ -155,6 +156,8 @@ stages:
   # TODO: I think Linux/vcpkg is broken: https://github.com/mcgoo/vcpkg-rs/issues/21
   - ${{ each build in parameters.vcpkgBuilds }}:
     - job: ${{ format('build_{0}_vcpkg', build.name) }}
+      ${{ if eq(build.name, 'windows') }}:  # work around timeouts with slow builds
+        dependsOn: windows_vcpkg_prebuild
       pool:
         vmImage: ${{ build.vmImage }}
       steps:
@@ -253,6 +256,37 @@ stages:
         artifactName: book
     - bash: cd docs && ../mdbook test
       displayName: mdbook test
+
+  # Hack to build Windows vcpkg deps in their own job, because it takes so long
+  # that the Windows jobs routinely hit the 60-minute timeout.
+  - job: windows_vcpkg_prebuild
+    pool:
+      vmImage: windows-2019
+    steps:
+    - bash: cargo install cargo-vcpkg
+      displayName: Install cargo-vcpkg
+
+    - bash: |
+        set -xeuo pipefail
+        cargo vcpkg -v build
+
+        # There is something weird about buildtrees/icu/ that prevents
+        # us from easily rm -rf'ing it. Too bad because that directory
+        # is easily the largest part of the vcpkg tree.
+        rm -rf target/vcpkg/downloads
+        cd target/vcpkg/buildtrees
+        for d in * ; do
+          if [ $d != icu ] ; then
+            rm -rf $d
+          fi
+        done
+      displayName: Build vcpkg deps
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish vcpkg deps as artifact
+      inputs:
+        targetPath: 'target/vcpkg'
+        artifactName: vcpkg-deps-windows
 
 
 # If all of those succeed and we're not in a pull request, run the deployment

--- a/dist/azure-generic-build.yml
+++ b/dist/azure-generic-build.yml
@@ -16,28 +16,42 @@ parameters:
 - name: primaryBuild
   type: boolean
   default: false
-- name: externalDeps
+- name: defaultFeatures
   type: boolean
-  default: false
+  default: true
+- name: explicitFeatures
+  type: string
+  default: ''
 
 steps:
+# We use two variables for feature flagging just because I'm worried about
+# quoting the `--features` argument, which will contain spaces.
 - bash: |
-    if [[ $EXTERNAL_DEPS == True ]] ; then
-      features="external-harfbuzz"
-    else
-      features=
+    ffs=
+    fts=
+
+    if [[ $DEFAULT_FEATURES_FLAG == False ]] ; then
+      ffs="--no-default-features"
     fi
 
-    echo "Cargo features for this build: $features"
-    echo "##vso[task.setvariable variable=CARGO_FEATURES;]$features"
+    if [[ $EXPLICIT_FEATURES == _all_ ]] ; then
+      ffs="--all-features"
+    else
+      fts="$EXPLICIT_FEATURES"
+    fi
+
+    echo "Cargo features for this build: $ffs --features=\"$fts\""
+    echo "##vso[task.setvariable variable=CARGO_FEATURES_EXPLICIT;]$fts"
+    echo "##vso[task.setvariable variable=CARGO_FEATURES_FLAGS;]$ffs"
   displayName: Set feature flags
   env:
-    EXTERNAL_DEPS: ${{ parameters.externalDeps }}
+    DEFAULT_FEATURES_FLAG: ${{ parameters.defaultFeatures }}
+    EXPLICIT_FEATURES: ${{ parameters.explicitFeatures }}
 
-- bash: cargo build --all --release --features="$CARGO_FEATURES" -v
+- bash: cargo build --all --release $CARGO_FEATURES_FLAGS --features="$CARGO_FEATURES_EXPLICIT" -v
   displayName: "cargo build"
 
-- bash: cargo test --all --release --features="$CARGO_FEATURES"
+- bash: cargo test --all --release $CARGO_FEATURES_FLAGS --features="$CARGO_FEATURES_EXPLICIT"
   displayName: "cargo test"
 
 # For non-canary builds, export artifacts.

--- a/docs/src/howto/build-tectonic/index.md
+++ b/docs/src/howto/build-tectonic/index.md
@@ -103,6 +103,13 @@ control build options. Tectonic offers the following features:
   to a “vendored” (static, internal) version of the [Harfbuzz] text shaping
   library. If you would like to link to an externally-supplied version instead,
   enable this feature.
+- **`geturl-reqwest`** (enabled by default). Uses the [reqwest] crate to get
+  URLs. This is a good portable default.
+
+[reqwest]: https://docs.rs/reqwest/
+
+Some lesser-used features are:
+
 - **`serialization`** (enabled by default). Disabling this feature turns off all
   Tectonic features that require the [serde] crate. This option is provided
   because Tectonic’s use of serde requires [procedural macro][proc-macro]

--- a/docs/src/howto/build-tectonic/index.md
+++ b/docs/src/howto/build-tectonic/index.md
@@ -103,9 +103,13 @@ control build options. Tectonic offers the following features:
   to a “vendored” (static, internal) version of the [Harfbuzz] text shaping
   library. If you would like to link to an externally-supplied version instead,
   enable this feature.
+- **`geturl-curl`**. Uses the [curl] crate to get URLs. In order for this to
+  take effect, you must use `--no-default-features` because `geturl-reqwest` is
+  a default feature and it takes precedence.
 - **`geturl-reqwest`** (enabled by default). Uses the [reqwest] crate to get
   URLs. This is a good portable default.
 
+[curl]: https://docs.rs/curl/
 [reqwest]: https://docs.rs/reqwest/
 
 Some lesser-used features are:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 // src/config.rs -- configuration for the Tectonic library.
-// Copyright 2016-2018 the Tectonic Project
+// Copyright 2016-2020 the Tectonic Project
 // Licensed under the MIT License.
 
 //! User configuration settings for the Tectonic engine.
@@ -12,17 +12,22 @@
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, Ordering},
+};
+use url::Url;
 
-use crate::app_dirs;
-use crate::errors::{ErrorKind, Result};
-use crate::io::cached_itarbundle::CachedITarBundle;
-use crate::io::dirbundle::DirBundle;
-use crate::io::zipbundle::ZipBundle;
-use crate::io::Bundle;
-use crate::status::StatusBackend;
+use crate::{
+    app_dirs,
+    errors::{ErrorKind, Result},
+    io::cached_itarbundle::CachedITarBundle,
+    io::dirbundle::DirBundle,
+    io::zipbundle::ZipBundle,
+    io::Bundle,
+    status::StatusBackend,
+};
 
 /// Awesome hack time!!!
 ///
@@ -145,7 +150,6 @@ impl PersistentConfig {
         status: &mut dyn StatusBackend,
     ) -> Result<Box<dyn Bundle>> {
         use std::io;
-        use tectonic_geturl::Url;
 
         if CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst) {
             return Ok(Box::new(crate::test_util::TestBundle::default()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::File,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -69,8 +68,11 @@ impl PersistentConfig {
     /// false, the default configuration is returned and the filesystem is not
     /// modified.
     pub fn open(auto_create_config_file: bool) -> Result<PersistentConfig> {
-        use std::io::ErrorKind as IoErrorKind;
-        use std::io::{Read, Write};
+        use std::{
+            fs::File,
+            io::{ErrorKind as IoErrorKind, Read, Write},
+        };
+
         let mut cfg_path = if auto_create_config_file {
             app_dirs::user_config()?
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,8 +144,8 @@ impl PersistentConfig {
         only_cached: bool,
         status: &mut dyn StatusBackend,
     ) -> Result<Box<dyn Bundle>> {
-        use reqwest::Url;
         use std::io;
+        use tectonic_geturl::Url;
 
         if CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst) {
             return Ok(Box::new(crate::test_util::TestBundle::default()));

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,7 +9,8 @@ use std::{
     io::{self, Read, Write},
     path::{Component, Path, PathBuf},
 };
-use tectonic_geturl::{DefaultBackend, GetUrlBackend, Url};
+use tectonic_geturl::{DefaultBackend, GetUrlBackend};
+use url::Url;
 
 use crate::{
     config, ctry,

--- a/src/document.rs
+++ b/src/document.rs
@@ -3,25 +3,20 @@
 
 //! Tectonic document definitions.
 
-use reqwest::Url;
 use std::{
     collections::HashMap,
     env, fs,
     io::{self, Read, Write},
     path::{Component, Path, PathBuf},
 };
+use tectonic_geturl::{DefaultBackend, GetUrlBackend, Url};
 
 use crate::{
     config, ctry,
     driver::{OutputFormat, PassSetting, ProcessingSessionBuilder},
     errmsg,
     errors::{ErrorKind, Result},
-    io::{
-        cached_itarbundle::{resolve_url, CachedITarBundle},
-        dirbundle::DirBundle,
-        zipbundle::ZipBundle,
-        Bundle,
-    },
+    io::{cached_itarbundle::CachedITarBundle, dirbundle::DirBundle, zipbundle::ZipBundle, Bundle},
     status::StatusBackend,
     test_util, tt_error, tt_note,
     workspace::WorkspaceCreator,
@@ -156,7 +151,8 @@ impl Document {
         let bundle_loc = if config::is_config_test_mode_activated() {
             "test-bundle".to_owned()
         } else {
-            resolve_url(config.default_bundle_loc(), status)?
+            let mut gub = DefaultBackend::default();
+            gub.resolve_url(config.default_bundle_loc(), status)?
         };
 
         // All done.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,6 @@
 #![allow(deprecated)]
 
 use error_chain::error_chain;
-use reqwest::StatusCode;
 use std::{convert, ffi, io, io::Write, num, result::Result as StdResult, str};
 use tectonic_errors::Error as NewError;
 use zip::result::ZipError;
@@ -58,7 +57,6 @@ error_chain! {
         Nul(ffi::NulError);
         ParseInt(num::ParseIntError);
         Persist(tempfile::PersistError);
-        Reqwest(reqwest::Error);
         ConfigRead(ReadError);
         ConfigWrite(WriteError);
         NewStyle(NewError);
@@ -92,11 +90,6 @@ error_chain! {
         EngineError(engine: &'static str) {
             description("some engine had an unrecoverable error")
             display("the {} engine had an unrecoverable error", engine)
-        }
-
-        UnexpectedHttpResponse(url: String, status: StatusCode) {
-            description("unexpected HTTP response to URL")
-            display("unexpected HTTP response to URL {}: {}", url, status)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,16 @@
 #![allow(deprecated)]
 
 use error_chain::error_chain;
-use std::{convert, ffi, io, io::Write, num, result::Result as StdResult, str};
+use std::{
+    convert, ffi,
+    fmt::{self, Debug, Display},
+    io,
+    io::Write,
+    num,
+    result::Result as StdResult,
+    str,
+    sync::{Arc, Mutex, Weak},
+};
 use tectonic_errors::Error as NewError;
 use zip::result::ZipError;
 
@@ -19,14 +28,13 @@ cfg_if::cfg_if! {
         pub type ReadError = toml::de::Error;
         pub type WriteError = toml::ser::Error;
     } else {
-        use std::fmt::{self, Formatter, Display};
         use std::error;
 
         #[derive(Debug)]
         pub enum ReadError {}
 
         impl Display for ReadError {
-            fn fmt(&self, _fmt: &mut Formatter<'_>) -> fmt::Result {
+            fn fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
                 Ok(())
             }
         }
@@ -37,7 +45,7 @@ cfg_if::cfg_if! {
         pub enum WriteError {}
 
         impl Display for WriteError {
-            fn fmt(&self, _fmt: &mut Formatter<'_>) -> fmt::Result {
+            fn fmt(&self, _fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
                 Ok(())
             }
         }
@@ -239,11 +247,6 @@ impl<T: DefinitelySame, E: DefinitelySame> DefinitelySame for StdResult<T, E> {
 //
 // This is needed to be able to turn error_chain errors into anyhow errors,
 // since the latter requires that they are sync.
-
-use std::{
-    fmt::{self, Debug, Display},
-    sync::{Arc, Mutex, Weak},
-};
 
 pub struct SyncError<T: 'static> {
     inner: Arc<Mutex<T>>,

--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -121,7 +121,9 @@ fn get_everything(
 
     let index = {
         let mut index = String::new();
-        GzDecoder::new(backend.get_url(&url, status)?).read_to_string(&mut index)?;
+        let index_url = format!("{}.index.gz", &url);
+        tt_note!(status, "downloading index {}", index_url);
+        GzDecoder::new(backend.get_url(&index_url, status)?).read_to_string(&mut index)?;
         index
     };
 

--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -140,7 +140,7 @@ fn get_everything(
             atry!(digest_info; ["backend does not provide needed {} file", digest::DIGEST_NAME])
         };
 
-        let mut range_reader = DefaultRangeReader::new(&url);
+        let mut range_reader = backend.open_range_reader(&url);
         String::from_utf8(get_file(
             &mut range_reader,
             digest::DIGEST_NAME,
@@ -249,6 +249,7 @@ impl CachedITarBundle {
         custom_cache_root: Option<&Path>,
         status: &mut dyn StatusBackend,
     ) -> Result<CachedITarBundle> {
+        let mut backend = DefaultBackend::default();
         let digest_path = cache_dir("urls", custom_cache_root)?.join(app_dirs::sanitized(url));
 
         let redirect_base = &cache_dir("redirects", custom_cache_root)?;
@@ -264,7 +265,6 @@ impl CachedITarBundle {
                 None => {
                     // At least one of the cached files does not exists. We fetch everything from
                     // scratch and save the files.
-                    let mut backend = DefaultBackend::default();
                     let (digest_text, index, redirect_url) = get_everything(&mut backend, url, status)?;
                     let _ = DigestData::from_str(&digest_text)?;
                     checked_digest = true;
@@ -346,7 +346,7 @@ impl CachedITarBundle {
 
         // All set.
 
-        let tar_data = DefaultRangeReader::new(&redirect_url);
+        let tar_data = backend.open_range_reader(&redirect_url);
 
         Ok(CachedITarBundle {
             url: url.to_owned(),

--- a/src/io/cached_itarbundle.rs
+++ b/src/io/cached_itarbundle.rs
@@ -227,7 +227,7 @@ fn make_txt_path(base: &Path, digest_text: &str) -> PathBuf {
 }
 
 /// Bundle provided by an indexed tar file over http with a local cache.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CachedITarBundle {
     url: String,
     redirect_url: String,

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -376,6 +376,7 @@ fn stdin_content() {
     success_or_panic(output);
 }
 
+#[cfg(feature = "serialization")]
 #[test]
 fn v2_new_build() {
     util::set_test_root();
@@ -429,7 +430,7 @@ fn v2_new_build() {
 }
 
 #[test]
-#[cfg(not(windows))] // `echo` may not be available
+#[cfg(all(feature = "serialization", not(windows)))] // `echo` may not be available
 fn v2_new_build_open() {
     util::set_test_root();
 


### PR DESCRIPTION
Implementing @malbarbo's #525 with a sub-crate to isolate the HTTP backend API.

~Starting out as a draft, checking that we didn't break anything before adding the new `curl` backend.~

This will supersede #525 once it's ready.