### PR TITLE
Add open document option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1752,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "md-5",
+ "open",
  "pkg-config",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
 termcolor = "^1.1"
 toml = { version = "^0.5", optional = true }
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
+open = "1.4.0"
 
 [features]
 default = ["serialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,18 +60,18 @@ app_dirs = { version = "2", package = "app_dirs2" }
 atty = "0.2"
 byte-unit = "^4.0"
 cfg-if = "1.0"
-structopt = "0.3"
 error-chain = "^0.12"
 flate2 = { version = "^1.0.19", default-features = false, features = ["zlib"] }
 fs2 = "^0.4"
 headers = "^0.2"
 lazy_static = "^1.4"
 libc = "^0.2"
-tempfile = "^3.1"
 md-5 = "^0.9"
+open = "1.4.0"
 reqwest = "^0.9"
-sha2 = "^0.9"
 serde = { version = "^1.0", features = ["derive"], optional = true }
+sha2 = "^0.9"
+structopt = "0.3"
 tectonic_bridge_flate = { path = "crates/bridge_flate", version = "0.0.0-dev.0" }
 tectonic_bridge_freetype2 = { path = "crates/bridge_freetype2", version = "0.0.0-dev.0" }
 tectonic_bridge_graphite2 = { path = "crates/bridge_graphite2", version = "0.0.0-dev.0" }
@@ -81,10 +81,10 @@ tectonic_errors = { path = "crates/errors", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "crates/io_base", version = "0.0.0-dev.0" }
 tectonic_status_base = { path = "crates/status_base", version = "0.0.0-dev.0" }
 tectonic_xdv = { path = "crates/xdv", version = "0.0.0-dev.0" }
+tempfile = "^3.1"
 termcolor = "^1.1"
 toml = { version = "^0.5", optional = true }
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
-open = "1.4.0"
 
 [features]
 default = ["serialization"]

--- a/docs/src/v2cli/build.md
+++ b/docs/src/v2cli/build.md
@@ -16,6 +16,7 @@ tectonic -X build
   [--keep-logs]
   [--only-cached]
   [--print]
+  [--open]
 ```
 
 #### Remarks
@@ -49,3 +50,5 @@ The `--print` option (or `-p` for short) will cause the engine to print the
 regular terminal output of the TeX engine. This output is similar to, but not
 identical to, the contents of the log file. By default, this output is only
 printed if the engine encounteres a fatal error.
+
+The `--open` option will open the built document using the system handler.

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -146,6 +146,10 @@ pub struct BuildCommand {
     /// Print the engine's chatter during processing
     #[structopt(long = "print", short)]
     print_stdout: bool,
+
+    /// Open built document using system handler
+    #[structopt(long)]
+    open: bool,
 }
 
 impl BuildCommand {
@@ -159,7 +163,8 @@ impl BuildCommand {
                 .only_cached(self.only_cached)
                 .keep_intermediates(self.keep_intermediates)
                 .keep_logs(self.keep_logs)
-                .print_stdout(self.print_stdout);
+                .print_stdout(self.print_stdout)
+                .open(self.open);
             doc.build(output_name, &opts, status)?;
         }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -27,8 +27,6 @@ use crate::{
     workspace::WorkspaceCreator,
 };
 
-use tectonic_status_base::MessageKind;
-
 /// A Tectonic document.
 #[derive(Debug)]
 pub struct Document {

--- a/src/document.rs
+++ b/src/document.rs
@@ -387,17 +387,15 @@ impl Document {
                     .with_extension(match profile.target_type {
                         BuildTargetType::Pdf => "pdf",
                     });
-            status.note_highlighted("Opening ", &format!("`{}`", out_file.display()), "");
-            if open::that(&out_file).is_err() {
-                status.report(
-                    MessageKind::Error,
-                    format_args!(
-                        "Failed to open `{}` with system handler",
-                        out_file.display()
-                    ),
-                    None,
+            tt_note!(status, "opening `{}`", out_file.display());
+            if let Err(e) = open::that(&out_file) {
+                tt_error!(
+                    status,
+                    "failed to open `{}` with system handler",
+                    out_file.display();
+                    e.into()
                 )
-            };
+            }
         }
 
         result.map(|_| 0)


### PR DESCRIPTION
Fixes https://github.com/tectonic-typesetting/tectonic/issues/109

Adds the `--open` option to the `build` subcommand of the new v2 cli.