### PR TITLE
Add basic watching ability to v2 cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +239,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -410,6 +420,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,12 +469,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "embed-resource"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b2f39c0462f098c1ca4abc408f7482949bbe2ab19bca5a4419f91f69e5bccc"
+dependencies = [
+ "vswhom",
+ "winreg 0.8.0",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -522,6 +576,25 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -642,6 +715,25 @@ name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "h2"
@@ -882,6 +974,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,6 +1058,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -1070,6 +1188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.23",
+ "slab",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1303,37 @@ checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.23",
+ "mio-extras",
+ "walkdir",
  "winapi 0.3.9",
 ]
 
@@ -1559,7 +1720,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -1842,6 +2003,7 @@ dependencies = [
  "toml",
  "url",
  "vcpkg",
+ "watchexec",
  "zip",
 ]
 
@@ -1986,6 +2148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2172,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 
@@ -2431,6 +2604,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2736,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
+name = "watchexec"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbfc1fbf8116589a4bd490496235dab282e18ee5104981988ff4a2d0c510aef"
+dependencies = [
+ "clap",
+ "derive_builder",
+ "embed-resource",
+ "env_logger",
+ "glob",
+ "globset",
+ "lazy_static",
+ "log",
+ "nix",
+ "notify",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2813,15 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d107f8c6e916235c4c01cabb3e8acf7bea8ef6a63ca2e7fa0527c049badfc48c"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ tempfile = "^3.1"
 termcolor = "^1.1"
 toml = { version = "^0.5", optional = true }
 url = "^2.0"
+watchexec = "1.14.1"
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
 
 [features]

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -15,6 +15,7 @@ use tectonic::{
 };
 
 mod compile;
+mod watch;
 
 #[cfg(feature = "serialization")]
 mod v2cli;

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -4,7 +4,7 @@
 //! The "v2cli" command-line interface -- a "multitool" interface resembling
 //! Cargo, as compared to the classic "rustc-like" CLI.
 
-use std::{borrow::ToOwned, ffi::OsString, path::PathBuf, process, str::FromStr};
+use std::{ffi::OsString, path::PathBuf, process, str::FromStr};
 use structopt::{clap::AppSettings, StructOpt};
 use tectonic::{
     self,
@@ -211,13 +211,8 @@ impl WatchCommand {
         #[cfg(not(any(unix, windows)))]
         final_command.push_str(" ; echo [Finished running]");
 
-        let split_command: Vec<String> = final_command
-            .split_whitespace()
-            .map(ToOwned::to_owned)
-            .collect();
-
         let mut args = watchexec::ArgsBuilder::default();
-        args.cmd(split_command)
+        args.cmd(vec![final_command])
             .paths(vec![std::env::current_dir()?])
             .ignores(vec!["build".to_owned()]);
 

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -4,7 +4,7 @@
 //! The "v2cli" command-line interface -- a "multitool" interface resembling
 //! Cargo, as compared to the classic "rustc-like" CLI.
 
-use std::{ffi::OsString, path::PathBuf, process, str::FromStr};
+use std::{borrow::ToOwned, ffi::OsString, path::PathBuf, process, str::FromStr};
 use structopt::{clap::AppSettings, StructOpt};
 use tectonic::{
     self,
@@ -12,7 +12,7 @@ use tectonic::{
     ctry,
     errors::{Result, SyncError},
     status::{termcolor::TermcolorStatusBackend, ChatterLevel, StatusBackend},
-    tt_note,
+    tt_error, tt_note,
     workspace::{self, Workspace},
 };
 use tectonic_status_base::plain::PlainStatusBackend;
@@ -113,6 +113,10 @@ enum Commands {
     /// Run a standalone (La)TeX compilation
     Compile(crate::compile::CompileOptions),
 
+    #[structopt(name = "watch")]
+    /// Watch input files and execute commands on change
+    Watch(WatchCommand),
+
     #[structopt(name = "new")]
     /// Create a new document
     New(NewCommand),
@@ -123,6 +127,7 @@ impl Commands {
         match self {
             Commands::Build(o) => o.execute(config, status),
             Commands::Compile(o) => o.execute(config, status),
+            Commands::Watch(o) => o.execute(config, status),
             Commands::New(o) => o.execute(config, status),
         }
     }
@@ -169,6 +174,103 @@ impl BuildCommand {
         }
 
         Ok(0)
+    }
+}
+
+/// `watch`: Watch input files and execute commands on change
+#[derive(Debug, PartialEq, StructOpt)]
+pub struct WatchCommand {
+    /// Tectonic commands to execute on build [default: build]
+    #[structopt(long = "exec", short = "x")]
+    execute: Vec<String>,
+}
+
+impl WatchCommand {
+    fn execute(self, _config: PersistentConfig, status: &mut dyn StatusBackend) -> Result<i32> {
+        let mut cmds = Vec::new();
+        for x in self.execute.iter() {
+            let mut cmd = "tectonic -X ".to_owned();
+            let x = x.trim();
+            if !x.is_empty() {
+                cmd.push_str(x);
+                cmds.push(cmd)
+            }
+        }
+
+        if cmds.is_empty() {
+            cmds.push("tectonic -X build".to_owned())
+        }
+
+        let command = cmds.join(" && ");
+
+        let mut final_command = command.clone();
+        #[cfg(unix)]
+        final_command.push_str("; echo [Finished running. Exit status: $?]");
+        #[cfg(windows)]
+        final_command.push_str(" & echo [Finished running. Exit status: %ERRORLEVEL%]");
+        #[cfg(not(any(unix, windows)))]
+        final_command.push_str(" ; echo [Finished running]");
+
+        let split_command: Vec<String> = final_command
+            .split_whitespace()
+            .map(ToOwned::to_owned)
+            .collect();
+
+        let mut args = watchexec::ArgsBuilder::default();
+        args.cmd(split_command)
+            .paths(vec![std::env::current_dir()?])
+            .ignores(vec!["build".to_owned()]);
+
+        let exec_handler = watchexec::run::ExecHandler::new(args.build()?);
+        match exec_handler {
+            Err(e) => {
+                tt_error!(
+                    status,
+                    "failed to build arguments for watch ExecHandler";
+                    e.into()
+                );
+                Ok(1)
+            }
+            Ok(exec_handler) => {
+                let handler = Watcher {
+                    command,
+                    inner: exec_handler,
+                };
+                if let Err(e) = watchexec::watch(&handler) {
+                    tt_error!(status, "failed to execute watch"; e.into());
+                    Ok(1)
+                } else {
+                    Ok(0)
+                }
+            }
+        }
+    }
+}
+
+struct Watcher {
+    command: String,
+    inner: watchexec::run::ExecHandler,
+}
+
+impl watchexec::Handler for Watcher {
+    fn args(&self) -> watchexec::Args {
+        self.inner.args()
+    }
+
+    fn on_manual(&self) -> watchexec::error::Result<bool> {
+        self.start();
+        self.inner.on_manual()
+    }
+
+    fn on_update(&self, ops: &[watchexec::pathop::PathOp]) -> watchexec::error::Result<bool> {
+        self.start();
+        self.inner.on_update(ops)
+    }
+}
+
+impl Watcher {
+    fn start(&self) {
+        println!("[Running `{}`]", self.command)
     }
 }
 

--- a/src/bin/tectonic/watch.rs
+++ b/src/bin/tectonic/watch.rs
@@ -1,0 +1,45 @@
+use std::env;
+use std::path::PathBuf;
+
+pub(crate) struct Watcher {
+    pub(crate) command: String,
+    pub(crate) inner: watchexec::run::ExecHandler,
+}
+
+impl watchexec::Handler for Watcher {
+    fn args(&self) -> watchexec::Args {
+        self.inner.args()
+    }
+
+    fn on_manual(&self) -> watchexec::error::Result<bool> {
+        self.start();
+        self.inner.on_manual()
+    }
+
+    fn on_update(&self, ops: &[watchexec::pathop::PathOp]) -> watchexec::error::Result<bool> {
+        self.start();
+        self.inner.on_update(ops)
+    }
+}
+
+impl Watcher {
+    fn start(&self) {
+        println!("[Running `{}`]", self.command)
+    }
+}
+
+/// Obtain the executable name without a prefix if the executable is available in the PATH, e.g.
+/// most cases. Otherwise, use the full path e.g. in development.
+pub(crate) fn get_trimmed_exe_name() -> PathBuf {
+    let exe_name = env::current_exe().expect("Get current executable name");
+
+    let path = env::var("PATH").unwrap_or_else(|_| env::var("Path").unwrap_or_default());
+    let paths = env::split_paths(&path).collect::<Vec<_>>();
+
+    for path in paths {
+        if let Ok(p) = exe_name.strip_prefix(&path) {
+            return p.to_owned();
+        }
+    }
+    exe_name
+}


### PR DESCRIPTION
Fixes #719

This adds the `watch` subcommand, based off of `cargo-watch`. This design should allow for future addition of subcommands such as `check` or `format` which may run after or before a build stage or in place of one. It is very dumb at the moment and just watches all files in the current directory, besides the output `build` dir.

Tested that it works for me on a setup from `tectonic -X new`.

Haven't really got a good idea of how to go about testing this kind of thing but most of the work is done by the `watchexec` crate anyway.