### PR TITLE
src/document.rs: set the build date to "now"

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -330,6 +330,7 @@ impl Document {
         sess_builder
             .output_format(output_format)
             .format_name(&profile.tex_format)
+            .build_date(std::time::SystemTime::now())
             .pass(PassSetting::Default)
             .primary_input_buffer(DEFAULT_PRIMARY_INPUT)
             .tex_input_name(output_profile)


### PR DESCRIPTION
Fixes #740.

One day we should get cleverer about this and provide the option of locking in a build date in a `Tectonic.lock` file, for *true* reproducibility ... but until that day, we should use the current time.

**Edit:** Note to self ... If we start providing options to insert Git commit info, which I think we should, we should provide a way to set the date from the Git commit timestamp.