### PR TITLE
Tectonic.toml: preamble, index and postamble

### DIFF
--- a/docs/src/ref/documents.md
+++ b/docs/src/ref/documents.md
@@ -23,9 +23,10 @@ multiple documents inside a single workspace.
 [workspace]: ./workspaces.md
 
 The TeX sources are stored in a `src` subdirectory of the document root. This
-directory should contain at least three files: `index.tex`, `_preamble.tex`, and
-`_postamble.tex`. The [`build` command][cli-build] will process these
-files in the following order:
+directory should contain at least three files: `index.tex`, `_preamble.tex`,
+and `_postamble.tex`. These filenames can be changed in the
+[Tectonic.toml][tectonic-toml] configuration file. The [`build`
+command][cli-build] will process these files in the following order:
 
 1. `src/_preamble.tex`
 2. `src/index.tex`

--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -21,6 +21,9 @@ bundle = <url or filesystem path>  # the source of the TeX bundle
 name = <string>  # the output's name
 type = <"pdf">  # the output's type
 tex_format = [string]  # optional, defaults to "latex": the TeX format to use
+preamble = [string] # optional, defaults to "_preamble.tex": the preamble file to use (within `src`)
+index = [string] # optional, defaults to "index.tex": the index file to use (within `src`)
+postamble = [string] # optional, defaults to "_postamble.tex": the postamble file to use (within `src`)
 ```
 
 Unexpected items are not allowed.
@@ -68,3 +71,21 @@ which creates a [Portable Document Format][pdf] file.
 The TeX “format” of preloaded macros to use when compiling the document. The
 default is `"latex"`, corresponding to the standard LaTeX format. The exact set
 of formats that are supported will depend on the bundle that is being used.
+
+### `output.preamble`
+
+The preamble file to build the document with for this output. This defaults to
+`"_preamble.tex"` within the `src` directory. Typically this file will contain
+document setup steps.
+
+### `output.index`
+
+The index file to build the document with for this output. This defaults to
+`"index.tex"` within the `src` directory. Typically this file will contain
+the body of the document.
+
+### `output.postamble`
+
+The postamble file to build the document with for this output. This defaults to
+`"_postamble.tex"` within the `src` directory. Typically this file will contain
+document closing steps.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,6 +62,7 @@ error_chain! {
     foreign_links {
         AppDirs(app_dirs::AppDirsError);
         Io(io::Error);
+        Fmt(fmt::Error);
         Nul(ffi::NulError);
         ParseInt(num::ParseIntError);
         Persist(tempfile::PersistError);

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -505,15 +505,20 @@ fn v2_new_build_multiple_outputs() {
             .append(true)
             .open(toml_path)
             .unwrap();
-        writeln!(file, "tex_format = 'plain'").unwrap();
-        writeln!(file).unwrap();
-        writeln!(file, "[[output]]").unwrap();
-        writeln!(file, "name = 'alt'").unwrap();
-        writeln!(file, "type = 'pdf'").unwrap();
-        writeln!(file, "tex_format = 'plain'").unwrap();
-        writeln!(file, "preamble = '_preamble_alt.tex'").unwrap();
-        writeln!(file, "index = 'index_alt.tex'").unwrap();
-        writeln!(file, "postamble = '_postamble_alt.tex'").unwrap();
+        writeln!(
+            file,
+            "tex_format = 'plain'
+
+            [[output]]
+            name = 'alt'
+            type = 'pdf'
+            tex_format = 'plain'
+            preamble = '_preamble_alt.tex'
+            index = 'index_alt.tex'
+            postamble = '_postamble_alt.tex'
+            "
+        )
+        .unwrap();
     }
 
     // ... and write some files that are plain TeX.

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -481,3 +481,83 @@ fn v2_new_build_open() {
     let output = run_tectonic(&temppath, &["-X", "build", "--open"]);
     success_or_panic(output);
 }
+
+#[cfg(feature = "serialization")]
+#[test]
+fn v2_new_build_multiple_outputs() {
+    util::set_test_root();
+
+    let tempdir = setup_and_copy_files(&[]);
+    let mut temppath = tempdir.path().to_owned();
+    let output = run_tectonic(&temppath, &["-X", "new", "doc"]);
+    success_or_panic(output);
+
+    temppath.push("doc");
+
+    // To run a build in our test setup, we can only use plain TeX. So, jankily
+    // change the format ...
+
+    {
+        let mut toml_path = temppath.clone();
+        toml_path.push("Tectonic.toml");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(toml_path)
+            .unwrap();
+        writeln!(file, "tex_format = 'plain'").unwrap();
+        writeln!(file).unwrap();
+        writeln!(file, "[[output]]").unwrap();
+        writeln!(file, "name = 'alt'").unwrap();
+        writeln!(file, "type = 'pdf'").unwrap();
+        writeln!(file, "tex_format = 'plain'").unwrap();
+        writeln!(file, "preamble = '_preamble_alt.tex'").unwrap();
+        writeln!(file, "index = 'index_alt.tex'").unwrap();
+        writeln!(file, "postamble = '_postamble_alt.tex'").unwrap();
+    }
+
+    // ... and write some files that are plain TeX.
+
+    {
+        let mut path = temppath.clone();
+        path.push("src");
+
+        {
+            path.push("_preamble.tex");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file).unwrap();
+            path.pop();
+        }
+        {
+            path.push("_preamble_alt.tex");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file).unwrap();
+            path.pop();
+        }
+
+        {
+            path.push("index_alt.tex");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "Hello, alt!").unwrap();
+            path.pop();
+        }
+
+        {
+            path.push("_postamble.tex");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "\\end").unwrap();
+            path.pop();
+        }
+        {
+            path.push("_postamble_alt.tex");
+            let mut file = File::create(&path).unwrap();
+            writeln!(file, "\\end").unwrap();
+            path.pop();
+        }
+    }
+
+    // Now we can build.
+
+    let output = run_tectonic(&temppath, &["-X", "build"]);
+    success_or_panic(output);
+}


### PR DESCRIPTION
This enables the use of preamble, index and postamble keys in an output.
These get built together to form the input buffer and default to the
current defaults too.

There isn't any fancy checking here as we defer it to the latex engine.
In theory this could enable injection but I'm not aware that would be a
concern at the moment.

Fixes https://github.com/tectonic-typesetting/tectonic/issues/745
