### PR TITLE
dist/azure-coverage.yml: oh hey, let's unbreak coverage

### DIFF
--- a/dist/azure-coverage.yml
+++ b/dist/azure-coverage.yml
@@ -52,8 +52,7 @@ steps:
 
 - bash: |
     set -xeuo pipefail
-    p="$(pwd)"
-    cargo kcov --no-clean-rebuild -- --include-pattern="$p/src,$p/tectonic,$p/xdv"
+    cargo kcov --no-clean-rebuild -- --include-path="$(pwd)" --exclude-pattern=/tests/
   displayName: cargo kcov
 
 # Our "executable" test executes the actual Tectonic binary. In order to collect
@@ -62,7 +61,7 @@ steps:
 - bash: |
     set -xeuo pipefail
     p="$(pwd)"
-    export TECTONIC_EXETEST_KCOV_RUNNER="kcov --include-pattern=$p/src,$p/tectonic,$p/xdv"
+    export TECTONIC_EXETEST_KCOV_RUNNER="kcov --include-path=$(pwd) --exclude-pattern=/tests/"
     cargo test --test executable
   displayName: Special-case executable tests
 


### PR DESCRIPTION
Trying to rework the arguments that we use so that the coverage analysis will be more robust to rearrangements of the source tree.