### PR TITLE
dist/azure-deployment-setup.yml: include submodules when checking out for deployment

### DIFF
--- a/dist/arch/PKGBUILD.src.in
+++ b/dist/arch/PKGBUILD.src.in
@@ -24,12 +24,12 @@ sha512sums=('@source_sha512@')
 
 build() {
 	cd $pkgname-$pkgver
-	cargo build --release
+	cargo build --release --features external-harfbuzz
 }
 
 check() {
 	cd $pkgname-$pkgver
-	cargo test --release
+	cargo test --release --features external-harfbuzz
 }
 
 package() {

--- a/dist/azure-deployment-setup.yml
+++ b/dist/azure-deployment-setup.yml
@@ -19,6 +19,7 @@ steps:
 - download: current
 
 - checkout: self
+  submodules: true
 
 - bash: |
     set -xeuo pipefail


### PR DESCRIPTION
This is needed to get the vendored sources. This should address part of #776, I believe, although I'll need to issue a new release of `tectonic_bridge_harfbuzz` to verify.