### PR TITLE
fixes for AUR

### DIFF
--- a/dist/arch/PKGBUILD.bin.in
+++ b/dist/arch/PKGBUILD.bin.in
@@ -1,4 +1,4 @@
-# Maintainer: lmartinez-mirror <lmartinez-mirror@noreply.github.com>
+# Maintainer: Luis Martinez <luis dot martinez at tuta dot io>
 # Contributor: tectonic-deploy <sasha+tectonic@hackafe.net>
 
 # The master version of this file is maintained here:
@@ -12,9 +12,9 @@
 pkgname=tectonic-bin
 _pkgname=tectonic
 pkgver=@version@
-pkgrel=0
+pkgrel=1
 pkgdesc='Modernized, complete, self-contained TeX/LaTeX engine, powered by XeTex and TeXLive (binary release)'
-arch=('x86_64' 'armv7h')
+arch=('x86_64' 'i686' 'armv7h')
 url='https://github.com/tectonic-typesetting/tectonic'
 license=('MIT')
 depends=('fontconfig' 'harfbuzz-icu' 'openssl')
@@ -22,12 +22,14 @@ provides=('tectonic')
 conflicts=('tectonic')
 source=("https://raw.githubusercontent.com/tectonic-typesetting/tectonic/master/LICENSE")
 source_x86_64=("$_pkgname-$pkgver.tar.gz::$url/releases/download/$_pkgname%40$pkgver/$_pkgname-$pkgver-x86_64-unknown-linux-gnu.tar.gz")
+source_i686=("$_pkgname-$pkgver.tar.gz::$url/releases/download/$_pkgname%40$pkgver/$_pkgname-$pkgver-i686-unknown-linux-gnu.tar.gz")
 source_armv7h=("$_pkgname-$pkgver.tar.gz::$url/releases/download/$_pkgname%40$pkgver/$_pkgname-$pkgver-arm-unknown-linux-musleabihf.tar.gz")
 sha512sums=('5d2f16e9171ba223b0d9d12b0c022718e02b2a8738ec4a664b9eb2ca19d7b67f178f6606edd75a8201e1ab99a88937b9e4c4d01e4a3cdf0ccfedb536207db0a3')
 sha512sums_x86_64=('@x86_64_sha512@')
+sha512sums_i686=('@i686_sha512@')
 sha512sums_armv7h=('@armv7h_sha512@')
 
 package() {
   install -Dm755 tectonic -t "$pkgdir/usr/bin/"
-  install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/$_pkgname/"
+  install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
 }

--- a/dist/arch/PKGBUILD.src.in
+++ b/dist/arch/PKGBUILD.src.in
@@ -12,24 +12,24 @@
 
 pkgname=tectonic
 pkgver=@version@
-pkgrel=0
-arch=('x86_64')
+pkgrel=1
+arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 pkgdesc='Modernized, complete, self-contained TeX/LaTeX engine, powered by XeTeX and TeXLive'
 url=https://tectonic-typesetting.github.io/
 license=('MIT')
 depends=('fontconfig' 'harfbuzz-icu' 'openssl')
-makedepends=('rust' 'gcc' 'pkg-config')
+makedepends=('cargo' 'pkg-config')
 source=("$pkgname-$pkgver.tar.gz::https://crates.io/api/v1/crates/$pkgname/$pkgver/download")
 sha512sums=('@source_sha512@')
 
 build() {
 	cd $pkgname-$pkgver
-	cargo build --release --features external-harfbuzz
+	cargo build --release --locked --features external-harfbuzz
 }
 
 check() {
 	cd $pkgname-$pkgver
-	cargo test --release --features external-harfbuzz
+	cargo test --release --locked --features external-harfbuzz
 }
 
 package() {


### PR DESCRIPTION
Hi, I am the package maintainer for the binary release of tectonic on the AUR.

I looked back at the package and upstream and noticed a few things that needed fixing.

1. An email change to something that actually can receive messages 
2. `pkgrel` must always start at 1 according to [Arch package guidelines](https://wiki.archlinux.org/title/Arch_package_guidelines#Package_versioning)
3. Added new architectures to reflect the new binaries
4. The same guidelines for [Rust](https://wiki.archlinux.org/title/Rust_package_guidelines#Building) list `--locked` for building.