### PR TITLE
bridge_harfbuzz: exclude some Harfbuzz files from the Cargo package

### DIFF
--- a/crates/bridge_harfbuzz/Cargo.toml
+++ b/crates/bridge_harfbuzz/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2020 the Tectonic Project
+# Copyright 2020-2021 the Tectonic Project
 # Licensed under the MIT License.
 
 # See README.md for discussion of features (or lack thereof) in this crate.
@@ -17,6 +17,7 @@ readme = "README.md"
 license = "MIT"
 edition = "2018"
 links = "harfbuzz"
+exclude = ["/harfbuzz/docs/", "/harfbuzz/perf/", "/harfbuzz/test/"]
 
 [dependencies]
 tectonic_bridge_graphite2 = { path = "../bridge_graphite2", version = "0.0.0-dev.0" }


### PR DESCRIPTION
We need to do this to keep the crate size under the 10 MB limit. The main culprit is the test suite.

Addresses #778, hopefully.