### PR TITLE
Add a new centralized security API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ x86_64-unknown-linux-gnu = { install = ["fontconfig","freetype","harfbuzz[icu,gr
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["fontconfig","freetype","harfbuzz[icu,graphite2]"] }
 
 [package.metadata.internal_dep_versions]
-tectonic_bridge_core = "4e16bf963700aae59772a6fb223981ceaa9b5f57"
+tectonic_bridge_core = "thiscommit:2021-06-14:3sp2O1O"
 tectonic_bridge_flate = "thiscommit:2021-01-01:eer4ahL4"
 tectonic_bridge_graphite2 = "2c1ffcd702a662c003bd3d7d0ca4d169784cb6ad"
 tectonic_bridge_harfbuzz = "2c1ffcd702a662c003bd3d7d0ca4d169784cb6ad"

--- a/crates/bridge_core/README.md
+++ b/crates/bridge_core/README.md
@@ -28,6 +28,6 @@ use tectonic_bridge_core;
 
 ## Cargo features
 
-This crate does not currently provides any [Cargo features][features].
+This crate does not currently provide any [Cargo features][features].
 
 [features]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/docs/src/v2cli/build.md
+++ b/docs/src/v2cli/build.md
@@ -17,6 +17,7 @@ tectonic -X build
   [--only-cached]
   [--print]
   [--open]
+  [--untrusted]
 ```
 
 #### Remarks
@@ -52,3 +53,15 @@ identical to, the contents of the log file. By default, this output is only
 printed if the engine encounteres a fatal error.
 
 The `--open` option will open the built document using the system handler.
+
+Use the `--untrusted` option if building untrusted content. This is not the
+default because in most cases you *will* trust the document that you’re
+building, probably because you have created it yourself, and it would be very
+annoying to have to pass `--trusted` every time you build a document that uses
+shell-escape. See the security discussion in the documentation of the
+[compile](./compile.md) command for details. In actual usage, it would obviously
+be easy to forget to use this option; in cases where untrusted inputs are a
+genuine concern, we recommend setting the environment variable
+`TECTONIC_UNTRUSTED_MODE` to a non-empty value. This has the same effect as the
+`--untrusted` option. Note, however, that a hostile shell user can trivially
+clear this variable.

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -36,6 +36,7 @@ tectonic -X compile  # full form
   [--print] [-p]
   [--reruns COUNT] [-r COUNT]
   [--synctex]
+  [--untrusted]
   [--web-bundle URL] [-w]
   [-Z UNSTABLE-OPTION]
   TEXPATH
@@ -63,6 +64,27 @@ This will compile the file and create `myfile.pdf` if nothing went wrong. You
 can use an input filename of `-` to have Tectonic process standard input. (In
 this case, the output file will be named `texput.pdf`.)
 
+##### Security
+
+By default, the document is compiled in a “trusted” mode. This means that the
+calling user can request to enable certain engine features that could raise
+security concerns if used with untrusted input: the classic example of this
+being TeX's “shell-escape” functionality. These features are *not* enabled by
+default, but they can be enabled on the command line; in the case of
+shell-escape, this is done with `-Z shell-escape`.
+
+If the command-line argument `--untrusted` is provided, these features cannot be
+enabled, regardless of other settings such as `-Z shell-escape`. So if you are
+going to process untrusted input in a command-line script, as long as you make
+sure that `--untrusted` is provided, the known-dangerous features will be
+disabled.
+
+Furthermore, if the environment variable `TECTONIC_UNTRUSTED_MODE` is set to a
+non-empty value, Tectonic will behave as if `--untrusted` were specified,
+regardless of the actual command-line arguments. Setting this variable can
+provide a modest extra layer of protection if the Tectonic engine is being run
+outside of its CLI form. Keep in mind that untrusted shell scripts and the like
+can trivially defeat this by explicitly clearing the environment variable.
 
 #### Options
 
@@ -87,6 +109,7 @@ The following are the available flags.
 | `-p`  | `--print`                 | Print the engine's chatter during processing |
 | `-r`  | `--reruns <COUNT>`        | Rerun the TeX engine exactly this many times after the first |
 |       | `--synctex`               | Generate SyncTeX data |
+|       | `--untrusted`             | Input is untrusted: disable all known-insecure features |
 | `-V`  | `--version`               | Prints version information |
 | `-w`  | `--web-bundle <URL>`      | Use this URL find resource files instead of the default |
 | `-Z`  | `-Z <UNSTABLE-OPTION>`    | Activate experimental “unstable” options |
@@ -102,5 +125,5 @@ the set of unstable options is subject to change at any time.
 | `-Z continue-on-errors`  | Keep compiling even when severe errors occur |
 | `-Z min-crossrefs=<num>` | Equivalent to bibtex's `-min-crossrefs` flag. Default vaue: 2 |
 | `-Z paper-size=<spec>`   | Change the initial paper size. Default: `letter` |
-| `-Z shell-escape`        | Enable `\write18` |
+| `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
 


### PR DESCRIPTION
In the wake of adding shell-escape support, I felt like I wanted to offer a more coherent story for users to be able to control security settings. We do this with some new security settings APIs, changing the default behavior to "untrusted" mode where known problematic features are disabled.

On the user front, in the regular `tectonic` program, insecure features will still be disabled by default. You can enable, say, shell-escape with `-Z shell-escape` as before. But now there's a `--untrusted` option that overrides any other settings and prevents shell-escape from being turned on (cf. #747).

Furthermore, the security APIs are set up in a centralized fashion such that the environment variable `$TECTONIC_UNTRUSTED_MODE` will always be honored, with the same effect as `--untrusted`.

Note that in a certain sense it's not great to have `--untrusted` be an extra option, not the default, but from a usability standpoint people are going to be spending most of their time building trusted documents.