### PR TITLE
Attempt to fix the docs.rs build with CARGO_NET_OFFLINE

### DIFF
--- a/crates/bridge_core/build.rs
+++ b/crates/bridge_core/build.rs
@@ -27,6 +27,11 @@ fn main() {
 
     let mut manifest_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
 
+    // 2021 June: work around https://github.com/tectonic-typesetting/tectonic/issues/788
+    if env::var_os("DOCS_RS").is_some() {
+        env::set_var("CARGO_NET_OFFLINE", "true");
+    }
+
     cbindgen::Builder::new()
         .with_config(config)
         .with_crate(&manifest_dir)

--- a/crates/bridge_flate/build.rs
+++ b/crates/bridge_flate/build.rs
@@ -23,14 +23,10 @@ fn main() {
 
     let mut manifest_dir: PathBuf = env::var("CARGO_MANIFEST_DIR").unwrap().into();
 
-    // Experimental (2021 June): currently the build of `tectonic` on docs.rs
-    // fails because cbindgen calls `cargo metadata`, which has to hit the
-    // network because the standalone crate has not Cargo.lock file -- and
-    // docs.rs disable network access. We can't control the Cargo command line,
-    // but hopefully this environment variable will tell Cargo not to try? I
-    // don't know if Cargo will succeed this way, but I think the only way to
-    // test is to make a release and see.
-    std::env::set_var("CARGO_NET_OFFLINE", "true");
+    // 2021 June: work around https://github.com/tectonic-typesetting/tectonic/issues/788
+    if env::var_os("DOCS_RS").is_some() {
+        env::set_var("CARGO_NET_OFFLINE", "true");
+    }
 
     cbindgen::Builder::new()
         .with_config(config)

--- a/crates/engine_bibtex/build.rs
+++ b/crates/engine_bibtex/build.rs
@@ -8,6 +8,11 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let mut manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
+    // 2021 June: work around https://github.com/tectonic-typesetting/tectonic/issues/788
+    if env::var_os("DOCS_RS").is_some() {
+        env::set_var("CARGO_NET_OFFLINE", "true");
+    }
+
     // cbindgen to generate the C header from our Rust code.
 
     let mut gen_header_path: PathBuf = out_dir.clone().into();

--- a/crates/engine_xdvipdfmx/build.rs
+++ b/crates/engine_xdvipdfmx/build.rs
@@ -9,6 +9,11 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let mut manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
+    // 2021 June: work around https://github.com/tectonic-typesetting/tectonic/issues/788
+    if env::var_os("DOCS_RS").is_some() {
+        env::set_var("CARGO_NET_OFFLINE", "true");
+    }
+
     // cbindgen to generate the C header from our Rust code.
 
     let mut gen_header_path: PathBuf = out_dir.clone().into();

--- a/crates/engine_xetex/build.rs
+++ b/crates/engine_xetex/build.rs
@@ -9,6 +9,11 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let mut manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
+    // 2021 June: work around https://github.com/tectonic-typesetting/tectonic/issues/788
+    if env::var_os("DOCS_RS").is_some() {
+        env::set_var("CARGO_NET_OFFLINE", "true");
+    }
+
     // cbindgen to generate the C header from our Rust code.
 
     let mut gen_header_path: PathBuf = out_dir.clone().into();


### PR DESCRIPTION
Cf. https://github.com/tectonic-typesetting/tectonic/issues/788 . Based on my investigations, it looks like this workaround will get the main crate building on docs.rs. No way to be fully sure without making the releases and seeing what happens, though ...