### PR TITLE
Don't wrap diagnostic warnings

### DIFF
--- a/crates/engine_xetex/xetex/xetex-output.c
+++ b/crates/engine_xetex/xetex/xetex-output.c
@@ -139,16 +139,20 @@ print_raw_char(UTF16_code s, bool incr_offset)
         ttstub_output_putc(log_file, s);
         if (incr_offset)
             file_offset++;
-        if (file_offset == max_print_line)
-            print_ln();
+        if (file_offset == max_print_line) {
+            ttstub_output_putc(log_file, '\n');
+            file_offset = 0;
+        }
         break;
     case SELECTOR_TERM_ONLY:
         warn_char(s);
         ttstub_output_putc(rust_stdout, s);
         if (incr_offset)
             term_offset++;
-        if (term_offset == max_print_line)
-            print_ln();
+        if (term_offset == max_print_line) {
+            ttstub_output_putc(rust_stdout, '\n');
+            term_offset = 0;
+        }
         break;
     case SELECTOR_NO_PRINT:
         break;


### PR DESCRIPTION
The `print_ln()` calls in the original code would also output newlines to the current diagnostic. Changing it to directly print newlines fixes this issue (though interestingly, the code for the `SELECTOR_TERM_AND_LOG` already did this). This change shouldn't affect the contents of the tex log, only the nicer-looking warnings that get printed to the terminal.

Fixes #684, I think, though that issue might be referring to the actual tex log that's being printed to `rust_stdout`.