### PR TITLE
Improve biber handling by parsing the `.run.xml` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2110,7 @@ dependencies = [
  "libc",
  "md-5",
  "open",
+ "quick-xml",
  "serde",
  "sha2",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ lazy_static = "^1.4"
 libc = "^0.2"
 md-5 = "^0.9"
 open = "1.4.0"
+quick-xml = "^0.22"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 sha2 = "^0.9"
 structopt = "0.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,6 +68,7 @@ error_chain! {
         ConfigRead(ReadError);
         ConfigWrite(WriteError);
         NewStyle(NewError);
+        QuickXml(quick_xml::Error);
         Time(std::time::SystemTimeError);
         Utf8(str::Utf8Error);
         Xdv(tectonic_xdv::XdvError);

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -264,22 +264,49 @@ fn run_with_biber(args: &str, stdin: &str) -> Output {
 const BIBER_TRIGGER_TEX: &str = r#"
 % Test if we're on the second pass by seeing if the BCF already exists
 \newif\ifsecond
-\newread\rbcf
-\openin\rbcf=myfile.bcf
-\ifeof\rbcf
+\newread\r
+\openin\r=texput.bcf
+\ifeof\r
 \message{first pass}
 \secondfalse
 \else
 \message{second pass}
 \secondtrue
-\closein\rbcf
+\closein\r
 \fi
 
 % Now create BCF
-\newwrite\wbcf
-\immediate\openout\wbcf=myfile.bcf\relax
-\immediate\write\wbcf{Hello BCF file}
-\immediate\closeout\wbcf
+\newwrite\w
+\immediate\openout\w=texput.bcf\relax
+\immediate\write\w{Hello BCF file}
+\immediate\closeout\w
+
+% Now create run.xml
+\immediate\openout\w=texput.run.xml\relax
+\immediate\write\w{
+<requests version="1.0">
+    <external package="biblatex" priority="5" active="1">
+        <generic>biber</generic>
+        <cmdline>
+            <binary>biber</binary>
+            <infile>texput</infile>
+        </cmdline>
+        <input>
+            <file>texput.bcf</file>
+        </input>
+        <output>
+            <file>texput.bbl</file>
+        </output>
+        <provides type="dynamic">
+            <file>texput.bbl</file>
+        </provides>
+        <requires type="dynamic">
+            <file>texput.bcf</file>
+        </requires>
+    </external>
+</requests>
+}
+\immediate\closeout\w
 "#;
 
 #[test]


### PR DESCRIPTION
It turns out that in some cases, biber needs access to various `.bib` files that may be associated with the document build. Fortunately, the `.run.xml` file contains exactly the information we need to populate the temporary tool directly properly. We have to link in an XML parser, but so be it.

I wasn't aware of the `.run.xml` file before and we potentially could use it a lot more aggressively. We don't do that here, but the support is written to try to be future-conscious.

Addresses #796.