### PR TITLE
Improve path processing in FilesystemIo

### DIFF
--- a/crates/io_base/src/filesystem.rs
+++ b/crates/io_base/src/filesystem.rs
@@ -182,10 +182,12 @@ impl IoProvider for FilesystemIo {
         // We're essentially hiding the real path pointed to by hidden_path, including resolving
         // symlinks (i.e. 5). The way we're handling it, we'll correctly handle 1 and 2, and reject
         // both 3 and 4 (though 3 and 4 can be changes somewhat easily).
+        //
+        // I'll admit that this may be more complex than necessary, but I'm not sure how much
+        // correctness we want.
 
-        // TODO do conversion at initialisation? We would fail to block files that get created
-        // halfway through.
-        // TODO this is a lot of canonicalize calls -- is this okay?
+        // TODO do conversion at initialisation? Doing that would fail to block files that get
+        // created halfway through.
         let canon_hidden_paths: Vec<PathBuf> = self
             .hidden_input_paths
             .iter()

--- a/crates/io_base/src/filesystem.rs
+++ b/crates/io_base/src/filesystem.rs
@@ -11,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tectonic_errors::Result;
-use tectonic_status_base::StatusBackend;
+use tectonic_status_base::{tt_warning, StatusBackend};
 
 use super::{
     try_open_file, InputFeatures, InputHandle, InputOrigin, IoProvider, OpenResult, OutputHandle,
@@ -83,6 +83,7 @@ pub struct FilesystemIo {
     writes_allowed: bool,
     absolute_allowed: bool,
     hidden_input_paths: HashSet<PathBuf>,
+    reported_paths: HashSet<PathBuf>,
 }
 
 impl FilesystemIo {
@@ -98,6 +99,7 @@ impl FilesystemIo {
             writes_allowed,
             absolute_allowed,
             hidden_input_paths,
+            reported_paths: HashSet::new(),
         }
     }
 
@@ -158,7 +160,7 @@ impl IoProvider for FilesystemIo {
     fn input_open_name_with_abspath(
         &mut self,
         name: &str,
-        _status: &mut dyn StatusBackend,
+        status: &mut dyn StatusBackend,
     ) -> OpenResult<(InputHandle, Option<PathBuf>)> {
         let path = match self.construct_path(name) {
             Ok(p) => p,
@@ -216,6 +218,21 @@ impl IoProvider for FilesystemIo {
                 };
             }
         };
+
+        // Report the absolute path only if we're able to open it, since the xetex engine tries to
+        // read a lot of places.
+        //
+        // We check with the original requested name since construct_path might make relative paths
+        // into absolute paths (e.g. when self.root is absolute).
+        let name_path = Path::new(name);
+        if name_path.is_absolute() && !self.reported_paths.contains(name_path) {
+            tt_warning!(
+                status,
+                "accessing absolute path '{}'; build may not be reproducible on other systems",
+                name_path.display()
+            );
+            self.reported_paths.insert(name_path.to_owned());
+        }
 
         // Issue #754 - if you run Tectonic on an input that is located in a
         // directory containing a sub-directory named `latex`, you get a

--- a/crates/io_base/src/filesystem.rs
+++ b/crates/io_base/src/filesystem.rs
@@ -165,8 +165,18 @@ impl IoProvider for FilesystemIo {
             Err(e) => return OpenResult::Err(e),
         };
 
-        if self.hidden_input_paths.contains(&path) {
-            return OpenResult::NotAvailable;
+        if let Ok(canonical_path) = path.canonicalize() {
+            // Note: std::fs::canonicalize fails if the target doesn't exist.
+            let is_hidden = self
+                .hidden_input_paths
+                .iter()
+                .any(|p| match p.canonicalize() {
+                    Ok(p) => p == canonical_path,
+                    Err(_) => false,
+                });
+            if is_hidden {
+                return OpenResult::NotAvailable;
+            }
         }
 
         let f = match File::open(&path) {


### PR DESCRIPTION
This addresses #8 and #769 by adding path checks to `input_open_name_with_abspath`. The hidden path checking is a bit complex, but hopefully it correctly handles edge cases involving symlinks.