### PR TITLE
Support custom search directories

### DIFF
--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -764,6 +764,11 @@ impl SecuritySettings {
     pub fn allow_shell_escape(&self) -> bool {
         !self.disable_insecures
     }
+
+    /// Query whether we're allowed to specify extra paths to read files from.
+    pub fn allow_extra_search_paths(&self) -> bool {
+        !self.disable_insecures
+    }
 }
 
 impl Default for SecuritySettings {

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -126,4 +126,4 @@ the set of unstable options is subject to change at any time.
 | `-Z min-crossrefs=<num>` | Equivalent to bibtex's `-min-crossrefs` flag. Default vaue: 2 |
 | `-Z paper-size=<spec>`   | Change the initial paper size. Default: `letter` |
 | `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
-
+| `-Z search-path=<path>`  | Also look in <path> for files, like TEXINPUTS. Can be specified multiple times |

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -18,6 +18,8 @@ tectonic -X compile myfile.tex
 
 #### Usage Synopsis
 
+<!-- Keep options alphabetized -->
+
 ```sh
 tectonic -X compile  # full form
   [--bundle PATH] [-b PATH]
@@ -90,6 +92,8 @@ can trivially defeat this by explicitly clearing the environment variable.
 
 The following are the available flags.
 
+<!-- Keep alphabetized by full name: -->
+
 | Short | Full                      | Explanation                                                                                    |
 |:------|:--------------------------|:-----------------------------------------------------------------------------------------------|
 | `-b`  | `--bundle <PATH>`         | Use this Zip-format bundle file to find resource files instead of the default |
@@ -119,11 +123,13 @@ The following are the available flags.
 The following unstable options may be available. As the name aims to indicate,
 the set of unstable options is subject to change at any time.
 
+<!-- Keep alphabetized: -->
+
 | Expression               | Explanation |
 |:-------------------------|:------------|
 | `-Z help`                | List all unstable options |
 | `-Z continue-on-errors`  | Keep compiling even when severe errors occur |
 | `-Z min-crossrefs=<num>` | Equivalent to bibtex's `-min-crossrefs` flag. Default vaue: 2 |
 | `-Z paper-size=<spec>`   | Change the initial paper size. Default: `letter` |
+| `-Z search-path=<path>`  | Also look in `<path>` for files (unless `--untrusted` has been specified), like TEXINPUTS. Can be specified multiple times. |
 | `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
-| `-Z search-path=<path>`  | Also look in <path> for files (unless `--untrusted` has been specified), like TEXINPUTS. Can be specified multiple times |

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -126,4 +126,4 @@ the set of unstable options is subject to change at any time.
 | `-Z min-crossrefs=<num>` | Equivalent to bibtex's `-min-crossrefs` flag. Default vaue: 2 |
 | `-Z paper-size=<spec>`   | Change the initial paper size. Default: `letter` |
 | `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
-| `-Z search-path=<path>`  | Also look in <path> for files, like TEXINPUTS. Can be specified multiple times |
+| `-Z search-path=<path>`  | Also look in <path> for files (unless `--untrusted` has been specified), like TEXINPUTS. Can be specified multiple times |

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1071,12 +1071,18 @@ impl ProcessingSessionBuilder {
         // move this out of self to get around borrow checker issues
         let hidden_input_paths = self.hidden_input_paths;
 
-        let extra_search_paths = self
-                .unstables
+        let extra_search_paths = if self.security.allow_extra_search_paths() {
+            self.unstables
                 .extra_search_paths
                 .iter()
                 .map(|p| FilesystemIo::new(p, false, false, hidden_input_paths.clone()))
-                .collect();
+                .collect()
+        } else {
+            if !self.unstables.extra_search_paths.is_empty() {
+                tt_warning!(status, "Extra search path(s) ignored due to security");
+            }
+            Vec::new()
+        };
 
         let filesystem = FilesystemIo::new(&filesystem_root, false, true, hidden_input_paths);
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -451,7 +451,8 @@ macro_rules! bridgestate_ioprovider_cascade {
                 bridgestate_ioprovider_try!(p, $($inner)+);
             }
 
-            // extra search paths
+            // Extra search paths. This has higher priority than bundles but lower than current
+            // working dir to support the use case of overriding broken bundles (see issue #816).
             for fsio in $self.extra_search_paths.iter_mut() {
                 bridgestate_ioprovider_try!(fsio, $($inner)+);
             }

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -8,8 +8,10 @@
 //! to be reliable or very polished. In particular, many of these prevent the build from being
 //! reproducible.
 
-use crate::errmsg;
-use crate::errors::{Error, Result};
+use crate::{
+    errmsg,
+    errors::{Error, Result},
+};
 use std::default::Default;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -819,4 +819,16 @@ fn extra_search_paths() {
         "\\input 1.tex\n\\bye",
     );
     error_or_panic(&output);
+
+    let output = run_tectonic_with_stdin(
+        tempdir.path(),
+        &[
+            &fmt_arg,
+            "-",
+            "-Zsearch-path=subdirectory/content",
+            "--untrusted",
+        ],
+        "\\input 1.tex\n\\bye",
+    );
+    error_or_panic(&output);
 }

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -807,4 +807,16 @@ fn extra_search_paths() {
         "\\input 1.tex\n\\bye",
     );
     success_or_panic(&output);
+
+    let output = run_tectonic_with_stdin(
+        tempdir.path(),
+        &[
+            &fmt_arg,
+            "-",
+            "--hide=subdirectory/content/1.tex",
+            "-Zsearch-path=subdirectory/content",
+        ],
+        "\\input 1.tex\n\\bye",
+    );
+    error_or_panic(&output);
 }

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -794,3 +794,17 @@ fn shell_escape_env_override() {
 
     error_or_panic(&output);
 }
+
+/// Test that include paths work
+#[test]
+fn extra_search_paths() {
+    let fmt_arg = get_plain_format_arg();
+    let tempdir = setup_and_copy_files(&["subdirectory/content/1.tex"]);
+
+    let output = run_tectonic_with_stdin(
+        tempdir.path(),
+        &[&fmt_arg, "-", "-Zsearch-path=subdirectory/content"],
+        "\\input 1.tex\n\\bye",
+    );
+    success_or_panic(&output);
+}


### PR DESCRIPTION
This add the `-Z search-path` option, which make tectonic look in additional paths for files.

Resolves #755.

I'm not that much of a fan of that option name (maybe something like `-Zinclude` is better?), so if you have any suggestions I'm happy to change this PR.

Todo:

- [x] `--hide` support
- [x] untrusted mode support