### PR TITLE
pdf_io: prevent fallthrough when reading EXIF data

### DIFF
--- a/crates/pdf_io/pdf_io/dpx-jpegimage.c
+++ b/crates/pdf_io/pdf_io/dpx-jpegimage.c
@@ -719,6 +719,7 @@ read_APP1_Exif (struct JPEG_info *info, rust_input_handle_t handle, size_t lengt
                 res_unit = 2.54;
                 break;
             }
+            break;
         case JPEG_EXIF_TAG_RESUNIT_MS: /* PixelUnit */
             if (type != JPEG_EXIF_TYPE_BYTE || count != 1) {
                 dpx_warning("%s: Invalid data for ResolutionUnit in Exif chunk.", JPEG_DEBUG_STR);


### PR DESCRIPTION
This unintended fallthrough caused the JPEG decoder to issue a warning
when including a JPEG image.

Fixes #821.