### PR TITLE
Shell escape arg error

### DIFF
--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -61,6 +61,18 @@ impl FromStr for UnstableArg {
             })
         };
 
+        let require_no_value = |unwanted_value: Option<&str>, builtin_value: UnstableArg| {
+            if let Some(value) = unwanted_value {
+                Err(format!(
+                    "'-Z {}={}', was supplied but '-Z {}' does not take a value.",
+                    arg, value, arg
+                )
+                .into())
+            } else {
+                Ok(builtin_value)
+            }
+        };
+
         match arg {
             "help" => Ok(UnstableArg::Help),
 
@@ -76,7 +88,7 @@ impl FromStr for UnstableArg {
 
             "search-path" => require_value("path").map(|s| UnstableArg::SearchPath(s.into())),
 
-            "shell-escape" => Ok(UnstableArg::ShellEscapeEnabled),
+            "shell-escape" => require_no_value(value, UnstableArg::ShellEscapeEnabled),
 
             _ => Err(format!("Unknown unstable option '{}'", arg).into()),
         }

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -753,6 +753,22 @@ fn shell_escape() {
     success_or_panic(&output);
 }
 
+/// Initial revisions with shell-escape ignored any value specified.
+/// Rather than allow this to toggle shell-escape which won't work with old installs.
+/// Test that shell-escape=false gives an error.
+#[test]
+fn shell_escape_arg_err() {
+    let fmt_arg = get_plain_format_arg();
+    let tempdir = setup_and_copy_files(&[]);
+
+    let output = run_tectonic_with_stdin(
+        tempdir.path(),
+        &[&fmt_arg, "-", "-Zshell-escape=false"],
+        SHELL_ESCAPE_TEST_DOC,
+    );
+    error_or_panic(&output);
+}
+
 /// Test that shell-escape can be killed by command-line-option
 #[test]
 fn shell_escape_cli_override() {


### PR DESCRIPTION
This is a quick hack, to error on shell-escape if an argument is given, currently it ignores any value given via `-Z shell-escape=foo`, which means if you call `-Z shell-escape=false` it is still set to true.

Rather than try and set this up to toggle the value, since that would have backwards compatibility implications, throw an error if a value is set.

I had some troubles trying to figure out here what was needed for the errmsg! macro, and ended up hacking it to just use `Err(format!`, so that might need another iteration.

The test added in the first commit fails with the current master, and should pass by the second commit.