### PR TITLE
bundles: update the builtin URL to our new webservice

### DIFF
--- a/crates/bundles/src/lib.rs
+++ b/crates/bundles/src/lib.rs
@@ -103,13 +103,10 @@ impl<B: Bundle + ?Sized> Bundle for Box<B> {
 /// setting, so you should use that if you are in a position to do so.
 ///
 /// This URL will be embedded in the binaries that you create, which may be used
-/// for years into the future, so it needs to be durable and reliable. At the
-/// moment, the URL is hosted on `archive.org` and redirects to a web-based
-/// storage service that has changed a few times over the years. Note that
-/// `archive.org` is blocked in China, causing problems for that potential user
-/// base.
-pub const FALLBACK_BUNDLE_URL: &str =
-    "https://archive.org/services/purl/net/pkgwpub/tectonic-default";
+/// for years into the future, so it needs to be durable and reliable. We used
+/// `archive.org` for a while, but it had low-level reliability problems and was
+/// blocked in China. We now use a custom webservice.
+pub const FALLBACK_BUNDLE_URL: &str = "https://relay.fullyjustified.net/default_bundle.tar";
 
 /// Open the fallback bundle.
 ///


### PR DESCRIPTION
archive.org has been problematic because it has had low-level reliability problems and, more importantly, it is unfortunately blocked in China. I finally registered my own domain to set up a simple webservice that performs the redirection and provides a custom domain to host the bundle assets.

CC #765, #831, #832.