### PR TITLE
docs: add g++ to fedora packages list

### DIFF
--- a/docs/src/howto/build-tectonic/external-dep-install.md
+++ b/docs/src/howto/build-tectonic/external-dep-install.md
@@ -41,7 +41,7 @@ Install Tectonic’s dependencies with:
 
 ```sh
 sudo dnf install \
-  fontconfig-devel graphite2-devel harfbuzz-devel libicu-devel openssl-devel zlib-devel
+  gcc-c++ fontconfig-devel graphite2-devel harfbuzz-devel libicu-devel openssl-devel zlib-devel
 ```
 
 


### PR DESCRIPTION
Default Fedora Workstation install doesn't include a C++ compiler therefore failing the compilation stage of tectonic