### PR TITLE
Fix external tool file copy to include sub directories, fix #843

### DIFF
--- a/crates/cfg_support/src/lib.rs
+++ b/crates/cfg_support/src/lib.rs
@@ -223,7 +223,7 @@ macro_rules! target_cfg {
             {$($current)+}
         ] [
             $($rest)*
-        ]);
+        ])
     };
 
     // This rule comes next. It fires when the next un-parsed token is *not* a
@@ -242,7 +242,7 @@ macro_rules! target_cfg {
             )*
         ] [
             $($rest)*
-        ] $($current)* $tok);
+        ] $($current)* $tok)
     };
 
     // This rule fires when there are no more tokens to parse in this list. We
@@ -260,7 +260,7 @@ macro_rules! target_cfg {
                 {$($grouped)+}
             )*
             {$($current)+}
-        );
+        )
     };
 
     // Finally, these are the "toplevel" syntaxes for specific tests that can

--- a/crates/io_base/src/filesystem.rs
+++ b/crates/io_base/src/filesystem.rs
@@ -155,6 +155,7 @@ impl IoProvider for FilesystemIo {
         }
     }
 
+    #[allow(clippy::if_same_then_else)]
     fn input_open_name_with_abspath(
         &mut self,
         name: &str,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -333,8 +333,9 @@ impl BridgeState {
                 if name.contains("../") {
                     return Err(errmsg!(
                         "relative parent paths are not supported for the \
-                        external tool. Got path `{}`.", name
-                    ))
+                        external tool. Got path `{}`.",
+                        name
+                    ));
                 }
 
                 // We could try to be clever and symlink when the input file has

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -328,6 +328,15 @@ impl BridgeState {
 
         {
             for name in &read_files {
+                // If a relative parent is found in the file to open, this fn
+                // does not properly handle that. Thus, throw an error.
+                if name.contains("../") {
+                    return Err(errmsg!(
+                        "relative parent paths are not supported for the \
+                        external tool. Got path `{}`.", name
+                    ))
+                }
+
                 // We could try to be clever and symlink when the input file has
                 // an abspath or something, but ... meh.
                 let mut ih = self.input_open_name(name, status).must_exist()?;

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -335,7 +335,7 @@ impl BridgeState {
                 let tool_path = tempdir.path().join(name);
                 let tool_parent = tool_path.parent().unwrap();
 
-                if tool_parent != tempdir.path() && !tool_parent.exists() {
+                if tool_parent != tempdir.path() {
                     ctry!(
                         std::fs::create_dir_all(&tool_parent);
                         "failed to create sub directory `{}`", tool_parent.display()

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -333,6 +333,14 @@ impl BridgeState {
                 let mut ih = self.input_open_name(name, status).must_exist()?;
 
                 let tool_path = tempdir.path().join(name);
+                let tool_parent = tool_path.parent().unwrap();
+
+                if tool_parent != tempdir.path() && !tool_parent.exists() {
+                    ctry!(
+                        std::fs::create_dir_all(&tool_parent);
+                        "failed to create sub directory `{}`", tool_parent.display()
+                    );
+                }
                 let mut f = ctry!(
                     File::create(&tool_path);
                     "failed to create file `{}`", tool_path.display()

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -279,7 +279,7 @@ fn bad_outfmt_1() {
 
 fn run_with_biber(args: &str, stdin: &str) -> Output {
     let fmt_arg = get_plain_format_arg();
-    let tempdir = setup_and_copy_files(&[]);
+    let tempdir = setup_and_copy_files(&["subdirectory/empty.bib"]);
     let mut command = prep_tectonic(tempdir.path(), &[&fmt_arg, "-"]);
 
     let test_cmd = if cfg!(windows) {
@@ -350,6 +350,9 @@ const BIBER_TRIGGER_TEX: &str = r#"
         </provides>
         <requires type="dynamic">
             <file>texput.bcf</file>
+        </requires>
+        <requires type="editable">
+            <file>subdirectory/empty.bib</file>
         </requires>
     </external>
 </requests>


### PR DESCRIPTION
Fixes files used for external tools not being copied if they are located in sub directories (#843). This is done by checking the file directory against the temp directory. If they do not match, `std::fs::create_dir_all()` is used to create the directory structure for the file.

I would love to get some feedback on this implementation. Is it a decent implementation?, is it "rust-like"?, what can I change?, et cetera. It is my first time writing some rust, so I have no clue ;).