### PR TITLE
Updating Arch Linux packages

### DIFF
--- a/crates/xdv/src/lib.rs
+++ b/crates/xdv/src/lib.rs
@@ -250,11 +250,7 @@ impl<T: XdvEvents> XdvParser<T> {
             if n_in_buffer != 0 && n_consumed == 0 {
                 // We're going to need a bigger buffer in order to handle whatever
                 // we're reading. Let's double it.
-                let len = buf.len();
-                buf.reserve(len);
-                unsafe {
-                    buf.set_len(2 * len);
-                }
+                buf.resize(2 * buf.len(), 0);
             }
 
             if n_read == 0 {

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -84,9 +84,9 @@ $ sudo pacman -S tectonic
 and [tectonic-git][arch-tectonic-git] from the [AUR].
 
 [Arch Linux]: https://archlinux.org/
-[arch-tectonic]: https://aur.archlinux.org/packages/tectonic-bin/
+[arch-tectonic]: https://archlinux.org/packages/community/x86_64/tectonic/
 [AUR]: https://aur.archlinux.org/
-[arch-tectonic-git]: https://aur.archlinux.org/packages/tectonic/
+[arch-tectonic-git]: https://aur.archlinux.org/packages/tectonic-git
 
 ### Homebrew
 

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -77,15 +77,16 @@ $ conda install -c conda-forge tectonic
 
 ### Arch Linux
 
-For users of [Arch Linux], there are two Tectonic packages available. The
-[tectonic-bin][arch-tectonic-bin] package on [AUR] provides actual pre-compiled
-binaries, while the [tectonic][arch-tectonic] will build the binary on your
-machine, which may take a while.
+For users of [Arch Linux], there are two Tectonic packages available: [tectonic][arch-tectonic] from the official repositories, which can be installed with
+```sh
+$ sudo pacman -S tectonic
+```
+and [tectonic-git][arch-tectonic-git] from the [AUR].
 
 [Arch Linux]: https://archlinux.org/
-[arch-tectonic-bin]: https://aur.archlinux.org/packages/tectonic-bin/
+[arch-tectonic]: https://aur.archlinux.org/packages/tectonic-bin/
 [AUR]: https://aur.archlinux.org/
-[arch-tectonic]: https://aur.archlinux.org/packages/tectonic/
+[arch-tectonic-git]: https://aur.archlinux.org/packages/tectonic/
 
 ### Homebrew
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1550,7 +1550,7 @@ impl ProcessingSession {
             status.note_highlighted(
                 "Writing ",
                 &format!("`{}`", real_path.display()),
-                &format!(" ({})", byte_len.get_appropriate_unit(true).to_string()),
+                &format!(" ({})", byte_len.get_appropriate_unit(true)),
             );
 
             let mut f = File::create(&real_path)?;


### PR DESCRIPTION
Now tectonic is available in the official repos, and tectonic-bin from the AUR is not available anymore, from the AUR only tectonic-git.