### PR TITLE
Avoid using patched Pinot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,8 +1770,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinot"
-version = "0.1.3"
-source = "git+https://github.com/tectonic-typesetting/pinot?branch=basic-math#f93bac061c59a6efab309b43eb893bf041c93ee1"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3ae90d2484923177d7f6157cf88d025e8ff0b802932fe2d7431dd2ce03f08f"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,9 +89,6 @@ url = "^2.0"
 watchexec = "^1.15.3"
 zip = { version = "^0.5", default-features = false, features = ["deflate"] }
 
-[patch.crates-io]
-pinot = { git = 'https://github.com/tectonic-typesetting/pinot', branch = 'basic-math' }
-
 [features]
 default = ["geturl-reqwest", "serialization"]
 
@@ -142,7 +139,7 @@ tectonic_cfg_support = "thiscommit:aeRoo7oa"
 tectonic_dep_support = "5faf4205bdd3d31101b749fc32857dd746f9e5bc"
 tectonic_docmodel = "thiscommit:2022-02-20:2SpEl4c"
 tectonic_engine_bibtex = "thiscommit:2021-01-17:KuhaeG1e"
-tectonic_engine_spx2html = "thiscommit:2022-03-01:lfIdfFH"
+tectonic_engine_spx2html = "thiscommit:2022-03-02:IQWAncv"
 tectonic_engine_xdvipdfmx = "7dcbc52e58f9774b3d592919a9105377faeac509"
 tectonic_engine_xetex = "thiscommit:2022-02-20:J4dXT3x"
 tectonic_errors = "317ae79ceaa2593fb56090e37bf1f5cc24213dd9"

--- a/crates/engine_spx2html/Cargo.toml
+++ b/crates/engine_spx2html/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 [dependencies]
 byteorder = "^1.4"
 percent-encoding = "^2.1"
-pinot = "^0.1"
+pinot = "^0.1.4"
 tectonic_bridge_core = { path = "../bridge_core", version = "0.0.0-dev.0" }
 tectonic_errors = { path = "../errors", version = "0.0.0-dev.0" }
 tectonic_io_base = { path = "../io_base", version = "0.0.0-dev.0" }
@@ -28,12 +28,6 @@ tectonic_status_base = { path = "../status_base", version = "0.0.0-dev.0" }
 tectonic_xdv = { path = "../xdv", version = "0.0.0-dev.0" }
 tempfile = "^3.1"
 tera = "^1.13"
-
-# This statement currently (2022 Mar) leads to a warning on every Cargo invocation,
-# but I think that is needed for `cargo install tectonic` to work with released
-# packages: https://github.com/rust-lang/cargo/issues/10440 :-(
-[patch.crates-io]
-pinot = { git = 'https://github.com/tectonic-typesetting/pinot', branch = 'basic-math' }
 
 [package.metadata.internal_dep_versions]
 tectonic_bridge_core = "4e16bf963700aae59772a6fb223981ceaa9b5f57"


### PR DESCRIPTION
OK, based on feedback, I think we have to temporarily stop using the patched Pinot.

The first version of this PR should fail with a new CI test that aims to catch the issue that I encountered.