### PR TITLE
Warn on attempted pipe inputs

### DIFF
--- a/crates/engine_xetex/xetex/xetex-io.c
+++ b/crates/engine_xetex/xetex/xetex-io.c
@@ -24,10 +24,21 @@ tt_xetex_open_input (int filefmt)
 {
     rust_input_handle_t handle;
 
-    if (filefmt == TTBC_FILE_FORMAT_TECTONIC_PRIMARY)
+    if (filefmt == TTBC_FILE_FORMAT_TECTONIC_PRIMARY) {
         handle = ttstub_input_open_primary ();
-    else
+    } else if (name_of_file[0] == '|') {
+        // Tectonic TODO: issue #859. In mainline XeTeX, a pipe symbol indicates
+        // piped input from an external command via `popen()`. Now that we have
+        // shell-escape support we could also support this, but we don't have a
+        // real implementation yet. For now, issue a warning.
+        print_nl_cstr("Warning: ");
+        diagnostic_begin_capture_warning_here();
+        print_cstr("piped inputs from external commands are not implemented in Tectonic");
+        capture_to_diagnostic(NULL);
+        return NULL;
+    } else {
         handle = ttstub_input_open (name_of_file, (ttbc_file_format) filefmt, 0);
+    }
 
     if (handle == NULL)
         return NULL;

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -289,6 +289,13 @@ fn pdfoutput() {
 }
 
 #[test]
+fn pipe_input() {
+    TestCase::new("pipe_input")
+        .expect_msg("failed to open input file \"|pipeproblems\"")
+        .go()
+}
+
+#[test]
 fn png_formats() {
     TestCase::new("png_formats").check_pdf(true).go()
 }

--- a/tests/tex-outputs/pipe_input.log
+++ b/tests/tex-outputs/pipe_input.log
@@ -1,0 +1,3 @@
+**
+(pipe_input.tex
+Warning: piped inputs from external commands are not implemented in Tectonic

--- a/tests/tex-outputs/pipe_input.tex
+++ b/tests/tex-outputs/pipe_input.tex
@@ -1,0 +1,2 @@
+\input{|pipeproblems}
+\end


### PR DESCRIPTION
I've been looking into #859 a bit. Unfortunately I don't see a super convenient way to "defuse" pipe input opens in the engine. Or, with a bit more work we *could* treat pipe opens as if they were accessing `/dev/null`, but the LaTeX3 code that's causing us problems still fails if we do so, so we're going to need to patch up the bundle anyway.

So for now, let's just add a warning message and figure out how we're going to patch the bundle.