### PR TITLE
Add shell escape working directory option

### DIFF
--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -229,7 +229,6 @@ pub struct OutputProfile {
     ///
     /// Directory is not managed and any files created in it will not be deleted.
     ///
-    /// Only meaningful when shell_escape = true.
     pub shell_escape_cwd: Option<String>,
 }
 

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -221,6 +221,16 @@ pub struct OutputProfile {
     /// shell-escape opens enormous security holes. It should only ever be
     /// activated with fully trusted input.
     pub shell_escape: bool,
+
+    /// Directory to use as the cwd for shell escaped execution.
+    ///
+    /// Setting this to $(pwd) gives the same relative path shell-escape behaviour
+    /// (e.g. for \inputminted), as other engines, such as xelatex
+    ///
+    /// Directory is not managed and any files created in it will not be deleted.
+    ///
+    /// Only meaningful when shell_escape = true.
+    pub shell_escape_cwd: Option<String>,
 }
 
 /// The output target type of a document build.
@@ -295,6 +305,7 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
             index_file: DEFAULT_INDEX_FILE.to_owned(),
             postamble_file: DEFAULT_POSTAMBLE_FILE.to_owned(),
             shell_escape: false,
+            shell_escape_cwd: None,
         },
     );
     outputs
@@ -335,6 +346,7 @@ mod syntax {
         #[serde(rename = "postamble")]
         pub postamble_file: Option<String>,
         pub shell_escape: Option<bool>,
+        pub shell_escape_cwd: Option<String>,
     }
 
     impl OutputProfile {
@@ -364,6 +376,7 @@ mod syntax {
             };
 
             let shell_escape = if !rt.shell_escape { None } else { Some(true) };
+            let shell_escape_cwd = rt.shell_escape_cwd.clone();
 
             OutputProfile {
                 name: rt.name.clone(),
@@ -373,6 +386,7 @@ mod syntax {
                 index_file,
                 postamble_file,
                 shell_escape,
+                shell_escape_cwd,
             }
         }
 
@@ -399,6 +413,7 @@ mod syntax {
                     .clone()
                     .unwrap_or_else(|| DEFAULT_POSTAMBLE_FILE.to_owned()),
                 shell_escape: self.shell_escape.unwrap_or_default(),
+                shell_escape_cwd: self.shell_escape_cwd.clone(),
             }
         }
     }

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -133,3 +133,4 @@ the set of unstable options is subject to change at any time.
 | `-Z paper-size=<spec>`   | Change the initial paper size. Default: `letter` |
 | `-Z search-path=<path>`  | Also look in `<path>` for files (unless `--untrusted` has been specified), like TEXINPUTS. Can be specified multiple times. |
 | `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
+| `-Z shell-escape-cwd=<path>` | Working directory to use for \write18. Use $(pwd) for same behaviour as most other engines (e.g. for relative paths in \inputminted). Implies -Z shell-escape |

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -164,7 +164,11 @@ impl DocumentExt for Document {
 
         if profile.shell_escape {
             // For now, this is the only option we allow.
-            sess_builder.shell_escape_with_temp_dir();
+            if let Some(cwd) = &profile.shell_escape_cwd {
+                sess_builder.shell_escape_with_work_dir(cwd);
+            } else {
+                sess_builder.shell_escape_with_temp_dir();
+            }
         }
 
         if setup_options.only_cached {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1159,7 +1159,9 @@ impl ProcessingSessionBuilder {
         } else {
             match self.shell_escape_mode {
                 ShellEscapeMode::Defaulted => {
-                    if self.unstables.shell_escape {
+                    if let Some(ref cwd) = self.unstables.shell_escape_cwd {
+                        ShellEscapeMode::ExternallyManagedDir(cwd.into())
+                    } else if self.unstables.shell_escape {
                         ShellEscapeMode::TempDir
                     } else {
                         ShellEscapeMode::Disabled

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -26,6 +26,9 @@ const HELPMSG: &str = r#"Available unstable options:
     -Z search-path=<path>       Also look in <path> for files, like TEXINPUTS. Can be specified
                                     multiple times.
     -Z shell-escape             Enable \write18
+    -Z shell-escape-cwd         Working directory to use for \write18. Use $(pwd) for same behaviour as
+                                    most other engines (e.g. for relative paths in \inputminted).
+                                    Implies -Z shell-escape
 "#;
 
 // Each entry of this should correspond to a field of UnstableOptions.

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -37,6 +37,7 @@ pub enum UnstableArg {
     PaperSize(String),
     SearchPath(PathBuf),
     ShellEscapeEnabled,
+    ShellEscapeCwd(String),
 }
 
 impl FromStr for UnstableArg {
@@ -90,6 +91,10 @@ impl FromStr for UnstableArg {
 
             "shell-escape" => require_no_value(value, UnstableArg::ShellEscapeEnabled),
 
+            "shell-escape-cwd" => {
+                require_value("path").map(|s| UnstableArg::ShellEscapeCwd(s.to_string()))
+            }
+
             _ => Err(format!("Unknown unstable option '{}'", arg).into()),
         }
     }
@@ -102,6 +107,7 @@ pub struct UnstableOptions {
     pub shell_escape: bool,
     pub min_crossrefs: Option<i32>,
     pub extra_search_paths: Vec<PathBuf>,
+    pub shell_escape_cwd: Option<String>,
 }
 
 impl UnstableOptions {
@@ -123,6 +129,7 @@ impl UnstableOptions {
                 PaperSize(size) => opts.paper_size = Some(size),
                 ShellEscapeEnabled => opts.shell_escape = true,
                 SearchPath(p) => opts.extra_search_paths.push(p),
+                ShellEscapeCwd(p) => opts.shell_escape_cwd = Some(p),
             }
         }
 

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -129,7 +129,10 @@ impl UnstableOptions {
                 PaperSize(size) => opts.paper_size = Some(size),
                 ShellEscapeEnabled => opts.shell_escape = true,
                 SearchPath(p) => opts.extra_search_paths.push(p),
-                ShellEscapeCwd(p) => opts.shell_escape_cwd = Some(p),
+                ShellEscapeCwd(p) => {
+                    opts.shell_escape_cwd = Some(p);
+                    opts.shell_escape = true;
+                }
             }
         }
 

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use std::collections::HashSet;
-use std::fs::File;
 use std::path::Path;
 use std::time;
 
@@ -15,7 +14,6 @@ use tectonic::{TexEngine, XdvipdfmxEngine};
 use tectonic_bridge_core::{CoreBridgeLauncher, MinimalDriver};
 use tectonic_errors::{anyhow::anyhow, Result};
 use tectonic_status_base::NoopStatusBackend;
-use tempfile::TempDir;
 
 #[path = "util/mod.rs"]
 mod util;

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -14,6 +14,7 @@ use tectonic::{TexEngine, XdvipdfmxEngine};
 use tectonic_bridge_core::{CoreBridgeLauncher, MinimalDriver};
 use tectonic_errors::{anyhow::anyhow, Result};
 use tectonic_status_base::NoopStatusBackend;
+use tempfile::TempDir;
 
 #[path = "util/mod.rs"]
 mod util;
@@ -261,6 +262,21 @@ fn shell_escape() {
         ..Default::default()
     };
     TestCase::new("shell_escape")
+        .with_unstables(unstables)
+        .check_pdf(true)
+        .go()
+}
+
+#[test]
+fn shell_escape_cwd() {
+    let tmpdir = TempDir::new().unwrap();
+    let tmppath = Some(tmpdir.into_path().into_os_string().into_string().unwrap());
+    let unstables = tectonic::unstable_opts::UnstableOptions {
+        shell_escape: true,
+        shell_escape_cwd: tmppath,
+        ..Default::default()
+    };
+    TestCase::new("shell_escape_cwd")
         .with_unstables(unstables)
         .check_pdf(true)
         .go()

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use std::collections::HashSet;
+use std::fs::File;
 use std::path::Path;
 use std::time;
 
@@ -262,21 +263,6 @@ fn shell_escape() {
         ..Default::default()
     };
     TestCase::new("shell_escape")
-        .with_unstables(unstables)
-        .check_pdf(true)
-        .go()
-}
-
-#[test]
-fn shell_escape_cwd() {
-    let tmpdir = TempDir::new().unwrap();
-    let tmppath = Some(tmpdir.into_path().into_os_string().into_string().unwrap());
-    let unstables = tectonic::unstable_opts::UnstableOptions {
-        shell_escape: true,
-        shell_escape_cwd: tmppath,
-        ..Default::default()
-    };
-    TestCase::new("shell_escape_cwd")
         .with_unstables(unstables)
         .check_pdf(true)
         .go()


### PR DESCRIPTION
Hi

This adds support for a `-Z shell-escape-cwd=<dir>` which sets a working directory for `shell-escape` (`-Z shell-escape-cwd=$(pwd)` gives essentially the "normal" behaviour of engines for `shell-escape`). This allows using stuff like `\inputminted` (see: #835) to work the same as with other engines.

I have tested this by hand for my own use-case (#835) and it seems to work. I have not tested the toml format (because I don't use the v2 interface and couldn't get it working). I couldn't get a unit test case for it working properly though, if I run `tectonic` normally `\write18{pwd > file}` will work and send `pwd` to `file`, but when run as part of the tests it wouldn't do anything, even if I gave it an absolute path. If a test case for this is needed, I'd appreciate some pointers as to what the issue could be.

fixes: #835 