### PR TITLE
Use the value of the continue-on-errors option

### DIFF
--- a/crates/engine_xetex/src/lib.rs
+++ b/crates/engine_xetex/src/lib.rs
@@ -191,37 +191,30 @@ impl TexEngine {
             // Note that we have to do all of this setup while holding the
             // lock, because we're modifying static state variables.
 
-            let v = if self.shell_escape_enabled { 1 } else { 0 };
-            unsafe {
-                c_api::tt_xetex_set_int_variable(b"shell_escape_enabled\0".as_ptr() as _, v);
-            }
-
-            let v = if self.halt_on_error { 1 } else { 0 };
-            unsafe {
-                c_api::tt_xetex_set_int_variable(b"halt_on_error_p\0".as_ptr() as _, v);
-            }
-
-            let v = if self.initex_mode { 1 } else { 0 };
-            unsafe {
-                c_api::tt_xetex_set_int_variable(b"in_initex_mode\0".as_ptr() as _, v);
-            }
-
-            let v = if self.synctex_enabled { 1 } else { 0 };
-            unsafe {
-                c_api::tt_xetex_set_int_variable(b"synctex_enabled\0".as_ptr() as _, v);
-            }
-
-            let v = if self.semantic_pagination_enabled {
-                1
-            } else {
-                0
-            };
-            unsafe {
-                c_api::tt_xetex_set_int_variable(b"semantic_pagination_enabled\0".as_ptr() as _, v);
-            }
-
             let r = unsafe {
-                c_api::tt_engine_xetex_main(
+                use c_api::*;
+                tt_xetex_set_int_variable(
+                    b"shell_escape_enabled\0".as_ptr() as _,
+                    self.shell_escape_enabled.into(),
+                );
+                tt_xetex_set_int_variable(
+                    b"halt_on_error_p\0".as_ptr() as _,
+                    self.halt_on_error.into(),
+                );
+                tt_xetex_set_int_variable(
+                    b"in_initex_mode\0".as_ptr() as _,
+                    self.initex_mode.into(),
+                );
+                tt_xetex_set_int_variable(
+                    b"synctex_enabled\0".as_ptr() as _,
+                    self.synctex_enabled.into(),
+                );
+                tt_xetex_set_int_variable(
+                    b"semantic_pagination_enabled\0".as_ptr() as _,
+                    self.semantic_pagination_enabled.into(),
+                );
+
+                tt_engine_xetex_main(
                     state,
                     cformat.as_ptr(),
                     cinput.as_ptr(),

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1780,7 +1780,7 @@ impl ProcessingSession {
                 CoreBridgeLauncher::new_with_security(&mut self.bs, status, self.security.clone());
 
             TexEngine::default()
-                .halt_on_error_mode(true)
+                .halt_on_error_mode(!self.unstables.continue_on_errors)
                 .initex_mode(self.output_format == OutputFormat::Format)
                 .synctex(self.synctex_enabled)
                 .semantic_pagination(self.output_format == OutputFormat::Html)


### PR DESCRIPTION
The actual effect of the continue-on-errors option probably got lost in refactoring, see https://github.com/tectonic-typesetting/tectonic/issues/916.

A bit off topic: While investigeting, using [`into()` for `bool` to `c_int` in `xetex_engine`](https://github.com/tectonic-typesetting/tectonic/commit/bda8f7e1ec82a185bbbac55d5ddd4fd4d185eec4) popped into my mind, but I am not sure if it is actually an improvement, so I left it out of this PR. It seems to me that both my "compaction" and the previous version assume that `libc::c_int == i32`, which is mostly true, I am not sure it is a problem we should worry about.

