### PR TITLE
Update book to recommend the drop-in installers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "app_dirs2"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d4e5e514a351fca663170f5f648ee564b0f7e4fe76ec7097b35c926b5ebd71"
+checksum = "47a8d2d8dbda5fca0a522259fb88e4f55d2b10ad39f5f03adeebf85031eba501"
 dependencies = [
  "jni",
  "ndk-context",
@@ -406,12 +406,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -895,7 +894,7 @@ dependencies = [
  "http 0.2.8",
  "indexmap",
  "slab",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-util",
  "tracing",
 ]
@@ -1061,7 +1060,7 @@ dependencies = [
  "itoa 1.0.3",
  "pin-project-lite",
  "socket2",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -1076,20 +1075,19 @@ dependencies = [
  "bytes 1.2.1",
  "hyper 0.14.20",
  "native-tls",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-native-tls",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a0714f28b1ee39ccec0770ccb544eb02c9ef2c82bb096230eefcffa6468b0"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -1116,7 +1114,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b287fb45c60bb826a0dc68ff08742b9d88a2fea13d6e0c286b3172065aaf878c"
 dependencies = [
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils 0.8.12",
  "globset",
  "lazy_static",
  "log",
@@ -1247,9 +1245,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libz-sys"
@@ -1546,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1574,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1615,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -1676,9 +1674,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1686,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1696,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1709,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
  "once_cell",
  "pest",
@@ -1851,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2011,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.2.1",
@@ -2027,16 +2025,16 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-native-tls",
  "tower-service",
  "url",
@@ -2132,18 +2130,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2299,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2592,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4685e72cb35f0eb74319c8fe2d3b61e93da5609841cde2cb87fcc3bea56d20"
+checksum = "3df578c295f9ec044ff1c829daf31bb7581d5b3c2a7a3d87419afe1f2531438c"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2645,18 +2643,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2724,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes 1.2.1",
@@ -2734,7 +2732,6 @@ dependencies = [
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "winapi 0.3.9",
@@ -2811,7 +2808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -2929,7 +2926,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tracing",
 ]
 

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -12,35 +12,50 @@ makes Tectonic super easy to install.
 
 [TeXLive]: https://www.tug.org/texlive/acquire-netinstall.html
 
-The quickest way to get started is to [download the latest release][gh-latest]
-from GitHub, or to [install a packaged version][inst-packaged] if one is
-available. If you’d like to see detailed instructions, go to the [How To Install
-Tectonic][inst-ref] guide. But the short version of the GitHub approach is that
-you should:
+The quickest way to get started is to using your terminal. On a
+computer running a Unix-like operating system, including macOS, just run the
+following command in your terminal:
 
-1. Click through to the most recent non-preview release
-2. Download the `.tar.gz` or `.zip` file that corresponds to your computer’s
-   operating system and CPU type
-3. Unpack that archive to obtain the `tectonic` executable file. (Or,
-   `tectonic.exe` on Windows.)
-4. Put that file in the appropriate location so that you can easily run it from
-   your computer’s command prompt.
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net |sh
+```
 
-[gh-latest]: https://tectonic-typesetting.github.io/latest.html
+This will download the `tectonic` program and place it into the directory where
+you ran the command.
+
+On Windows, copy-paste this into a PowerShell window, which will unpack
+`tectonic.exe` for you:
+
+```ps1
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://drop-ps1.fullyjustified.net'))
+```
+
+No matter your operating system, you should move the unpacked file into a
+directory in your executable search path so that you can run Tectonic from any
+working directory. For the time being, the download script doesn’t do this
+because it can be tricky to automatically determine what the best installation
+destination would be.
+
+Alternatively, you can to [install a packaged version of
+Tectonic][inst-packaged] if one is available. For detailed instructions and
+additional installation options, go to the [How To Install Tectonic][inst-ref]
+guide.
+
 [inst-packaged]: ../installation/index.md#pre-built-binary-packages
 [inst-ref]: ../installation/index.md
 
-That’s all there is to it! You’ll know that you’re set up when you can go to
-your computer’s command prompt and run:
+You’ll know that you’re set up when you can go to your computer’s command prompt
+and run:
 
 ```sh
 $ tectonic --help
 ```
 
 and the result is that you get a printout of information about different options
-and arguments that you can pass to the Tectonic program. (Here and elsewhere
-we’ll use a convention of a leading `$` to indicate a command that you should
-run at your computer’s command prompt. You don’t type the dollar sign itself.)
+and arguments that you can pass to the Tectonic program. (From now on we’ll use
+a convention of a leading `$` to indicate a command that you should run at your
+computer’s command prompt. You don’t type the dollar sign itself.)
 
 To be explicit, *Tectonic does not invoke an external `latex` program, and
 Tectonic is not a “wrapper” for (La)TeX.* Tectonic *is* the LaTeX program. This

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -5,22 +5,51 @@ stack is that all of Tectonic’s functionality is delivered in a single
 executable file — not the usual tree of thousands of interlocking data files and
 binary tools.
 
-***Know what you want? [Download the latest pre-built Tectonic binaries
-here][gh-latest].***
-
 You have several options for obtaining the Tectonic executable. The best choice
 depends on your computing environment and your needs.
 
+- **For the fastest and easiest installation, [copy-paste a command into your
+  terminal](#copy-paste-a-terminal-command)** that will automatically download
+  the right Tectonic program for your computer
 - [Direct download](#direct-download) a Tectonic release
 - [Pre-built binary packages](#pre-built-binary-packages) for your favorite
   operating system or package manager
 - [Compile it yourself](#compile-tectonic-yourself)
 
-The [direct download](#direct-download) method should cover most use cases, but
-if you want better integration with your operating system or computing
-environment, [packaged versions](#pre-built-binary-packages) might make more
-sense. There should be no need to compile Tectonic yourself unless you want to,
-or you’re hoping to run it on an unusual platform.
+The [copy-paste method](#copy-paste-a-terminal-command) should cover most use
+cases, but if you want better integration with your operating system or
+computing environment, [packaged versions](#pre-built-binary-packages) might
+make more sense. There should be no need to compile Tectonic yourself unless you
+want to, or you’re hoping to run it on an unusual platform.
+
+
+## Copy-paste a terminal command
+
+This is generally the easiest way to get Tectonic onto your computer. On a
+computer running a Unix-like operating system, including macOS, just run the
+following command in your terminal:
+
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net |sh
+```
+
+This will download the `tectonic` program and place it into the directory where
+you ran the command.
+
+On Windows, you can do the same in a PowerShell window:
+
+```ps1
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://drop-ps1.fullyjustified.net'))
+```
+
+This will unpack `tectonic.exe` for you.
+
+In both cases, you should probably move the unpacked file into a directory in
+your executable search path so that you can run Tectonic from any working
+directory. For the time being, the download script doesn’t do this because it
+can be tricky to automatically determine what the best installation destination
+would be.
 
 
 ## Direct download

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -36,20 +36,19 @@ curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net |sh
 This will download the `tectonic` program and place it into the directory where
 you ran the command.
 
-On Windows, you can do the same in a PowerShell window:
+On Windows, you can do the same in a PowerShell window, which will unpack
+`tectonic.exe` for you:
 
 ```ps1
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
 iex ((New-Object System.Net.WebClient).DownloadString('https://drop-ps1.fullyjustified.net'))
 ```
 
-This will unpack `tectonic.exe` for you.
-
-In both cases, you should probably move the unpacked file into a directory in
-your executable search path so that you can run Tectonic from any working
-directory. For the time being, the download script doesn’t do this because it
-can be tricky to automatically determine what the best installation destination
-would be.
+No matter your operating system, you should probably move the unpacked file into
+a directory in your executable search path so that you can run Tectonic from any
+working directory. For the time being, the download script doesn’t do this
+because it can be tricky to automatically determine what the best installation
+destination would be.
 
 
 ## Direct download


### PR DESCRIPTION
Unlike https://tectonic-typesetting.github.io/install.html, here we don't have any fancy JavaScript to automatically show the right magic command.