### PR TITLE
bridge_harfbuzz: work around build failure with macOS SDK 10.9

### DIFF
--- a/crates/bridge_harfbuzz/build.rs
+++ b/crates/bridge_harfbuzz/build.rs
@@ -105,6 +105,9 @@ mod inner {
 
         if target.contains("apple") {
             cfg.define("HAVE_CORETEXT", "1");
+
+            // AssertMacros.h defines a verify() that conflicts with hb-shape.cc.
+            cfg.define("__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES", "0");
         }
 
         if target.contains("windows-gnu") {


### PR DESCRIPTION
Hopefully this should fix the conda-forge package build, which uses a pretty old SDK.