### PR TITLE
Fix low level dvipdfmx issues

### DIFF
--- a/crates/engine_xdvipdfmx/Cargo.toml
+++ b/crates/engine_xdvipdfmx/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2021 the Tectonic Project
+# Copyright 2021-2022 the Tectonic Project
 # Licensed under the MIT License.
 
 # See README.md for discussion of features (or lack thereof) in this crate.
@@ -30,4 +30,4 @@ cc = "^1.0.66"
 [package.metadata.internal_dep_versions]
 tectonic_bridge_core = "thiscommit:2021-01-17:fohCh1sh"
 tectonic_errors = "5c9ba661edf5ef669f24f9904f99cca369d999e7"
-tectonic_pdf_io = "thiscommit:2022-03-29:6nizWic"
+tectonic_pdf_io = "thiscommit:2022-10-21:pkYKcMI"

--- a/crates/engine_xdvipdfmx/xdvipdfmx/dvipdfmx.c
+++ b/crates/engine_xdvipdfmx/xdvipdfmx/dvipdfmx.c
@@ -339,6 +339,11 @@ dvipdfmx_main (
   int has_id = 0;
   unsigned char id1[16], id2[16];
   struct pdf_setting settings;
+  int pdf_version_major = 1;
+  int pdf_version_minor = 5;
+  int compression_level = 9;
+  double annot_grow_x = 0;
+  double annot_grow_y = 0;
 
   assert(pdf_filename);
   assert(dvi_filename);
@@ -373,11 +378,6 @@ dvipdfmx_main (
 
   select_paper(paperspec);
 
-  int pdf_version_major = 1;
-  int pdf_version_minor = 5;
-  int compression_level = 9;
-  double annot_grow_x = 0;
-  double annot_grow_y = 0;
   bookmark_open = 0;
   key_bits = 40;
   permission = 0x003C;

--- a/crates/engine_xdvipdfmx/xdvipdfmx/dvipdfmx.c
+++ b/crates/engine_xdvipdfmx/xdvipdfmx/dvipdfmx.c
@@ -66,6 +66,7 @@ typedef struct page_range
   int last;
 } PageRange;
 
+/* Compatibility options */
 #define OPT_TPIC_TRANSPARENT_FILL (1 << 1)
 #define OPT_CIDFONT_FIXEDPITCH    (1 << 2)
 #define OPT_FONTMAP_FIRST_MATCH   (1 << 3)
@@ -73,12 +74,6 @@ typedef struct page_range
 #define OPT_PDFOBJ_NO_PREDICTOR   (1 << 5)
 #define OPT_PDFOBJ_NO_OBJSTM      (1 << 6)
 
-static int    pdf_version_major = 1;
-static int    pdf_version_minor = 5;
-static int    compression_level = 9;
-
-static double annot_grow_x = 0.0;
-static double annot_grow_y = 0.0;
 static char     ignore_colors = 0;
 static int      bookmark_open = 0;
 static double   mag           = 1.0;
@@ -248,10 +243,18 @@ do_dvi_pages (void)
         xo = x_offset; yo = y_offset;
         dvi_scan_specials(page_no,
                           &w, &h, &xo, &yo, &lm,
+                          /* No PDF version */
+                          NULL, NULL,
+                          /* No compression */
+                          NULL,
+                          /* No annotation grow */
+                          NULL, NULL,
                           /* No need for encryption options */
-                          NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                          NULL, NULL, NULL, NULL, NULL,
                           /* No trailer IDs */
-                          NULL, NULL, NULL);
+                          NULL, NULL, NULL,
+                          /* No opt_flags */
+                          NULL);
         if (lm != landscape_mode) { /* already swapped for the first page */
           SWAP(w, h);
           landscape_mode = lm;
@@ -369,8 +372,12 @@ dvipdfmx_main (
    * code bits. */
 
   select_paper(paperspec);
-  annot_grow_x = 0;
-  annot_grow_y = 0;
+
+  int pdf_version_major = 1;
+  int pdf_version_minor = 5;
+  int compression_level = 9;
+  double annot_grow_x = 0;
+  double annot_grow_y = 0;
   bookmark_open = 0;
   key_bits = 40;
   permission = 0x003C;
@@ -397,8 +404,10 @@ dvipdfmx_main (
                       &paper_width, &paper_height,
                       &x_offset, &y_offset, &landscape_mode,
                       &pdf_version_major, &pdf_version_minor,
+                      &compression_level,
+                      &annot_grow_x, &annot_grow_y,
                       &do_encryption, &key_bits, &permission, oplain, uplain,
-                      &has_id, id1, id2);
+                      &has_id, id1, id2, &opt_flags);
   }
 
   /*kpse_init_prog("", font_dpi, NULL, NULL);

--- a/crates/pdf_io/pdf_io/dpx-dvi.c
+++ b/crates/pdf_io/pdf_io/dpx-dvi.c
@@ -2495,6 +2495,8 @@ scan_special_config (const char **start, const char *end, int *opt_flags,
                      int *compression_level,
                      double *annot_grow_x, double *annot_grow_y)
 {
+  /* This section of code mirrors read_config_special() in `dvipdfm-x/dvipdfmx.c`. */
+
   skip_white(start, end);
   if (*start >= end)
     return;
@@ -2511,6 +2513,8 @@ scan_special_config (const char **start, const char *end, int *opt_flags,
     else
       arg = parse_ident(start, end);
   }
+
+  /* This section of code implements a subset of do_args_second_pass() in the same file. */
 
   if (streq_ptr(option, "C") && arg && opt_flags) {
     char *num_end;

--- a/crates/pdf_io/pdf_io/dpx-dvi.c
+++ b/crates/pdf_io/pdf_io/dpx-dvi.c
@@ -2490,12 +2490,75 @@ scan_special_trailerid (unsigned char *id1, unsigned char *id2,
   return error;
 }
 
+static void
+scan_special_config (const char **start, const char *end, int *opt_flags,
+                     int *compression_level,
+                     double *annot_grow_x, double *annot_grow_y)
+{
+  skip_white(start, end);
+  if (*start >= end)
+    return;
+
+  char *option = parse_ident(start, end);
+  if (!option)
+    return;
+
+  char *arg = NULL;
+  skip_white(start, end);
+  if (*start < end) {
+    if (**start == '"')
+      arg = parse_c_string(start, end);
+    else
+      arg = parse_ident(start, end);
+  }
+
+  if (streq_ptr(option, "C") && arg && opt_flags) {
+    char *num_end;
+    int flags = (unsigned) strtol(arg, &num_end, 0);
+    if (num_end == arg)
+      dpx_warning("Invalid dvipdfmx compatibility flag: '%s'", arg);
+    else if (flags < 0)
+      *opt_flags  = -flags;
+    else
+      *opt_flags |=  flags;
+  } else if (streq_ptr(option, "z") && arg && compression_level) {
+    *compression_level = atoi(arg);
+  } else if (streq_ptr(option, "g") && arg && annot_grow_x && annot_grow_y) {
+    const char *comma = strchr(arg, ',');
+    const char *arg_ptr = arg; /* dpx_until_read_length changes the pointer */
+    const char *arg_end = arg + strlen(arg);
+    int error;
+    if (comma) {
+      error = dpx_util_read_length(annot_grow_x, 1.0, &arg_ptr, comma);
+      arg_ptr = comma + 1;
+      if (!error)
+        error = dpx_util_read_length(annot_grow_y, 1.0, &arg_ptr, arg_end);
+    } else {
+      error = dpx_util_read_length(annot_grow_x, 1.0, &arg_ptr, arg_end);
+      if (!error)
+        *annot_grow_y = *annot_grow_x;
+    }
+    if (error) {
+      dpx_warning("Error reading argument for \"-g\" option: %s", arg);
+    }
+  } else {
+    dpx_warning("Tectonic doesn't support '%s' config special"
+                " or the argument is missing", option);
+  }
+
+  free(arg);
+  free(option);
+}
+
 static int
 scan_special (double *wd, double *ht, double *xo, double *yo, int *lm,
               int *majorversion, int *minorversion,
+              int *compression_level,
+              double *annot_grow_x, double *annot_grow_y,
               int *enable_encryption, int *key_bits, int32_t *permission,
               char *opassword, char *upassword,
               int *has_id, unsigned char *id1, unsigned char *id2,
+              int *opt_flags,
               const char *buf, uint32_t size)
 {
     char  *q;
@@ -2626,7 +2689,7 @@ scan_special (double *wd, double *ht, double *xo, double *yo, int *lm,
             *enable_encryption = 1;
             error = scan_special_encrypt(key_bits, permission, opassword, upassword, &p, endptr);
         } else if (ns_dvipdfmx && streq_ptr(q, "config")) {
-            dpx_warning("Tectonic does not support `config' special. Ignored.");
+            scan_special_config(&p, endptr, opt_flags, compression_level, annot_grow_x, annot_grow_y);
         } else if (has_id && id1 && id2 && ns_pdf && !strcmp(q, "trailerid")) {
             error = scan_special_trailerid(id1, id2, &p, endptr);
             if (error) {
@@ -2648,9 +2711,12 @@ dvi_scan_specials (int page_no,
                    double *page_width, double *page_height,
                    double *x_offset, double *y_offset, int *landscape,
                    int *majorversion, int *minorversion,
+                   int *compression_level,
+                   double *annot_grow_x, double *annot_grow_y,
                    int *do_enc, int *key_bits, int32_t *permission,
                    char *owner_pw, char *user_pw,
-                   int *has_id, unsigned char *id1, unsigned char *id2)
+                   int *has_id, unsigned char *id1, unsigned char *id2,
+                   int *opt_flags)
 {
     uint32_t       offset;
     unsigned char  opcode;
@@ -2694,8 +2760,11 @@ dvi_scan_specials (int page_no,
                 _tt_abort("Reading DVI file failed!");
             if (scan_special(page_width, page_height, x_offset, y_offset, landscape,
                              majorversion, minorversion,
+                             compression_level,
+                             annot_grow_x, annot_grow_y,
                              do_enc, key_bits, permission, owner_pw, user_pw,
                              has_id, id1, id2,
+                             opt_flags,
                              buf, size))
                 dpx_warning("Reading special command failed: \"%.*s\"", size, buf);
 #undef buf

--- a/crates/pdf_io/pdf_io/dpx-dvi.h
+++ b/crates/pdf_io/pdf_io/dpx-dvi.h
@@ -75,8 +75,11 @@ void  dvi_scan_specials (int page_no,
                                 double *width, double *height,
                                 double *x_offset, double *y_offset, int *landscape,
                                 int *majorversion, int *minorversion,
+                                int *compression_level,
+                                double *annot_grow_x, double *annot_grow_y,
                                 int *do_enc, int *keybits, int32_t *perm,
-                                char *opasswd, char *upasswd, int *has_id, unsigned char *id1, unsigned char *id2);
+                                char *opasswd, char *upasswd, int *has_id, unsigned char *id1, unsigned char *id2,
+                                int *opt_flags);
 unsigned int dvi_locate_font (const char *name, spt_t ptsize);
 
 /* link or nolink:

--- a/crates/pdf_io/pdf_io/dpx-spc_pdfm.c
+++ b/crates/pdf_io/pdf_io/dpx-spc_pdfm.c
@@ -1619,7 +1619,7 @@ spc_handler_pdfm_stream_with_type (struct spc_env *spe, struct spc_arg *args, in
 {
   pdf_obj *fstream;
   ssize_t nb_read;
-  char    *ident, *instring, *fullname;
+  char    *ident, *instring;
   pdf_obj *tmp;
   rust_input_handle_t handle = NULL;
 
@@ -1655,19 +1655,11 @@ spc_handler_pdfm_stream_with_type (struct spc_env *spe, struct spc_arg *args, in
       free(ident);
       return  -1;
     }
-    fullname = NULL; /*kpse_find_pict(instring);*/
-    if (!fullname) {
-      spc_warn(spe, "File \"%s\" not found.", instring);
-      pdf_release_obj(tmp);
-      free(ident);
-      return  -1;
-    }
-    handle = ttstub_input_open(fullname, TTBC_FILE_FORMAT_PICT, 0);
+    handle = ttstub_input_open(instring, TTBC_FILE_FORMAT_PICT, 0);
     if (handle == NULL) {
       spc_warn(spe, "Could not open file: %s", instring);
       pdf_release_obj(tmp);
       free(ident);
-      free(fullname);
       return -1;
     }
     fstream = pdf_new_stream(STREAM_COMPRESS);
@@ -1675,7 +1667,6 @@ spc_handler_pdfm_stream_with_type (struct spc_env *spe, struct spc_arg *args, in
             ttstub_input_read(handle, work_buffer, WORK_BUFFER_SIZE)) > 0)
       pdf_add_stream(fstream, work_buffer, nb_read);
     ttstub_input_close(handle);
-    free(fullname);
     break;
   case STRING_STREAM:
     fstream = pdf_new_stream(STREAM_COMPRESS);


### PR DESCRIPTION
This code change is bigger than I anticipated, but nonetheless, here it is. I appreciate any feedback and testing (I don't use LaTeX much, so don't have real documents to test with).

Both commit messages are reproduced below.

In upstream dvipdfmx the `dvidpfmx:config` DVI special can be used to
pass arguments to dvipdfmx. This has seen some use in XeTeX packages.

For example, the ubiqitous package "hyperref" uses:

    \special{dvipdfmx:config C 0x0010}

This is normally parsed by dvipdfmx as command line arguments, i.e. as
if xdvipdfmx was ran as:

    xdvipdfmx -C 0x0010

The `C` option is a bitset of compatibility flags. In this case hyperref
needs the option `OPT_PDFDOC_NO_DEST_REMOVE`, which makes dvipdfmx
handle PDF destinations differently (I didn't check thoroughly how).

The `opt_flags` global variable used to hold these bitflags and the
`dvipdfmx:config` special could be used to set them. #92 removed that
option.

While passing arbitrary command line arguments to dvidpfmx is probably
not what we want, I definitely know, that we at least need the
compatibility flags to work, and there is probably no other way packages
can set them.

The code that does the option parsing is mostly port from the 'C' option
parsing from dvipdfmx's `read_config_special` and `do_args_second_pass`.
IMHO the way `opt_flags` gets modified is undefined behaviour and does
other weird things with negative values, but the purpose of this commit
is to increase compatibility with upstream, not to fix things (which
should preferably be done upstream IMO).

Like with other options, instead of having a global variable, the
pointer to the value in `dvipdfmx_main` is passed around instead.

While at it, I also added `z` and `g` options which also seem to be used
by LaTeX, so this should be enough for a while.

Hopefully fixes #904.

A previous change left the `fullname` variable unconditionally set to
`NULL`, which meant that all attempts to find streams would fail.

The `fullname` variable is however no longer needed, since Tectonic
doesn't have the two step Kpathsea file workflow (find full name +
open), but it suffices to just open the file with `ttstub_input_open`.