### PR TITLE
Fix everything for Rust 1.67's Clippy

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,5 +9,5 @@ fn main() {
     // they want to spawn off executables.
 
     let target = env::var("TARGET").unwrap();
-    println!("cargo:rustc-env=TARGET={}", target);
+    println!("cargo:rustc-env=TARGET={target}");
 }

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -349,7 +349,7 @@ impl<'a> CoreBridgeState<'a> {
         // `lipsum.ltd.tex` under the name `lipsum.ltd`.
 
         for e in format.extensions() {
-            let ext = format!("{}.{}", name, e);
+            let ext = format!("{name}.{e}");
 
             if let FileFormat::Format = format {
                 match io.input_open_format(&ext, self.status) {

--- a/crates/bridge_graphite2/build.rs
+++ b/crates/bridge_graphite2/build.rs
@@ -55,5 +55,5 @@ fn main() {
         ""
     };
 
-    println!("cargo:define_static={}", define_static_flag);
+    println!("cargo:define_static={define_static_flag}");
 }

--- a/crates/bundles/src/cache.rs
+++ b/crates/bundles/src/cache.rs
@@ -461,7 +461,7 @@ impl<CB: CacheBackend> CachingBundle<CB> {
         // line-based manifest format. Be paranoid and refuse to record such
         // filenames.
         if !name.contains(|c| c == '\n' || c == '\r') {
-            writeln!(man, "{} {} {}", name, length, digest_text)?;
+            writeln!(man, "{name} {length} {digest_text}")?;
         }
 
         self.contents.insert(

--- a/crates/bundles/src/lib.rs
+++ b/crates/bundles/src/lib.rs
@@ -117,9 +117,7 @@ pub fn get_fallback_bundle_url(format_version: u32) -> String {
     if format_version < 32 {
         "https://relay.fullyjustified.net/default_bundle.tar".to_owned()
     } else {
-        format!(
-            "https://relay.fullyjustified.net/default_bundle_v{format_version}.tar"
-        )
+        format!("https://relay.fullyjustified.net/default_bundle_v{format_version}.tar")
     }
 }
 

--- a/crates/bundles/src/lib.rs
+++ b/crates/bundles/src/lib.rs
@@ -118,8 +118,7 @@ pub fn get_fallback_bundle_url(format_version: u32) -> String {
         "https://relay.fullyjustified.net/default_bundle.tar".to_owned()
     } else {
         format!(
-            "https://relay.fullyjustified.net/default_bundle_v{}.tar",
-            format_version
+            "https://relay.fullyjustified.net/default_bundle_v{format_version}.tar"
         )
     }
 }

--- a/crates/dep_support/src/lib.rs
+++ b/crates/dep_support/src/lib.rs
@@ -223,7 +223,7 @@ impl<'a, T: Spec> Dependency<'a, T> {
                                 // graphite2 is not available on Debian. So
                                 // let's jump through the hoops of testing
                                 // whether the static archive seems findable.
-                                let libname = format!("lib{}.a", libbase);
+                                let libname = format!("lib{libbase}.a");
                                 state
                                     .libs
                                     .link_paths
@@ -233,11 +233,11 @@ impl<'a, T: Spec> Dependency<'a, T> {
                         };
 
                         let mode = if do_static { "static=" } else { "" };
-                        println!("cargo:rustc-link-lib={}{}", mode, libbase);
+                        println!("cargo:rustc-link-lib={mode}{libbase}");
                     }
 
                     for fw in &state.libs.frameworks {
-                        println!("cargo:rustc-link-lib=framework={}", fw);
+                        println!("cargo:rustc-link-lib=framework={fw}");
                     }
                 } else {
                     // Just let pkg-config do its thing.

--- a/crates/engine_spx2html/src/font.rs
+++ b/crates/engine_spx2html/src/font.rs
@@ -406,7 +406,7 @@ impl FontData {
         // CSS info for the main font.
 
         let rel_url = utf8_percent_encode(&self.basename, CONTROLS).to_string();
-        let mut rv = vec![(None, format!(r#"url("{}") format("opentype")"#, rel_url))];
+        let mut rv = vec![(None, format!(r#"url("{rel_url}") format("opentype")"#))];
 
         // Alternates until we're done
 
@@ -468,7 +468,7 @@ impl FontData {
             let rel_url = utf8_percent_encode(&varname, CONTROLS).to_string();
             rv.push((
                 Some(cur_map_index),
-                format!(r#"url("{}") format("opentype")"#, rel_url),
+                format!(r#"url("{rel_url}") format("opentype")"#),
             ));
         }
 

--- a/crates/engine_spx2html/src/lib.rs
+++ b/crates/engine_spx2html/src/lib.rs
@@ -333,7 +333,7 @@ impl InitializationState {
         let mut ih = None;
 
         for ext in &["", ".otf"] {
-            texpath = format!("{}{}", name, ext);
+            texpath = format!("{name}{ext}");
 
             match io.input_open_name(&texpath, common.status) {
                 OpenResult::Ok(h) => {
@@ -391,7 +391,7 @@ impl InitializationState {
 
         let info = FontInfo {
             rel_url: utf8_percent_encode(basename, CONTROLS).to_string(),
-            family_name: format!("tdux{}", font_num),
+            family_name: format!("tdux{font_num}"),
             family_relation: FamilyRelativeFontId::Regular,
             fd_key,
             size,
@@ -595,7 +595,7 @@ impl InitializationState {
                 b.family_name = if let Some(fname) = text.strip_prefix("family-name:") {
                     fname.to_owned()
                 } else {
-                    format!("tdux{}", font_num)
+                    format!("tdux{font_num}")
                 };
 
                 // Say that the "regular" font of the first font family definition
@@ -1083,7 +1083,7 @@ impl EmittingState {
                 "mfs" => {
                     if self.content_finished {
                         self.warn_finished_content(
-                            &format!("manual flexible start tag {:?}", remainder),
+                            &format!("manual flexible start tag {remainder:?}"),
                             common,
                         );
                         Ok(())
@@ -1095,7 +1095,7 @@ impl EmittingState {
                 "me" => {
                     if self.content_finished {
                         self.warn_finished_content(
-                            &format!("manual end tag </{}>", remainder),
+                            &format!("manual end tag </{remainder}>"),
                             common,
                         );
                     } else {
@@ -1484,7 +1484,7 @@ impl EmittingState {
         common: &mut Common,
     ) -> Result<()> {
         if self.content_finished {
-            self.warn_finished_content(&format!("text `{}`", text), common);
+            self.warn_finished_content(&format!("text `{text}`"), common);
             return Ok(());
         }
 
@@ -1609,7 +1609,7 @@ impl EmittingState {
                         self.current_content.push(' ');
                     }
 
-                    write!(self.current_content, "<span style=\"{}\">", font_sel).unwrap();
+                    write!(self.current_content, "<span style=\"{font_sel}\">").unwrap();
                     html_escape::encode_text_to_string(ch_as_str, &mut self.current_content);
                     write!(self.current_content, "</span>").unwrap();
                 } else {
@@ -2108,7 +2108,7 @@ struct FontInfo {
 impl FontInfo {
     fn selection_style_text(&self, alternate_map_index: Option<usize>) -> String {
         let alt_text = alternate_map_index
-            .map(|i| format!("vg{}", i))
+            .map(|i| format!("vg{i}"))
             .unwrap_or_default();
 
         let extra = match self.family_relation {
@@ -2124,7 +2124,7 @@ impl FontInfo {
 
     fn font_face_text(&self, alternate_map_index: Option<usize>) -> String {
         let alt_text = alternate_map_index
-            .map(|i| format!("vg{}", i))
+            .map(|i| format!("vg{i}"))
             .unwrap_or_default();
 
         let extra = match self.family_relation {

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -52,12 +52,12 @@ pub struct AnnotatedMessage {
 impl AnnotatedMessage {
     /// Set the primary message associated with this annotated report.
     pub fn set_message<T: fmt::Display>(&mut self, m: T) {
-        self.message = format!("{}", m);
+        self.message = format!("{m}");
     }
 
     /// Add an additional note to be associated with this annotated report.
     pub fn add_note<T: fmt::Display>(&mut self, n: T) {
-        self.notes.push(format!("{}", n));
+        self.notes.push(format!("{n}"));
     }
 
     /// Obtain the set of notes associated with this report.

--- a/crates/geturl/src/curl.rs
+++ b/crates/geturl/src/curl.rs
@@ -23,7 +23,7 @@ fn get_url_generic(
 
     if let Some((start, length)) = range {
         let end = start + length as u64 - 1;
-        handle.range(&format!("{}-{}", start, end))?;
+        handle.range(&format!("{start}-{end}"))?;
     }
 
     let mut buf = Vec::new();

--- a/crates/geturl/src/reqwest.rs
+++ b/crates/geturl/src/reqwest.rs
@@ -131,7 +131,7 @@ impl RangeReader for ReqwestRangeReader {
 
     fn read_range(&mut self, offset: u64, length: usize) -> Result<Response> {
         let end_inclusive = offset + length as u64 - 1;
-        let header_val = format!("bytes={}-{}", offset, end_inclusive).parse()?;
+        let header_val = format!("bytes={offset}-{end_inclusive}").parse()?;
 
         let mut headers = HeaderMap::new();
         headers.insert(RANGE, header_val);

--- a/crates/io_base/src/digest.rs
+++ b/crates/io_base/src/digest.rs
@@ -31,7 +31,7 @@ pub struct BadLengthError {
 pub fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes
         .iter()
-        .map(|b| format!("{:02x}", b))
+        .map(|b| format!("{b:02x}"))
         .collect::<Vec<_>>()
         .concat()
 }

--- a/crates/pdf_io/build.rs
+++ b/crates/pdf_io/build.rs
@@ -81,7 +81,7 @@ fn main() {
 
     fn compile(cfg: &mut cc::Build, s: &str) {
         cfg.file(s);
-        println!("cargo:rerun-if-changed={}", s);
+        println!("cargo:rerun-if-changed={s}");
     }
 
     ccfg.include("pdf_io")

--- a/crates/status_base/src/lib.rs
+++ b/crates/status_base/src/lib.rs
@@ -121,7 +121,7 @@ pub trait StatusBackend {
     fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
         self.report(
             MessageKind::Note,
-            format_args!("{}{}{}", before, highlighted, after),
+            format_args!("{before}{highlighted}{after}"),
             None,
         )
     }

--- a/crates/status_base/src/plain.rs
+++ b/crates/status_base/src/plain.rs
@@ -54,14 +54,14 @@ impl StatusBackend for PlainStatusBackend {
         };
 
         if kind == MessageKind::Note && !self.always_stderr {
-            println!("{} {}", prefix, args);
+            println!("{prefix} {args}");
         } else {
-            eprintln!("{} {}", prefix, args);
+            eprintln!("{prefix} {args}");
         }
 
         if let Some(e) = err {
             for item in e.chain() {
-                eprintln!("caused by: {}", item);
+                eprintln!("caused by: {item}");
             }
         }
     }
@@ -70,7 +70,7 @@ impl StatusBackend for PlainStatusBackend {
         let mut prefix = "error";
 
         for item in err.chain() {
-            eprintln!("{}: {}", prefix, item);
+            eprintln!("{prefix}: {item}");
             prefix = "caused by";
         }
     }
@@ -78,7 +78,7 @@ impl StatusBackend for PlainStatusBackend {
     fn note_highlighted(&mut self, before: &str, highlighted: &str, after: &str) {
         self.report(
             MessageKind::Note,
-            format_args!("{}{}{}", before, highlighted, after),
+            format_args!("{before}{highlighted}{after}"),
             None,
         );
     }

--- a/crates/xdv/examples/xdvdump.rs
+++ b/crates/xdv/examples/xdvdump.rs
@@ -30,13 +30,13 @@ impl Display for Error {
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
-        Error(format!("{}", e)) // note: weirdly, can't use `Self` on this line
+        Error(format!("{e}")) // note: weirdly, can't use `Self` on this line
     }
 }
 
 impl From<XdvError> for Error {
     fn from(e: XdvError) -> Self {
-        Error(format!("{}", e))
+        Error(format!("{e}"))
     }
 }
 
@@ -52,14 +52,14 @@ impl tectonic_xdv::XdvEvents for Stats {
     type Error = Error;
 
     fn handle_header(&mut self, filetype: FileType, comment: &[u8]) -> Result<(), Self::Error> {
-        println!("file type: {}", filetype);
+        println!("file type: {filetype}");
 
         match str::from_utf8(comment) {
             Ok(s) => {
-                println!("comment: {}", s);
+                println!("comment: {s}");
             }
             Err(e) => {
-                println!("cannot parse comment: {}", e);
+                println!("cannot parse comment: {e}");
             }
         };
 
@@ -78,8 +78,7 @@ impl tectonic_xdv::XdvEvents for Stats {
         embolden: Option<u32>,
     ) -> Result<(), Self::Error> {
         println!(
-            "define native font: `{}` num={} size={} faceIndex={} color={:?} extend={:?} slant={:?} embolden={:?}",
-            name, font_num, size, face_index, color_rgba, extend, slant, embolden
+            "define native font: `{name}` num={font_num} size={size} faceIndex={face_index} color={color_rgba:?} extend={extend:?} slant={slant:?} embolden={embolden:?}"
         );
         Ok(())
     }
@@ -109,10 +108,10 @@ impl tectonic_xdv::XdvEvents for Stats {
     fn handle_special(&mut self, x: i32, y: i32, contents: &[u8]) -> Result<(), Self::Error> {
         match str::from_utf8(contents) {
             Ok(s) => {
-                println!("special: {} (@ {},{})", s, x, y);
+                println!("special: {s} (@ {x},{y})");
             }
             Err(e) => {
-                println!("cannot UTF8-parse special: {}", e);
+                println!("cannot UTF8-parse special: {e}");
             }
         };
 
@@ -122,8 +121,7 @@ impl tectonic_xdv::XdvEvents for Stats {
     fn handle_char_run(&mut self, font_num: i32, chars: &[i32]) -> Result<(), Self::Error> {
         let all_ascii_printable = chars.iter().all(|c| *c > 0x20 && *c < 0x7F);
         println!(
-            "chars font={}: {:?} all_ascii_printable={:?}",
-            font_num, chars, all_ascii_printable
+            "chars font={font_num}: {chars:?} all_ascii_printable={all_ascii_printable:?}"
         );
         Ok(())
     }
@@ -135,12 +133,12 @@ impl tectonic_xdv::XdvEvents for Stats {
         x: &[i32],
         y: &[i32],
     ) -> Result<(), Self::Error> {
-        println!("glyphs font={}: {:?} (@ {:?}, {:?}", font_num, glyphs, x, y);
+        println!("glyphs font={font_num}: {glyphs:?} (@ {x:?}, {y:?}");
         Ok(())
     }
 
     fn handle_rule(&mut self, x: i32, y: i32, height: i32, width: i32) -> Result<(), Self::Error> {
-        println!("rule W={} H={} @ {:?}, {:?}", width, height, x, y);
+        println!("rule W={width} H={height} @ {x:?}, {y:?}");
         Ok(())
     }
 }
@@ -203,6 +201,6 @@ fn main() {
             }
         };
 
-        println!("{} bytes parsed.", n_bytes);
+        println!("{n_bytes} bytes parsed.");
     }
 }

--- a/crates/xdv/examples/xdvdump.rs
+++ b/crates/xdv/examples/xdvdump.rs
@@ -120,9 +120,7 @@ impl tectonic_xdv::XdvEvents for Stats {
 
     fn handle_char_run(&mut self, font_num: i32, chars: &[i32]) -> Result<(), Self::Error> {
         let all_ascii_printable = chars.iter().all(|c| *c > 0x20 && *c < 0x7F);
-        println!(
-            "chars font={font_num}: {chars:?} all_ascii_printable={all_ascii_printable:?}"
-        );
+        println!("chars font={font_num}: {chars:?} all_ascii_printable={all_ascii_printable:?}");
         Ok(())
     }
 

--- a/crates/xdv/src/lib.rs
+++ b/crates/xdv/src/lib.rs
@@ -47,21 +47,19 @@ impl Display for XdvError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
         match *self {
             XdvError::Malformed(offset) => {
-                write!(f, "unexpected XDV data at byte offset {}", offset)
+                write!(f, "unexpected XDV data at byte offset {offset}")
             }
             XdvError::IllegalOpcode(opcode, offset) => {
-                write!(f, "illegal XDV opcode {} at byte offset {}", opcode, offset)
+                write!(f, "illegal XDV opcode {opcode} at byte offset {offset}")
             }
             XdvError::UnexpectedEndOfStream => write!(f, "stream ended unexpectedly soon"),
             XdvError::FromUTF8(offset) => write!(
                 f,
-                "illegal UTF8 sequence starting at byte offset {}",
-                offset
+                "illegal UTF8 sequence starting at byte offset {offset}"
             ),
             XdvError::FromUTF16(offset) => write!(
                 f,
-                "illegal UTF16 sequence starting at byte offset {}",
-                offset
+                "illegal UTF16 sequence starting at byte offset {offset}"
             ),
         }
     }
@@ -86,7 +84,7 @@ impl error::Error for XdvError {
 /// In case you want to use String as your error type.
 impl From<XdvError> for String {
     fn from(e: XdvError) -> Self {
-        format!("{}", e)
+        format!("{e}")
     }
 }
 
@@ -361,7 +359,7 @@ impl<T: XdvEvents> XdvParser<T> {
 
         // Now we can do the main content.
 
-        stream.seek(SeekFrom::Start(0))?;
+        stream.rewind()?;
         parser.mode = ParserMode::UntilPostamble;
         parser.state = ParserState::Preamble;
         parser.process_part(&mut stream)?;

--- a/crates/xdv/src/lib.rs
+++ b/crates/xdv/src/lib.rs
@@ -53,14 +53,12 @@ impl Display for XdvError {
                 write!(f, "illegal XDV opcode {opcode} at byte offset {offset}")
             }
             XdvError::UnexpectedEndOfStream => write!(f, "stream ended unexpectedly soon"),
-            XdvError::FromUTF8(offset) => write!(
-                f,
-                "illegal UTF8 sequence starting at byte offset {offset}"
-            ),
-            XdvError::FromUTF16(offset) => write!(
-                f,
-                "illegal UTF16 sequence starting at byte offset {offset}"
-            ),
+            XdvError::FromUTF8(offset) => {
+                write!(f, "illegal UTF8 sequence starting at byte offset {offset}")
+            }
+            XdvError::FromUTF16(offset) => {
+                write!(f, "illegal UTF16 sequence starting at byte offset {offset}")
+            }
         }
     }
 }

--- a/crates/xetex_format/examples/decode.rs
+++ b/crates/xetex_format/examples/decode.rs
@@ -117,7 +117,7 @@ fn main() {
     let options = Options::from_args();
 
     if let Err(e) = options.execute() {
-        eprintln!("error: {}", e);
+        eprintln!("error: {e}");
         process::exit(1);
     }
 }

--- a/crates/xetex_format/examples/emit.rs
+++ b/crates/xetex_format/examples/emit.rs
@@ -17,7 +17,7 @@ fn inner() -> Result<()> {
 
 fn main() {
     if let Err(e) = inner() {
-        eprintln!("error: {}", e);
+        eprintln!("error: {e}");
         process::exit(1);
     }
 }

--- a/crates/xetex_format/src/commands.rs
+++ b/crates/xetex_format/src/commands.rs
@@ -368,7 +368,7 @@ impl Commands {
         if let Some(cmd) = self.codes.get(&code) {
             cmd.describe(arg)
         } else {
-            format!("[??? {} {}]", code, arg)
+            format!("[??? {code} {arg}]")
         }
     }
 
@@ -381,7 +381,7 @@ impl Commands {
         if let Some(cmd) = self.codes.get(&code) {
             (cmd.describe(arg), cmd.extended_info(arg, format))
         } else {
-            (format!("[??? {} {}]", code, arg), None)
+            (format!("[??? {code} {arg}]"), None)
         }
     }
 
@@ -412,7 +412,7 @@ typedef struct xetex_format_primitive_def_t {{
         for cmd in self.codes.values() {
             for prim in cmd.primitives() {
                 let arg = match prim.arg {
-                    ArgKind::Unnamed(v) => format!("{}", v),
+                    ArgKind::Unnamed(v) => format!("{v}"),
                     ArgKind::Symbol(s) => s.to_string(),
                 };
 

--- a/crates/xetex_format/src/commands/simpleenum.rs
+++ b/crates/xetex_format/src/commands/simpleenum.rs
@@ -276,9 +276,9 @@ impl Command for ShorthandDef {
             TOKS => "toksdef",
             XETEX_MATH_CHAR_NUM => "XeTeXmathcharnumdef",
             XETEX_MATH_CHAR => "XeTeXmathchardef",
-            _ => return format!("[{:?}?? {}]", self, arg),
+            _ => return format!("[{self:?}?? {arg}]"),
         };
-        format!("[{}]", s)
+        format!("[{s}]")
     }
 
     fn primitives(&self) -> Vec<CommandPrimitive> {

--- a/crates/xetex_format/src/format.rs
+++ b/crates/xetex_format/src/format.rs
@@ -73,7 +73,7 @@ impl Format {
     pub fn dump_string_table<W: Write>(&self, stream: &mut W) -> Result<()> {
         for sp in self.strings.all_sps() {
             let value = self.strings.lookup(sp);
-            writeln!(stream, "{} = \"{}\"", sp, value)?;
+            writeln!(stream, "{sp} = \"{value}\"")?;
         }
 
         Ok(())
@@ -165,10 +165,10 @@ impl Format {
                 (self.engine.commands.describe(entry.ty, entry.value), None)
             };
 
-            writeln!(stream, "{} => {}", cs_desc, cmd_desc)?;
+            writeln!(stream, "{cs_desc} => {cmd_desc}")?;
 
             if let Some(e) = extended {
-                writeln!(stream, "--------\n{}\n--------", e)?;
+                writeln!(stream, "--------\n{e}\n--------")?;
             }
         }
 
@@ -240,7 +240,7 @@ impl Format {
                     }
 
                     (true, 5 /* OUT_PARAM */) => {
-                        writeln!(result, "#{}", chr).unwrap();
+                        writeln!(result, "#{chr}").unwrap();
                     }
 
                     _ => {
@@ -273,7 +273,7 @@ impl Format {
         if let Some(text) = self.cshash.stringify(ptr, &self.strings) {
             fmt_csname(text)
         } else {
-            format!("[undecodable cseq pointer {}]", ptr)
+            format!("[undecodable cseq pointer {ptr}]")
         }
     }
 
@@ -481,18 +481,18 @@ pub fn fmt_usv(c: i32) -> String {
 
     if let Some(chr) = maybe_chr {
         if chr == ' ' {
-            format!("' ' (0x{:06x})", c)
+            format!("' ' (0x{c:06x})")
         } else if chr == '\'' {
-            format!("\\' (0x{:06x})", c)
+            format!("\\' (0x{c:06x})")
         } else if chr == '\"' {
-            format!("\\\" (0x{:06x})", c)
+            format!("\\\" (0x{c:06x})")
         } else if chr.is_control() || chr.is_whitespace() {
             format!("{} (0x{:06x})", chr.escape_default(), c)
         } else {
-            format!("{} (0x{:06x})", chr, c)
+            format!("{chr} (0x{c:06x})")
         }
     } else {
-        format!("*invalid* (0x{:06x})", c)
+        format!("*invalid* (0x{c:06x})")
     }
 }
 
@@ -503,7 +503,7 @@ pub fn fmt_csname<S: AsRef<str>>(name: S) -> String {
     match (name.len(), has_ws) {
         (0, _) => "[null CS]".to_owned(),
         (1, _) => format!("'\\{}'", fmt_usv(name.chars().next().unwrap() as i32)),
-        (_, false) => format!("\\{}", name),
-        (_, true) => format!("\"\\{}\"", name),
+        (_, false) => format!("\\{name}"),
+        (_, true) => format!("\"\\{name}\""),
     }
 }

--- a/crates/xetex_format/src/symbols.rs
+++ b/crates/xetex_format/src/symbols.rs
@@ -168,7 +168,7 @@ impl SymbolTable {
 
         if let Some(prev) = self.by_name.insert(name.clone(), value) {
             // We let identical values get re-inserted, mainly for NORMAL.
-            ensure!(prev == value, format!("changed symbol name `{}`", name));
+            ensure!(prev == value, format!("changed symbol name `{name}`"));
         } else {
             let group = self.grouped.entry(cat).or_insert_with(Vec::new);
             group.push(name);
@@ -195,7 +195,7 @@ impl SymbolTable {
 
             for name in names {
                 let value = self.by_name.get(name).unwrap();
-                writeln!(stream, "#define {} {} /* = 0x{:x} */", name, value, value)?;
+                writeln!(stream, "#define {name} {value} /* = 0x{value:x} */")?;
             }
         }
 

--- a/crates/xetex_layout/build.rs
+++ b/crates/xetex_layout/build.rs
@@ -123,7 +123,7 @@ fn main() {
 
     fn compile(cfg: &mut cc::Build, s: &str) {
         cfg.file(s);
-        println!("cargo:rerun-if-changed={}", s);
+        println!("cargo:rerun-if-changed={s}");
     }
 
     cppcfg
@@ -214,22 +214,22 @@ fn main() {
     // that allows us to have a network of crates containing both C/C++ and Rust
     // code that all interlink.
 
-    print!("cargo:include-path={}", out_dir);
+    print!("cargo:include-path={out_dir}");
 
     for item in harfbuzz_include_path.split(';') {
-        print!(";{}", item);
+        print!(";{item}");
     }
 
     for item in freetype2_include_path.split(';') {
-        print!(";{}", item);
+        print!(";{item}");
     }
 
     for item in graphite2_include_path.split(';') {
-        print!(";{}", item);
+        print!(";{item}");
     }
 
     for item in icu_include_path.split(';') {
-        print!(";{}", item);
+        print!(";{item}");
     }
 
     println!();

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -404,7 +404,7 @@ impl BundleSearchCommand {
 
         for filename in &files {
             if filter(filename) {
-                println!("{}", filename);
+                println!("{filename}");
             }
         }
 
@@ -528,7 +528,7 @@ impl WatchCommand {
             .expect("Executable path wasn't valid UTF-8");
         let mut cmds = Vec::new();
         for x in self.execute.iter() {
-            let mut cmd = format!("{} -X ", exe_name);
+            let mut cmd = format!("{exe_name} -X ");
             let x = x.trim();
             if !x.is_empty() {
                 cmd.push_str(x);
@@ -537,7 +537,7 @@ impl WatchCommand {
         }
 
         if cmds.is_empty() {
-            cmds.push(format!("{} -X build", exe_name))
+            cmds.push(format!("{exe_name} -X build"))
         }
 
         let command = cmds.join(" && ");

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -131,8 +131,7 @@ impl DocumentExt for Document {
     ) -> Result<ProcessingSessionBuilder> {
         let profile = self.outputs.get(output_profile).ok_or_else(|| {
             ErrorKind::Msg(format!(
-                "unrecognized output profile name \"{}\"",
-                output_profile
+                "unrecognized output profile name \"{output_profile}\""
             ))
         })?;
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -281,8 +281,7 @@ impl BridgeState {
     /// format file name, and filesystem I/O is bypassed.
     fn enter_format_mode(&mut self, format_file_name: &str) {
         self.format_primary = Some(BufferedPrimaryIo::from_text(format!(
-            "\\input {}",
-            format_file_name
+            "\\input {format_file_name}"
         )));
     }
 
@@ -1284,7 +1283,7 @@ impl ProcessingSession {
         for (name, info) in &self.bs.events {
             if info.access_pattern == AccessPattern::ReadThenWritten {
                 let file_changed = match (&info.read_digest, &info.write_digest) {
-                    (&Some(ref d1), &Some(ref d2)) => d1 != d2,
+                    (Some(d1), Some(d2)) => d1 != d2,
                     (&None, &Some(_)) => true,
                     (_, _) => {
                         // Other cases shouldn't happen.
@@ -1455,7 +1454,7 @@ impl ProcessingSession {
         if n_skipped_intermediates > 0 {
             status.note_highlighted(
                 "Skipped writing ",
-                &format!("{}", n_skipped_intermediates),
+                &format!("{n_skipped_intermediates}"),
                 " intermediate files (use --keep-intermediates to keep them)",
             );
         }
@@ -1560,7 +1559,7 @@ impl ProcessingSession {
             if file.data.is_empty() {
                 status.note_highlighted(
                     "Not writing ",
-                    &format!("`{}`", sname),
+                    &format!("`{sname}`"),
                     ": it would be empty.",
                 );
                 continue;
@@ -1634,7 +1633,7 @@ impl ProcessingSession {
                 match rerun_result {
                     Some(RerunReason::Biber) => "biber was run".to_owned(),
                     Some(RerunReason::Bibtex) => "bibtex was run".to_owned(),
-                    Some(RerunReason::FileChange(ref s)) => format!("\"{}\" changed", s),
+                    Some(RerunReason::FileChange(ref s)) => format!("\"{s}\" changed"),
                     None => break,
                 }
             };
@@ -1714,7 +1713,7 @@ impl ProcessingSession {
 
         let result = {
             self.bs
-                .enter_format_mode(&format!("tectonic-format-{}.tex", stem));
+                .enter_format_mode(&format!("tectonic-format-{stem}.tex"));
             let mut launcher =
                 CoreBridgeLauncher::new_with_security(&mut self.bs, status, self.security.clone());
             let r = TexEngine::default()
@@ -1773,7 +1772,7 @@ impl ProcessingSession {
     ) -> Result<Option<&'static str>> {
         let result = {
             if let Some(s) = rerun_explanation {
-                status.note_highlighted("Rerunning ", "TeX", &format!(" because {} ...", s));
+                status.note_highlighted("Rerunning ", "TeX", &format!(" because {s} ..."));
             } else {
                 status.note_highlighted("Running ", "TeX", " ...");
             }
@@ -1825,7 +1824,7 @@ impl ProcessingSession {
         aux_file: &String,
     ) -> Result<i32> {
         let result = {
-            status.note_highlighted("Running ", "BibTeX", &format!(" on {} ...", aux_file));
+            status.note_highlighted("Running ", "BibTeX", &format!(" on {aux_file} ..."));
             let mut launcher =
                 CoreBridgeLauncher::new_with_security(&mut self.bs, status, self.security.clone());
             let mut engine = BibtexEngine::new();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -145,7 +145,7 @@ macro_rules! ctry {
 
 impl convert::From<Error> for io::Error {
     fn from(err: Error) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, format!("{}", err))
+        io::Error::new(io::ErrorKind::Other, format!("{err}"))
     }
 }
 
@@ -165,13 +165,13 @@ impl Error {
         let mut s = io::stderr();
 
         for item in self.iter() {
-            writeln!(s, "{} {}", prefix, item).expect("write to stderr failed");
+            writeln!(s, "{prefix} {item}").expect("write to stderr failed");
             prefix = "caused by:";
         }
 
         if let Some(backtrace) = self.backtrace() {
             writeln!(s, "debugging: backtrace follows:").expect("write to stderr failed");
-            writeln!(s, "{:?}", backtrace).expect("write to stderr failed");
+            writeln!(s, "{backtrace:?}").expect("write to stderr failed");
         }
     }
 }

--- a/src/status/termcolor.rs
+++ b/src/status/termcolor.rs
@@ -114,10 +114,10 @@ impl TermcolorStatusBackend {
         };
 
         self.styled(kind, |s| {
-            write!(s, "{}", text).expect("failed to write to standard stream");
+            write!(s, "{text}").expect("failed to write to standard stream");
         });
         self.with_stream(kind, |s| {
-            writeln!(s, " {}", args).expect("failed to write to standard stream");
+            writeln!(s, " {args}").expect("failed to write to standard stream");
         });
     }
 
@@ -128,16 +128,16 @@ impl TermcolorStatusBackend {
     pub fn note_styled(&mut self, args: Arguments) {
         if self.chatter > ChatterLevel::Minimal {
             if self.always_stderr {
-                writeln!(self.stderr, "{}", args).expect("write to stderr failed");
+                writeln!(self.stderr, "{args}").expect("write to stderr failed");
             } else {
-                writeln!(self.stdout, "{}", args).expect("write to stdout failed");
+                writeln!(self.stdout, "{args}").expect("write to stdout failed");
             }
         }
     }
 
     pub fn error_styled(&mut self, args: Arguments) {
         self.styled(MessageKind::Error, |s| {
-            writeln!(s, "{}", args).expect("write to stderr failed");
+            writeln!(s, "{args}").expect("write to stderr failed");
         });
     }
 
@@ -145,7 +145,7 @@ impl TermcolorStatusBackend {
         let mut prefix = "error:";
 
         for item in err.chain() {
-            self.generic_message(MessageKind::Error, Some(prefix), format_args!("{}", item));
+            self.generic_message(MessageKind::Error, Some(prefix), format_args!("{item}"));
             prefix = "caused by:";
         }
     }
@@ -168,7 +168,7 @@ impl StatusBackend for TermcolorStatusBackend {
 
         if let Some(e) = err {
             for item in e.chain() {
-                self.generic_message(kind, Some("caused by:"), format_args!("{}", item));
+                self.generic_message(kind, Some("caused by:"), format_args!("{item}"));
             }
         }
     }
@@ -179,10 +179,10 @@ impl StatusBackend for TermcolorStatusBackend {
 
         for item in err.chain() {
             if first {
-                self.generic_message(kind, None, format_args!("{}", item));
+                self.generic_message(kind, None, format_args!("{item}"));
                 first = false;
             } else {
-                self.generic_message(kind, Some("caused by:"), format_args!("{}", item));
+                self.generic_message(kind, Some("caused by:"), format_args!("{item}"));
             }
         }
     }
@@ -195,13 +195,13 @@ impl StatusBackend for TermcolorStatusBackend {
                 &mut self.stdout
             };
 
-            write!(stream, "{}", before).expect("write failed");
+            write!(stream, "{before}").expect("write failed");
             stream
                 .set_color(&self.highlight_spec)
                 .expect("write failed");
-            write!(stream, "{}", highlighted).expect("write failed");
+            write!(stream, "{highlighted}").expect("write failed");
             stream.reset().expect("write failed");
-            writeln!(stream, "{}", after).expect("write failed");
+            writeln!(stream, "{after}").expect("write failed");
         }
     }
 

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -68,8 +68,7 @@ impl FromStr for UnstableArg {
         let require_no_value = |unwanted_value: Option<&str>, builtin_value: UnstableArg| {
             if let Some(value) = unwanted_value {
                 Err(format!(
-                    "'-Z {}={}', was supplied but '-Z {}' does not take a value.",
-                    arg, value, arg
+                    "'-Z {arg}={value}', was supplied but '-Z {arg}' does not take a value."
                 )
                 .into())
             } else {
@@ -84,7 +83,7 @@ impl FromStr for UnstableArg {
 
             "min-crossrefs" => require_value("num")
                 .and_then(|s| {
-                    FromStr::from_str(s).map_err(|e| format!("-Z min-crossrefs: {}", e).into())
+                    FromStr::from_str(s).map_err(|e| format!("-Z min-crossrefs: {e}").into())
                 })
                 .map(UnstableArg::MinCrossrefs),
 
@@ -98,7 +97,7 @@ impl FromStr for UnstableArg {
                 require_value("path").map(|s| UnstableArg::ShellEscapeCwd(s.to_string()))
             }
 
-            _ => Err(format!("Unknown unstable option '{}'", arg).into()),
+            _ => Err(format!("Unknown unstable option '{arg}'").into()),
         }
     }
 }
@@ -141,6 +140,6 @@ impl UnstableOptions {
 }
 
 pub fn print_unstable_help_and_exit() {
-    print!("{}", HELPMSG);
+    print!("{HELPMSG}");
     std::process::exit(0);
 }

--- a/tests/cached_itarbundle.rs
+++ b/tests/cached_itarbundle.rs
@@ -45,7 +45,7 @@ impl TarIndexBuilder {
     fn push(&mut self, name: &str, content: &[u8]) -> &mut Self {
         let offset = self.tar.len();
         let len = content.len();
-        let _ = writeln!(&mut self.index, "{} {} {}", name, offset, len);
+        let _ = writeln!(&mut self.index, "{name} {offset} {len}");
         self.map
             .insert((offset as u64, len as u64), name.to_owned());
         self.tar.extend_from_slice(content);
@@ -246,8 +246,7 @@ fn check_req_count(requests: &[TectonicRequest], request: TectonicRequest, expec
     let number = requests.iter().filter(|r| **r == request).count();
     assert_eq!(
         number, expected_number,
-        "Expected {} requests of {:?}, got {}",
-        expected_number, request, number
+        "Expected {expected_number} requests of {request:?}, got {number}"
     );
 }
 #[test]

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -32,7 +32,7 @@ lazy_static! {
         target.make_ascii_uppercase();
 
         // run-time environment variable check:
-        if let Ok(runtext) = env::var(format!("CARGO_TARGET_{}_RUNNER", target)) {
+        if let Ok(runtext) = env::var(format!("CARGO_TARGET_{target}_RUNNER")) {
             runtext.split_whitespace().map(|x| x.to_owned()).collect()
         } else {
             vec![]
@@ -71,8 +71,8 @@ fn prep_tectonic(cwd: &Path, args: &[&str]) -> Command {
             tectonic
         )
     }
-    println!("using tectonic binary at {:?}", tectonic);
-    println!("using cwd {:?}", cwd);
+    println!("using tectonic binary at {tectonic:?}");
+    println!("using cwd {cwd:?}");
 
     // We may need to wrap the Tectonic invocation. If we're cross-compiling, we
     // might need to use something like QEMU to actually be able to run the
@@ -114,7 +114,7 @@ fn prep_tectonic(cwd: &Path, args: &[&str]) -> Command {
 fn run_tectonic(cwd: &Path, args: &[&str]) -> Output {
     let mut command = prep_tectonic(cwd, args);
     command.env("BROWSER", "echo");
-    println!("running {:?}", command);
+    println!("running {command:?}");
     command.output().expect("tectonic failed to start")
 }
 
@@ -124,9 +124,9 @@ fn run_tectonic_with_stdin(cwd: &Path, args: &[&str], stdin: &str) -> Output {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    println!("running {:?}", command);
+    println!("running {command:?}");
     let mut child = command.spawn().expect("tectonic failed to start");
-    write!(child.stdin.as_mut().unwrap(), "{}", stdin)
+    write!(child.stdin.as_mut().unwrap(), "{stdin}")
         .expect("failed to send data to tectonic subprocess");
     child
         .wait_with_output()
@@ -298,10 +298,10 @@ fn run_with_biber(args: &str, stdin: &str) -> Output {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    println!("running {:?}", command);
+    println!("running {command:?}");
     let mut child = command.spawn().expect("tectonic failed to start");
 
-    write!(child.stdin.as_mut().unwrap(), "{}", stdin)
+    write!(child.stdin.as_mut().unwrap(), "{stdin}")
         .expect("failed to send data to tectonic subprocess");
 
     child
@@ -375,16 +375,16 @@ fn biber_no_such_tool() {
     command.env("TECTONIC_TEST_FAKE_BIBER", "ohnothereisnobiberprogram");
 
     const REST: &str = r#"\bye"#;
-    let tex = format!("{}{}", BIBER_TRIGGER_TEX, REST);
+    let tex = format!("{BIBER_TRIGGER_TEX}{REST}");
 
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    println!("running {:?}", command);
+    println!("running {command:?}");
     let mut child = command.spawn().expect("tectonic failed to start");
 
-    write!(child.stdin.as_mut().unwrap(), "{}", tex)
+    write!(child.stdin.as_mut().unwrap(), "{tex}")
         .expect("failed to send data to tectonic subprocess");
 
     let output = child
@@ -411,7 +411,7 @@ a
 \fi
 \fi
 \bye"#;
-    let tex = format!("{}{}", BIBER_TRIGGER_TEX, REST);
+    let tex = format!("{BIBER_TRIGGER_TEX}{REST}");
     let output = run_with_biber("success", &tex);
     success_or_panic(&output);
 }
@@ -847,9 +847,9 @@ fn shell_escape_env_override() {
         .stderr(Stdio::piped())
         .env("TECTONIC_UNTRUSTED_MODE", "0");
 
-    println!("running {:?}", command);
+    println!("running {command:?}");
     let mut child = command.spawn().expect("tectonic failed to start");
-    write!(child.stdin.as_mut().unwrap(), "{}", SHELL_ESCAPE_TEST_DOC)
+    write!(child.stdin.as_mut().unwrap(), "{SHELL_ESCAPE_TEST_DOC}")
         .expect("failed to send data to tectonic subprocess");
 
     let output = child


### PR DESCRIPTION
It wants format strings to include variables inline, which is a change that I can get behind.