### PR TITLE
Remove preamble and postamble.

### DIFF
--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -21,23 +21,11 @@ use tectonic_errors::prelude::*;
 
 use crate::workspace::WorkspaceCreator;
 
-/// The default filesystem name for the "preamble" file of a document.
-///
-/// This default can be overridden on an output-by-output basis in
-/// `Tectonic.toml`.
-pub const DEFAULT_PREAMBLE_FILE: &str = "_preamble.tex";
-
 /// The default filesystem name for the main "index" file of a document.
 ///
 /// This default can be overridden on an output-by-output basis in
 /// `Tectonic.toml`.
 pub const DEFAULT_INDEX_FILE: &str = "index.tex";
-
-/// The default filesystem name for the "postamble" file of a document.
-///
-/// This default can be overridden on an output-by-output basis in
-/// `Tectonic.toml`.
-pub const DEFAULT_POSTAMBLE_FILE: &str = "_postamble.tex";
 
 /// A Tectonic document.
 #[derive(Debug)]
@@ -206,14 +194,8 @@ pub struct OutputProfile {
     /// The name of the TeX format used by this profile.
     pub tex_format: String,
 
-    /// The name of the preamble file within the `src` directory.
-    pub preamble_file: String,
-
     /// The name of the index (main) file within the `src` directory.
     pub index_file: String,
-
-    /// The name of the postamble file within the `src` directory.
-    pub postamble_file: String,
 
     /// Whether TeX's shell-escape feature should be activated in this profile.
     ///
@@ -300,9 +282,7 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
             name: "default".to_owned(),
             target_type: BuildTargetType::Pdf,
             tex_format: "latex".to_owned(),
-            preamble_file: DEFAULT_PREAMBLE_FILE.to_owned(),
             index_file: DEFAULT_INDEX_FILE.to_owned(),
-            postamble_file: DEFAULT_POSTAMBLE_FILE.to_owned(),
             shell_escape: false,
             shell_escape_cwd: None,
         },
@@ -312,7 +292,7 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
 
 /// The concrete syntax for saving document state, wired up via serde.
 mod syntax {
-    use super::{DEFAULT_INDEX_FILE, DEFAULT_POSTAMBLE_FILE, DEFAULT_PREAMBLE_FILE};
+    use super::DEFAULT_INDEX_FILE;
     use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
     #[derive(Debug, Deserialize, Serialize)]
@@ -338,12 +318,8 @@ mod syntax {
         #[serde(rename = "type")]
         pub target_type: BuildTargetType,
         pub tex_format: Option<String>,
-        #[serde(rename = "preamble")]
-        pub preamble_file: Option<String>,
         #[serde(rename = "index")]
         pub index_file: Option<String>,
-        #[serde(rename = "postamble")]
-        pub postamble_file: Option<String>,
         pub shell_escape: Option<bool>,
         pub shell_escape_cwd: Option<String>,
     }
@@ -356,22 +332,10 @@ mod syntax {
                 Some(rt.tex_format.clone())
             };
 
-            let preamble_file = if rt.preamble_file == DEFAULT_PREAMBLE_FILE {
-                None
-            } else {
-                Some(rt.preamble_file.clone())
-            };
-
             let index_file = if rt.index_file == DEFAULT_INDEX_FILE {
                 None
             } else {
                 Some(rt.index_file.clone())
-            };
-
-            let postamble_file = if rt.postamble_file == DEFAULT_POSTAMBLE_FILE {
-                None
-            } else {
-                Some(rt.postamble_file.clone())
             };
 
             let shell_escape = if !rt.shell_escape { None } else { Some(true) };
@@ -381,9 +345,7 @@ mod syntax {
                 name: rt.name.clone(),
                 target_type: BuildTargetType::from_runtime(&rt.target_type),
                 tex_format,
-                preamble_file,
                 index_file,
-                postamble_file,
                 shell_escape,
                 shell_escape_cwd,
             }
@@ -401,18 +363,10 @@ mod syntax {
                     .map(|s| s.as_ref())
                     .unwrap_or("latex")
                     .to_owned(),
-                preamble_file: self
-                    .preamble_file
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_PREAMBLE_FILE.to_owned()),
                 index_file: self
                     .index_file
                     .clone()
                     .unwrap_or_else(|| DEFAULT_INDEX_FILE.to_owned()),
-                postamble_file: self
-                    .postamble_file
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_POSTAMBLE_FILE.to_owned()),
                 shell_escape: self.shell_escape.unwrap_or(shell_escape_default),
                 shell_escape_cwd: self.shell_escape_cwd.clone(),
             }

--- a/crates/docmodel/src/workspace.rs
+++ b/crates/docmodel/src/workspace.rs
@@ -139,34 +139,17 @@ impl WorkspaceCreator {
         doc.create_toml()?;
 
         // Stub out the TeX.
-
         {
-            tex_dir.push("_preamble.tex");
+            tex_dir.push("index.tex");
             let mut f = fs::File::create(&tex_dir)?;
             f.write_all(
                 br#"\documentclass{article}
 \title{My Title}
 \begin{document}
-"#,
-            )?;
-            tex_dir.pop();
-        }
 
-        {
-            tex_dir.push("index.tex");
-            let mut f = fs::File::create(&tex_dir)?;
-            f.write_all(
-                br#"Hello, world.
-"#,
-            )?;
-            tex_dir.pop();
-        }
+Hello, world.
 
-        {
-            tex_dir.push("_postamble.tex");
-            let mut f = fs::File::create(&tex_dir)?;
-            f.write_all(
-                br#"\end{document}
+\end{document}
 "#,
             )?;
             tex_dir.pop();

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -141,14 +141,8 @@ impl DocumentExt for Document {
         };
 
         let mut input_buffer = String::new();
-        if !profile.preamble_file.is_empty() {
-            writeln!(input_buffer, "\\input{{{}}}", profile.preamble_file)?;
-        }
         if !profile.index_file.is_empty() {
             writeln!(input_buffer, "\\input{{{}}}", profile.index_file)?;
-        }
-        if !profile.postamble_file.is_empty() {
-            writeln!(input_buffer, "\\input{{{}}}", profile.postamble_file)?;
         }
 
         let mut sess_builder =


### PR DESCRIPTION
I don't really expect this to be merged as-is, but I would definitely be happy if it was. I'm using my fork for now, but I figured making it into a pr would be a good way to start a discussion at the very least.

# Why

I _despise_ the idea of an implicit preamble/postamble. Not because of compatibility; I'm perfectly fine with breaking compatibility. But because I don't like implicit dependencies.

If I want to split the preamble into a separate file, I will. But I don't want to be forced to do it.

I know you've attempted to justify this choice [here](https://github.com/tectonic-typesetting/tectonic/issues/846#issuecomment-985576778) and [here](https://github.com/tectonic-typesetting/tectonic/issues/876#issuecomment-1074696932). While I agree with everything you've said in those posts, I don't agree with the solution. Maybe some form of templating (#881) could achieve what you're aiming, but a hard-coded preamble/postamble seems clumsy at best to me.