### PR TITLE
Introduce `-Z deterministic-mode` to address a few reproducability issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ tempfile = "^3.1"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "ea222747b888b8d63df56240b262db38b095c68f"
+rev = "63366443439398a62afc9a63b34b9a3ba63b1cae"
 overlay-triplets-path = "dist/vcpkg-triplets"
 
 # If other targets start using custom triplets like x86_64-pc-windows-msvc,

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -254,7 +254,7 @@ impl<'a> CoreBridgeLauncher<'a> {
         self
     }
 
-    /// Ditto for file modification timestamps. In reproducible mode, we return
+    /// Ditto for file modification timestamps. In deterministic mode, we return
     /// the configured build time (i.e. `SOURCE_DATE_EPOCH`) instead of the
     /// modification timestamp reported by the IO subsystem.
     pub fn with_mtime_override(&mut self, mtime_override: Option<i64>) -> &mut Self {
@@ -815,7 +815,7 @@ struct FsEmulationSettings {
     /// resolve paths to TeX sources), we can disable them for reproducibility.
     expose_absolute_paths: bool,
 
-    /// Ditto for file modification timestamps. In reproducible mode, we return
+    /// Ditto for file modification timestamps. In deterministic mode, we return
     /// the configured build time (i.e. `SOURCE_DATE_EPOCH`) instead of the
     /// modification timestamp reported by the IO subsystem.
     mtime_override: Option<i64>,

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -219,6 +219,7 @@ pub struct CoreBridgeLauncher<'a> {
     hooks: &'a mut dyn DriverHooks,
     status: &'a mut dyn StatusBackend,
     security: SecuritySettings,
+    filesystem_emulation_settings: FsEmulationSettings,
 }
 
 impl<'a> CoreBridgeLauncher<'a> {
@@ -242,8 +243,18 @@ impl<'a> CoreBridgeLauncher<'a> {
             hooks,
             status,
             security,
+            filesystem_emulation_settings: FsEmulationSettings::default(),
         }
     }
+
+    /// Configure filesystem emulation settings. These default to an "accurate"
+    /// view of the provided IO subsystem, but can be restricted to provide
+    /// reproducible file modified timestamps or hide absolute paths.
+    pub fn with_fs_emulation_settings(&mut self, settings: FsEmulationSettings) -> &mut Self {
+        self.filesystem_emulation_settings = settings;
+        self
+    }
+
     /// Invoke a function to launch a bridged FFI engine with a global mutex
     /// held.
     ///
@@ -262,7 +273,12 @@ impl<'a> CoreBridgeLauncher<'a> {
         F: FnOnce(&mut CoreBridgeState<'_>) -> Result<T>,
     {
         let _guard = ENGINE_LOCK.lock().unwrap();
-        let mut state = CoreBridgeState::new(self.security.clone(), self.hooks, self.status);
+        let mut state = CoreBridgeState::new(
+            self.security.clone(),
+            self.hooks,
+            self.status,
+            self.filesystem_emulation_settings.clone(),
+        );
         let result = callback(&mut state);
 
         if let Err(ref e) = result {
@@ -284,6 +300,9 @@ impl<'a> CoreBridgeLauncher<'a> {
 pub struct CoreBridgeState<'a> {
     /// The security settings for this invocation
     security: SecuritySettings,
+
+    /// The filesystem emulation settings for this invocation.
+    fs_emulation_settings: FsEmulationSettings,
 
     /// The driver hooks associated with this engine invocation.
     hooks: &'a mut dyn DriverHooks,
@@ -312,6 +331,7 @@ impl<'a> CoreBridgeState<'a> {
         security: SecuritySettings,
         hooks: &'a mut dyn DriverHooks,
         status: &'a mut dyn StatusBackend,
+        fs_emulation_settings: FsEmulationSettings,
     ) -> CoreBridgeState<'a> {
         CoreBridgeState {
             security,
@@ -320,6 +340,7 @@ impl<'a> CoreBridgeState<'a> {
             output_handles: Vec::new(),
             input_handles: Vec::new(),
             latest_input_path: None,
+            fs_emulation_settings,
         }
     }
 
@@ -592,6 +613,9 @@ impl<'a> CoreBridgeState<'a> {
     }
 
     fn input_get_mtime(&mut self, handle: *mut InputHandle) -> i64 {
+        if let Some(mtime) = self.fs_emulation_settings.mtime_override {
+            return mtime;
+        }
         let rhandle: &mut InputHandle = unsafe { &mut *handle };
 
         let maybe_time = match rhandle.get_unix_mtime() {
@@ -770,6 +794,32 @@ impl SecuritySettings {
 impl Default for SecuritySettings {
     fn default() -> Self {
         SecuritySettings::new(SecurityStance::default())
+    }
+}
+
+/// A type that stores configuration knobs related to filesystem emulation.
+/// These options are not security-critical, but are relevant for
+/// reproducible document builds. We default to an "accurate" view of the
+/// underlying IO subsystem and have options that stub the respective IO
+/// functions with fake / stable values.
+#[derive(Clone, Debug)]
+pub struct FsEmulationSettings {
+    /// While absolute paths are useful (for SyncTeX and external tools that
+    /// resolve paths to TeX sources), we can disable them for reproducibility.
+    pub expose_absolute_paths: bool,
+
+    /// Ditto for file modification timestamps. In reproducible mode, we return
+    /// the configured build time (i.e. `SOURCE_DATE_EPOCH`) instead of the
+    /// modification timestamp reported by the IO subsystem.
+    pub mtime_override: Option<i64>,
+}
+
+impl Default for FsEmulationSettings {
+    fn default() -> Self {
+        Self {
+            expose_absolute_paths: true,
+            mtime_override: None,
+        }
     }
 }
 
@@ -968,6 +1018,9 @@ pub unsafe extern "C" fn ttbc_get_last_input_abspath(
     buffer: *mut u8,
     len: libc::size_t,
 ) -> libc::ssize_t {
+    if !es.fs_emulation_settings.expose_absolute_paths {
+        return 0;
+    }
     match es.latest_input_path {
         None => 0,
 

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -247,11 +247,18 @@ impl<'a> CoreBridgeLauncher<'a> {
         }
     }
 
-    /// Configure filesystem emulation settings. These default to an "accurate"
-    /// view of the provided IO subsystem, but can be restricted to provide
-    /// reproducible file modified timestamps or hide absolute paths.
-    pub fn with_fs_emulation_settings(&mut self, settings: FsEmulationSettings) -> &mut Self {
-        self.filesystem_emulation_settings = settings;
+    /// While absolute paths are useful (for SyncTeX and external tools that
+    /// resolve paths to TeX sources), we can disable them for reproducibility.
+    pub fn with_expose_absolute_paths(&mut self, expose_absolute_paths: bool) -> &mut Self {
+        self.filesystem_emulation_settings.expose_absolute_paths = expose_absolute_paths;
+        self
+    }
+
+    /// Ditto for file modification timestamps. In reproducible mode, we return
+    /// the configured build time (i.e. `SOURCE_DATE_EPOCH`) instead of the
+    /// modification timestamp reported by the IO subsystem.
+    pub fn with_mtime_override(&mut self, mtime_override: Option<i64>) -> &mut Self {
+        self.filesystem_emulation_settings.mtime_override = mtime_override;
         self
     }
 
@@ -803,15 +810,15 @@ impl Default for SecuritySettings {
 /// underlying IO subsystem and have options that stub the respective IO
 /// functions with fake / stable values.
 #[derive(Clone, Debug)]
-pub struct FsEmulationSettings {
+struct FsEmulationSettings {
     /// While absolute paths are useful (for SyncTeX and external tools that
     /// resolve paths to TeX sources), we can disable them for reproducibility.
-    pub expose_absolute_paths: bool,
+    expose_absolute_paths: bool,
 
     /// Ditto for file modification timestamps. In reproducible mode, we return
     /// the configured build time (i.e. `SOURCE_DATE_EPOCH`) instead of the
     /// modification timestamp reported by the IO subsystem.
-    pub mtime_override: Option<i64>,
+    mtime_override: Option<i64>,
 }
 
 impl Default for FsEmulationSettings {

--- a/crates/xetex_layout/layout/xetex-XeTeXFontInst.cpp
+++ b/crates/xetex_layout/layout/xetex-XeTeXFontInst.cpp
@@ -333,7 +333,7 @@ XeTeXFontInst::initialize(const char* pathname, int index, int &status)
 
     error = FT_New_Memory_Face(gFreeTypeLibrary, m_backingData, sz, index, &m_ftFace);
 
-    if (!FT_IS_SCALABLE(m_ftFace)) {
+    if (error || !FT_IS_SCALABLE(m_ftFace)) {
         status = 1;
         return;
     }

--- a/docs/src/ref/v1cli.md
+++ b/docs/src/ref/v1cli.md
@@ -49,16 +49,18 @@ The following are the available flags.
 | `-c`  | `--chatter <LEVEL>`       | How much chatter to print when running [default: default]  [possible values: default, minimal] |
 |       | `--format <PATH>`         | The name of the "format" file used to initialize the TeX engine [default: latex]               |
 | `-h`  | `--help`                  | Prints help information                                                                        |
-|       | `--hide <PATH>...`        | Tell the engine that no file at `<PATH>` exists, if it tries to read it                          |
+|       | `--hide <PATH>...`        | Tell the engine that no file at `<PATH>` exists, if it tries to read it                        |
 | `-k`  | `--keep-intermediates`    | Keep the intermediate files generated during processing                                        |
-|       | `--keep-logs`             | Keep the log files generated during processing                                                |
-|       | `--makefile-rules <PATH>` | Write Makefile-format rules expressing the dependencies of this run to <PATH>                  |
+|       | `--keep-logs`             | Keep the log files generated during processing                                                 |
+|       | `--makefile-rules <PATH>` | Write Makefile-format rules expressing the dependencies of this run to `<PATH>`                |
 | `-C`  | `--only-cached`           | Use only resource files cached locally                                                         |
 | `-o`  | `--outdir <OUTDIR>`       | The directory in which to place output files [default: the directory containing INPUT]         |
 |       | `--outfmt <FORMAT>`       | The kind of output to generate [default: pdf]  [possible values: pdf, html, xdv, aux, format]  |
 |       | `--pass <PASS>`           | Which engines to run [default: default]  [possible values: default, tex, bibtex_first]         |
 | `-p`  | `--print`                 | Print the engine's chatter during processing                                                   |
+|       | `--reproducible`          | Ensure deterministic builds                                                                    |
 | `-r`  | `--reruns <COUNT>`        | Rerun the TeX engine exactly this many times after the first                                   |
 |       | `--synctex`               | Generate SyncTeX data                                                                          |
+|       | `--untrusted`             | Input is untrusted: disable all known-insecure features                                        |
 | `-V`  | `--version`               | Prints version information                                                                     |
 | `-w`  | `--web-bundle <URL>`      | Use this URL find resource files instead of the default                                        |

--- a/docs/src/ref/v1cli.md
+++ b/docs/src/ref/v1cli.md
@@ -58,7 +58,6 @@ The following are the available flags.
 |       | `--outfmt <FORMAT>`       | The kind of output to generate [default: pdf]  [possible values: pdf, html, xdv, aux, format]  |
 |       | `--pass <PASS>`           | Which engines to run [default: default]  [possible values: default, tex, bibtex_first]         |
 | `-p`  | `--print`                 | Print the engine's chatter during processing                                                   |
-|       | `--reproducible`          | Ensure deterministic builds                                                                    |
 | `-r`  | `--reruns <COUNT>`        | Rerun the TeX engine exactly this many times after the first                                   |
 |       | `--synctex`               | Generate SyncTeX data                                                                          |
 |       | `--untrusted`             | Input is untrusted: disable all known-insecure features                                        |

--- a/docs/src/v2cli/build.md
+++ b/docs/src/v2cli/build.md
@@ -50,7 +50,7 @@ cause it to look for that file in the online support bundle.
 The `--print` option (or `-p` for short) will cause the engine to print the
 regular terminal output of the TeX engine. This output is similar to, but not
 identical to, the contents of the log file. By default, this output is only
-printed if the engine encounteres a fatal error.
+printed if the engine encounters a fatal error.
 
 The `--open` option will open the built document using the system handler.
 
@@ -65,3 +65,9 @@ genuine concern, we recommend setting the environment variable
 `TECTONIC_UNTRUSTED_MODE` to a non-empty value. This has the same effect as the
 `--untrusted` option. Note, however, that a hostile shell user can trivially
 clear this variable.
+
+The `--reproducible` option ensures a fully deterministic build environment.
+The most notable difference is a static document build time (`\today`), which can
+be configured explicitly by setting the `SOURCE_DATE_EPOCH` environment variable.
+There's a few ways to break determinism (shell escape, reading from `/dev/urandom`),
+but anything else (especially behaviour in TeXLive packages) is considered a bug.

--- a/docs/src/v2cli/build.md
+++ b/docs/src/v2cli/build.md
@@ -65,9 +65,3 @@ genuine concern, we recommend setting the environment variable
 `TECTONIC_UNTRUSTED_MODE` to a non-empty value. This has the same effect as the
 `--untrusted` option. Note, however, that a hostile shell user can trivially
 clear this variable.
-
-The `--reproducible` option ensures a fully deterministic build environment.
-The most notable difference is a static document build time (`\today`), which can
-be configured explicitly by setting the `SOURCE_DATE_EPOCH` environment variable.
-There's a few ways to break determinism (shell escape, reading from `/dev/urandom`),
-but anything else (especially behaviour in TeXLive packages) is considered a bug.

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -111,7 +111,6 @@ The following are the available flags.
 |       | `--outfmt <FORMAT>`       | The kind of output to generate. Possible values: `pdf` (the default), `html`, `xdv`, `aux`, `format` |
 |       | `--pass <PASS>`           | Which engines to run. Possible values: `default`, `tex`, `bibtex_first` |
 | `-p`  | `--print`                 | Print the engine's chatter during processing |
-|       | `--reproducible`          | Ensure deterministic builds |
 | `-r`  | `--reruns <COUNT>`        | Rerun the TeX engine exactly this many times after the first |
 |       | `--synctex`               | Generate SyncTeX data |
 |       | `--untrusted`             | Input is untrusted: disable all known-insecure features |
@@ -135,3 +134,4 @@ the set of unstable options is subject to change at any time.
 | `-Z search-path=<path>`  | Also look in `<path>` for files (unless `--untrusted` has been specified), like TEXINPUTS. Can be specified multiple times. |
 | `-Z shell-escape`        | Enable `\write18` (unless `--untrusted` has been specified) |
 | `-Z shell-escape-cwd=<path>` | Working directory to use for \write18. Use $(pwd) for same behaviour as most other engines (e.g. for relative paths in \inputminted). Implies -Z shell-escape |
+| `-Z deterministic-mode`  | Force a deterministic build environment. Note that setting `SOURCE_DATE_EPOCH` is usually sufficient for reproducible builds, and this option makes some extra functionality trade-offs. Specifically, deterministic mode breaks SyncTeX's auxiliary files as they include and rely on absolute file paths |

--- a/docs/src/v2cli/compile.md
+++ b/docs/src/v2cli/compile.md
@@ -111,6 +111,7 @@ The following are the available flags.
 |       | `--outfmt <FORMAT>`       | The kind of output to generate. Possible values: `pdf` (the default), `html`, `xdv`, `aux`, `format` |
 |       | `--pass <PASS>`           | Which engines to run. Possible values: `default`, `tex`, `bibtex_first` |
 | `-p`  | `--print`                 | Print the engine's chatter during processing |
+|       | `--reproducible`          | Ensure deterministic builds |
 | `-r`  | `--reruns <COUNT>`        | Rerun the TeX engine exactly this many times after the first |
 |       | `--synctex`               | Generate SyncTeX data |
 |       | `--untrusted`             | Input is untrusted: disable all known-insecure features |

--- a/docs/src/v2cli/dump.md
+++ b/docs/src/v2cli/dump.md
@@ -44,9 +44,9 @@ one of its parents.
 [tectonic-toml]: ../ref/tectonic-toml.md
 
 The “partial build” consists of one pass of the TeX engine. Future versions of
-this tool might gain options allowing you specify different passes. This command
-can be used to dump any file created by TeX during the build (so long as it's
-created on the first pass).
+this tool might gain options allowing you to specify different passes. This
+command can be used to dump any file created by TeX during the build (so long
+as it's created on the first pass).
 
 #### Command-Line Options
 

--- a/src/bin/tectonic/compile.rs
+++ b/src/bin/tectonic/compile.rs
@@ -89,10 +89,6 @@ pub struct CompileOptions {
     #[structopt(long)]
     untrusted: bool,
 
-    /// Ensure deterministic build environment
-    #[structopt(long = "reproducible")]
-    reproducible_mode: bool,
-
     /// Unstable options. Pass -Zhelp to show a list
     #[structopt(name = "option", short = "Z", number_of_values = 1)]
     unstable: Vec<UnstableArg>,
@@ -115,14 +111,14 @@ impl CompileOptions {
         let mut sess_builder =
             ProcessingSessionBuilder::new_with_security(SecuritySettings::new(stance));
         let format_path = self.format;
+        let deterministic_mode = unstable.deterministic_mode;
         sess_builder
             .unstables(unstable)
             .format_name(&format_path)
             .keep_logs(self.keep_logs)
             .keep_intermediates(self.keep_intermediates)
             .format_cache_path(config.format_cache_path()?)
-            .synctex(self.synctex)
-            .reproducible_mode(self.reproducible_mode);
+            .synctex(self.synctex);
 
         sess_builder.output_format(OutputFormat::from_str(&self.outfmt).unwrap());
 
@@ -202,7 +198,7 @@ impl CompileOptions {
         } else {
             sess_builder.bundle(config.default_bundle(only_cached, status)?);
         }
-        sess_builder.build_date_from_env(self.reproducible_mode);
+        sess_builder.build_date_from_env(deterministic_mode);
         run_and_report(sess_builder, status).map(|_| 0)
     }
 }

--- a/src/bin/tectonic/compile.rs
+++ b/src/bin/tectonic/compile.rs
@@ -6,10 +6,8 @@
 //! `compile` subcommand of the "V2" / "cargo-like" interface.
 
 use std::{
-    env,
     path::{Path, PathBuf},
     str::FromStr,
-    time,
 };
 use structopt::StructOpt;
 use tectonic_bridge_core::{SecuritySettings, SecurityStance};
@@ -91,6 +89,10 @@ pub struct CompileOptions {
     #[structopt(long)]
     untrusted: bool,
 
+    /// Ensure deterministic build environment
+    #[structopt(long = "reproducible")]
+    reproducible_mode: bool,
+
     /// Unstable options. Pass -Zhelp to show a list
     #[structopt(name = "option", short = "Z", number_of_values = 1)]
     unstable: Vec<UnstableArg>,
@@ -119,7 +121,8 @@ impl CompileOptions {
             .keep_logs(self.keep_logs)
             .keep_intermediates(self.keep_intermediates)
             .format_cache_path(config.format_cache_path()?)
-            .synctex(self.synctex);
+            .synctex(self.synctex)
+            .reproducible_mode(self.reproducible_mode);
 
         sess_builder.output_format(OutputFormat::from_str(&self.outfmt).unwrap());
 
@@ -199,18 +202,7 @@ impl CompileOptions {
         } else {
             sess_builder.bundle(config.default_bundle(only_cached, status)?);
         }
-
-        let build_date_str = env::var("SOURCE_DATE_EPOCH").ok();
-        let build_date = match build_date_str {
-            Some(s) => {
-                let epoch = s.parse::<u64>().expect("invalid build date (not a number)");
-                time::SystemTime::UNIX_EPOCH
-                    .checked_add(time::Duration::from_secs(epoch))
-                    .expect("time overflow")
-            }
-            None => time::SystemTime::now(),
-        };
-        sess_builder.build_date(build_date);
+        sess_builder.build_date_from_env(self.reproducible_mode);
         run_and_report(sess_builder, status).map(|_| 0)
     }
 }

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -238,10 +238,6 @@ pub struct BuildCommand {
     /// Open built document using system handler
     #[structopt(long)]
     open: bool,
-
-    /// Ensure deterministic build environment
-    #[structopt(long = "reproducible")]
-    reproducible_mode: bool,
 }
 
 impl BuildCommand {
@@ -264,7 +260,6 @@ impl BuildCommand {
         let mut setup_options =
             DocumentSetupOptions::new_with_security(SecuritySettings::new(stance));
         setup_options.only_cached(self.only_cached);
-        setup_options.reproducible_mode(self.reproducible_mode);
 
         for output_name in doc.output_names() {
             let mut builder = doc.setup_session(output_name, &setup_options, status)?;

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -238,6 +238,10 @@ pub struct BuildCommand {
     /// Open built document using system handler
     #[structopt(long)]
     open: bool,
+
+    /// Ensure deterministic build environment
+    #[structopt(long = "reproducible")]
+    reproducible_mode: bool,
 }
 
 impl BuildCommand {
@@ -260,6 +264,7 @@ impl BuildCommand {
         let mut setup_options =
             DocumentSetupOptions::new_with_security(SecuritySettings::new(stance));
         setup_options.only_cached(self.only_cached);
+        setup_options.reproducible_mode(self.reproducible_mode);
 
         for output_name in doc.output_names() {
             let mut builder = doc.setup_session(output_name, &setup_options, status)?;

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -40,6 +40,9 @@ pub struct DocumentSetupOptions {
 
     /// Security settings for engine features.
     security: SecuritySettings,
+
+    /// Ensure a deterministic build environment.
+    reproducible_mode: bool,
 }
 
 impl DocumentSetupOptions {
@@ -48,6 +51,7 @@ impl DocumentSetupOptions {
     pub fn new_with_security(security: SecuritySettings) -> Self {
         DocumentSetupOptions {
             only_cached: false,
+            reproducible_mode: false,
             security,
         }
     }
@@ -59,6 +63,12 @@ impl DocumentSetupOptions {
     /// have no effect.
     pub fn only_cached(&mut self, s: bool) -> &mut Self {
         self.only_cached = s;
+        self
+    }
+
+    /// Specify whether we want to ensure a deterministic build environment.
+    pub fn reproducible_mode(&mut self, s: bool) -> &mut Self {
+        self.reproducible_mode = s;
         self
     }
 }
@@ -157,7 +167,8 @@ impl DocumentExt for Document {
         sess_builder
             .output_format(output_format)
             .format_name(&profile.tex_format)
-            .build_date(std::time::SystemTime::now())
+            .build_date_from_env(setup_options.reproducible_mode)
+            .reproducible_mode(setup_options.reproducible_mode)
             .pass(PassSetting::Default)
             .primary_input_buffer(input_buffer.as_bytes())
             .tex_input_name(output_profile);

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -29,6 +29,7 @@ use crate::{
     errors::{ErrorKind, Result},
     status::StatusBackend,
     test_util, tt_note,
+    unstable_opts::UnstableOptions,
 };
 
 /// Options for setting up [`Document`] instances with the driver
@@ -42,7 +43,7 @@ pub struct DocumentSetupOptions {
     security: SecuritySettings,
 
     /// Ensure a deterministic build environment.
-    reproducible_mode: bool,
+    deterministic_mode: bool,
 }
 
 impl DocumentSetupOptions {
@@ -51,7 +52,7 @@ impl DocumentSetupOptions {
     pub fn new_with_security(security: SecuritySettings) -> Self {
         DocumentSetupOptions {
             only_cached: false,
-            reproducible_mode: false,
+            deterministic_mode: false,
             security,
         }
     }
@@ -67,8 +68,8 @@ impl DocumentSetupOptions {
     }
 
     /// Specify whether we want to ensure a deterministic build environment.
-    pub fn reproducible_mode(&mut self, s: bool) -> &mut Self {
-        self.reproducible_mode = s;
+    pub fn deterministic_mode(&mut self, s: bool) -> &mut Self {
+        self.deterministic_mode = s;
         self
     }
 }
@@ -167,8 +168,11 @@ impl DocumentExt for Document {
         sess_builder
             .output_format(output_format)
             .format_name(&profile.tex_format)
-            .build_date_from_env(setup_options.reproducible_mode)
-            .reproducible_mode(setup_options.reproducible_mode)
+            .build_date_from_env(setup_options.deterministic_mode)
+            .unstables(UnstableOptions {
+                deterministic_mode: setup_options.deterministic_mode,
+                ..Default::default()
+            })
             .pass(PassSetting::Default)
             .primary_input_buffer(input_buffer.as_bytes())
             .tex_input_name(output_profile);

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -817,7 +817,6 @@ pub struct ProcessingSessionBuilder {
     build_date: Option<SystemTime>,
     unstables: UnstableOptions,
     shell_escape_mode: ShellEscapeMode,
-    reproducible_mode: bool,
     html_assets_spec_path: Option<String>,
     html_precomputed_assets: Option<AssetSpecification>,
     html_do_not_emit_files: bool,
@@ -988,11 +987,11 @@ impl ProcessingSessionBuilder {
 
     /// Configures the date and time of the processing session from the environment:
     /// If `SOURCE_DATE_EPOCH` is set, it's used as the build date.
-    /// If `force_reproducible` is set, we fall back to UNIX_EPOCH.
+    /// If `force_deterministic` is set, we fall back to UNIX_EPOCH.
     /// Otherwise, we use the current system time.
-    pub fn build_date_from_env(&mut self, force_reproducible: bool) -> &mut Self {
+    pub fn build_date_from_env(&mut self, force_deterministic: bool) -> &mut Self {
         let build_date_str = std::env::var("SOURCE_DATE_EPOCH").ok();
-        let build_date = match (force_reproducible, build_date_str) {
+        let build_date = match (force_deterministic, build_date_str) {
             (_, Some(s)) => {
                 let epoch = s
                     .parse::<u64>()
@@ -1044,21 +1043,6 @@ impl ProcessingSessionBuilder {
     /// temporary directory will be used.
     pub fn shell_escape_disabled(&mut self) -> &mut Self {
         self.shell_escape_mode = ShellEscapeMode::Disabled;
-        self
-    }
-
-    /// Ensure a deterministic build environment.
-    ///
-    /// The most significant user-facing difference is a static document build
-    /// date, but this is already covered by [`build_date_from_env`], which
-    /// accepts a `reproducible` flag. Additionally, reproducible mode spoofs
-    /// file modification times and hides absolute paths from the engine.
-    ///
-    /// There's a few ways to break determinism (shell escape, reading from
-    /// `/dev/urandom`), but anything else (especially behaviour in TeXLive
-    /// packages) is considered a bug.
-    pub fn reproducible_mode(&mut self, reproducible: bool) -> &mut Self {
-        self.reproducible_mode = reproducible;
         self
     }
 
@@ -1277,7 +1261,6 @@ impl ProcessingSessionBuilder {
             build_date: self.build_date.unwrap_or(SystemTime::UNIX_EPOCH),
             unstables: self.unstables,
             shell_escape_mode,
-            reproducible_mode: self.reproducible_mode,
             html_assets_spec_path: self.html_assets_spec_path,
             html_precomputed_assets: self.html_precomputed_assets,
             html_emit_files: !self.html_do_not_emit_files,
@@ -1344,8 +1327,6 @@ pub struct ProcessingSession {
     build_date: SystemTime,
 
     unstables: UnstableOptions,
-
-    reproducible_mode: bool,
 
     /// How to handle shell-escape. The `Defaulted` option will never
     /// be used here.
@@ -1871,15 +1852,15 @@ impl ProcessingSession {
             let mut launcher =
                 CoreBridgeLauncher::new_with_security(&mut self.bs, status, self.security.clone());
 
-            // In reproducible mode, we stub a few aspects of the environment.
+            // In deterministic mode, we stub a few aspects of the environment.
             // They default to a "realistic" view, but we override them with static values:
-            if self.reproducible_mode {
+            if self.unstables.deterministic_mode {
                 launcher.with_expose_absolute_paths(false);
                 launcher.with_mtime_override(Some(
                     self.build_date
                         .duration_since(SystemTime::UNIX_EPOCH)
                         .map(|x| x.as_secs() as i64)
-                        .expect("invalid build date in reproducible mode"),
+                        .expect("invalid build date in deterministic mode"),
                 ));
             }
 


### PR DESCRIPTION
I've dusted off `tectonic-on-arXiv`, and I looks like upgrading to the TeXLive 2022 bundle uncovered new reproducibility issues:
- Documents that request synctex files with `\synctex=1` contain absolute paths to the TeX files. ~~This seems intentional, so I've left absolute paths enabled for `tectonic --synctex` runs.~~
- The `hyperxmp` package embeds a bunch of metadata into the output PDF. In particular, it derives a random "xmpMM:InstanceId" from a bunch of information sources. One of those is the input file modification timestamp. I've wired this up to be the document build date instead. ~~I'm not sure if there's a "legitimate" use case for file modification timestamps, so let's just try always returning the build date instead. :slightly_smiling_face:~~


=> https://tt.ente.ninja/#/compare/05d445d074674bf1da7dd277bc8524fe85388ea9-untrusted-run-1/05d445d074674bf1da7dd277bc8524fe85388ea9-untrusted-run-2