### PR TITLE
Added ability to specify target of build

### DIFF
--- a/docs/src/v2cli/build.md
+++ b/docs/src/v2cli/build.md
@@ -18,6 +18,7 @@ tectonic -X build
   [--print]
   [--open]
   [--untrusted]
+  [--target NAME]
 ```
 
 #### Remarks
@@ -31,6 +32,10 @@ directory.
 [tectonic-toml]: ../ref/tectonic-toml.md
 
 #### Command-Line Options
+
+The `--target` option will only build the
+[output](../ref/tectonic-toml.md#output) with the specified name. If this option
+is not given, all outputs will be built.
 
 The `--keep-intermediates` option (or `-k` for short) will cause the engine to
 save intermediate files (such as `mydoc.aux` or `mydoc.bbl`) in the build output

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -266,7 +266,6 @@ impl BuildCommand {
         setup_options.only_cached(self.only_cached);
 
         for output_name in doc.output_names() {
-
             // Added checking to see if the output name matches the specified target name
             if let Some(out) = self.target.clone() {
                 if out != output_name {

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -238,6 +238,10 @@ pub struct BuildCommand {
     /// Open built document using system handler
     #[structopt(long)]
     open: bool,
+
+    /// Specify a target to be used by the build
+    #[structopt(long, help = "Specify the target of the build.")]
+    target: Option<String>,
 }
 
 impl BuildCommand {
@@ -262,6 +266,14 @@ impl BuildCommand {
         setup_options.only_cached(self.only_cached);
 
         for output_name in doc.output_names() {
+
+            // Added checking to see if the output name matches the specified target name
+            if let Some(out) = self.target.clone() {
+                if out != output_name {
+                    continue;
+                }
+            }
+
             let mut builder = doc.setup_session(output_name, &setup_options, status)?;
 
             builder

--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -266,8 +266,7 @@ impl BuildCommand {
         setup_options.only_cached(self.only_cached);
 
         for output_name in doc.output_names() {
-            // Added checking to see if the output name matches the specified target name
-            if let Some(out) = self.target.clone() {
+            if let Some(out) = self.target.as_ref() {
                 if out != output_name {
                     continue;
                 }


### PR DESCRIPTION
Solves #970.

Simple PR that checks if an optional target is specified in the build command. If yes, matches it and builds only the specific output name.