### PR TITLE
added proper exe parsing for watch, supports spaces in tectonic location

### DIFF
--- a/src/bin/tectonic/v2cli.rs
+++ b/src/bin/tectonic/v2cli.rs
@@ -560,7 +560,7 @@ impl WatchCommand {
                 let cmd = Command::Shell {
                     shell: shell.clone(),
                     args: vec![],
-                    command: format!("{exe_name} -X {}", x),
+                    command: format!("\"{exe_name}\" -X {}", x),
                 };
                 cmds.push(cmd)
             }


### PR DESCRIPTION
1 line change to solve #1003.

Added quotes around exe_name to support running `watch -x` command for users with spaces in their tectonic bin location.