### PR TITLE
Grow global_str buffer by the correct amount

### DIFF
--- a/crates/engine_bibtex/src/c_api/global.rs
+++ b/crates/engine_bibtex/src/c_api/global.rs
@@ -23,7 +23,7 @@ impl GlobalData {
 
     fn grow(&mut self) {
         self.glb_bib_str_ptr.grow(MAX_GLOB_STRS);
-        self.global_strs.grow(MAX_GLOB_STRS);
+        self.global_strs.grow((GLOB_STR_SIZE + 1) * MAX_GLOB_STRS);
         self.glb_str_end.grow(MAX_GLOB_STRS);
     }
 }


### PR DESCRIPTION
Fixes #1054 
Out-of-bounds was caused because the actual global string list was being grown by `10`, not `STR_SIZE * 10`, basically.