### PR TITLE
Make file expectations always check all expected files at once

### DIFF
--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -1227,7 +1227,7 @@ pub unsafe extern "C" fn ttbc_diag_append(diag: &mut Diagnostic, text: *const li
 #[no_mangle]
 pub extern "C" fn ttbc_diag_finish(es: &mut CoreBridgeState, diag: *mut Diagnostic) {
     // By creating the box, we will free the diagnostic when this function exits.
-    let rdiag = unsafe { Box::from_raw(diag as *mut Diagnostic) };
+    let rdiag = unsafe { Box::from_raw(diag) };
     es.status
         .report(rdiag.kind, format_args!("{}", rdiag.message), None);
 }

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -1224,6 +1224,10 @@ pub unsafe extern "C" fn ttbc_diag_append(diag: &mut Diagnostic, text: *const li
 }
 
 /// "Finish" a diagnostic: report it to the driver and free the diagnostic object.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw Diagnostic pointer
 #[no_mangle]
 pub unsafe extern "C" fn ttbc_diag_finish(es: &mut CoreBridgeState, diag: *mut Diagnostic) {
     // By creating the box, we will free the diagnostic when this function exits.

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -1225,9 +1225,9 @@ pub unsafe extern "C" fn ttbc_diag_append(diag: &mut Diagnostic, text: *const li
 
 /// "Finish" a diagnostic: report it to the driver and free the diagnostic object.
 #[no_mangle]
-pub extern "C" fn ttbc_diag_finish(es: &mut CoreBridgeState, diag: *mut Diagnostic) {
+pub unsafe extern "C" fn ttbc_diag_finish(es: &mut CoreBridgeState, diag: *mut Diagnostic) {
     // By creating the box, we will free the diagnostic when this function exits.
-    let rdiag = unsafe { Box::from_raw(diag) };
+    let rdiag = Box::from_raw(diag);
     es.status
         .report(rdiag.kind, format_args!("{}", rdiag.message), None);
 }

--- a/crates/docmodel/src/workspace.rs
+++ b/crates/docmodel/src/workspace.rs
@@ -144,10 +144,10 @@ impl WorkspaceCreator {
             tex_dir.push("_preamble.tex");
             let mut f = fs::File::create(&tex_dir)?;
             f.write_all(
-                br#"\documentclass{article}
+                br"\documentclass{article}
 \title{My Title}
 \begin{document}
-"#,
+",
             )?;
             tex_dir.pop();
         }
@@ -156,8 +156,8 @@ impl WorkspaceCreator {
             tex_dir.push("index.tex");
             let mut f = fs::File::create(&tex_dir)?;
             f.write_all(
-                br#"Hello, world.
-"#,
+                br"Hello, world.
+",
             )?;
             tex_dir.pop();
         }
@@ -166,8 +166,8 @@ impl WorkspaceCreator {
             tex_dir.push("_postamble.tex");
             let mut f = fs::File::create(&tex_dir)?;
             f.write_all(
-                br#"\end{document}
-"#,
+                br"\end{document}
+",
             )?;
             tex_dir.pop();
         }

--- a/crates/io_base/src/lib.rs
+++ b/crates/io_base/src/lib.rs
@@ -674,7 +674,7 @@ fn try_normalize_tex_path(path: &str) -> Option<String> {
 
     let r = repeat("..")
         .take(parent_level)
-        .chain(r.into_iter())
+        .chain(r)
         // No `join` on `Iterator`.
         .collect::<Vec<_>>()
         .join("/");

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -173,10 +173,6 @@ parameters:
     vars:
       TARGET: i686-unknown-linux-gnu
 
-  - name: mips_unknown_linux_gnu
-    vars:
-      TARGET: mips-unknown-linux-gnu
-
   - name: x86_64_unknown_linux_musl
     vars:
       TARGET: x86_64-unknown-linux-musl

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -183,6 +183,46 @@ parameters:
 
 jobs:
 
+# rustfmt check
+- job: rustfmt
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+    - bash: rustup component add rustfmt
+      displayName: "Install rustfmt"
+    - bash: cargo fmt --all -- --check
+      displayName: "Check rustfmt (cargo)"
+  variables:
+    TOOLCHAIN: stable
+
+# clippy check
+- job: clippy
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+    - template: azure-generic-build-setup.yml
+    - bash: |
+        rustup component add clippy
+        cargo clippy --version
+      displayName: "Install clippy"
+    # Ew, redundant with stock builds:
+    - bash: |
+        set -xeuo pipefail
+        sudo apt-get update
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          libgraphite2-dev \
+          libharfbuzz-dev \
+          libfontconfig1-dev \
+          libicu-dev \
+          libssl-dev \
+          openssl \
+          zlib1g-dev
+      displayName: "Install pkg-config dependencies (Ubuntu)"
+    - bash: cargo clippy --all --all-targets --all-features -- --deny warnings
+      displayName: "Check clippy (cargo)"
+  variables:
+    TOOLCHAIN: stable
+
 # pkg-config builds
 - ${{ each build in parameters.pkgconfigBuilds }}:
   - job: ${{ format('build_{0}_pkgconfig', build.name) }}
@@ -224,46 +264,6 @@ jobs:
     vmImage: ubuntu-20.04
   steps:
     - template: azure-coverage.yml
-  variables:
-    TOOLCHAIN: stable
-
-# rustfmt check
-- job: rustfmt
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-    - bash: rustup component add rustfmt
-      displayName: "Install rustfmt"
-    - bash: cargo fmt --all -- --check
-      displayName: "Check rustfmt (cargo)"
-  variables:
-    TOOLCHAIN: stable
-
-# clippy check
-- job: clippy
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-    - template: azure-generic-build-setup.yml
-    - bash: |
-        rustup component add clippy
-        cargo clippy --version
-      displayName: "Install clippy"
-    # Ew, redundant with stock builds:
-    - bash: |
-        set -xeuo pipefail
-        sudo apt-get update
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-          libgraphite2-dev \
-          libharfbuzz-dev \
-          libfontconfig1-dev \
-          libicu-dev \
-          libssl-dev \
-          openssl \
-          zlib1g-dev
-      displayName: "Install pkg-config dependencies (Ubuntu)"
-    - bash: cargo clippy --all --all-targets --all-features -- --deny warnings
-      displayName: "Check clippy (cargo)"
   variables:
     TOOLCHAIN: stable
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -403,7 +403,7 @@ fn biber_no_such_tool() {
 
     command.env("TECTONIC_TEST_FAKE_BIBER", "ohnothereisnobiberprogram");
 
-    const REST: &str = r#"\bye"#;
+    const REST: &str = r"\bye";
     let tex = format!("{BIBER_TRIGGER_TEX}{REST}");
 
     command
@@ -431,7 +431,7 @@ fn biber_signal() {
 
 #[test]
 fn biber_success() {
-    const REST: &str = r#"
+    const REST: &str = r"
 \ifsecond
 \ifnum\input{biberout.qqq}=456\relax
 a
@@ -439,7 +439,7 @@ a
 \ohnothebiberdidntwork
 \fi
 \fi
-\bye"#;
+\bye";
     let tex = format!("{BIBER_TRIGGER_TEX}{REST}");
     let output = run_with_biber("success", &tex);
     success_or_panic(&output);
@@ -771,14 +771,14 @@ fn v2_dump_suffix() {
         writeln!(
             file,
             "{}", // <= works around {} fussiness in Rust format strings
-            r#"\newwrite\w
+            r"\newwrite\w
 \immediate\openout\w=first.demo\relax
 \immediate\write\w{content-un}
 \immediate\closeout\w
 \immediate\openout\w=second.demo\relax
 \immediate\write\w{content-deux}
 \immediate\closeout\w
-"#
+"
         )
         .unwrap();
     }
@@ -806,7 +806,7 @@ fn v2_dump_suffix() {
     assert!(saw_first && saw_second);
 }
 
-const SHELL_ESCAPE_TEST_DOC: &str = r#"\immediate\write18{mkdir shellwork}
+const SHELL_ESCAPE_TEST_DOC: &str = r"\immediate\write18{mkdir shellwork}
 \immediate\write18{echo 123 >shellwork/persist}
 \ifnum123=\input{shellwork/persist}
 a
@@ -814,7 +814,7 @@ a
 \ohnotheshellescapedidntwork
 \fi
 \bye
-"#;
+";
 
 /// Test that shell escape actually runs the commands
 #[test]

--- a/tests/trip.rs
+++ b/tests/trip.rs
@@ -24,7 +24,7 @@ use tectonic_status_base::NoopStatusBackend;
 
 #[path = "util/mod.rs"]
 mod util;
-use crate::util::{test_path, ExpectedInfo};
+use crate::util::{test_path, Expected, ExpectedFile};
 
 #[test]
 fn trip_test() {
@@ -41,11 +41,11 @@ fn trip_test() {
     let mut tfm = SingleInputFileIo::new(&p);
 
     // Read in the expected outputs.
-    let expected_log = ExpectedInfo::read_with_extension(&mut p, "log");
-    let expected_xdv = ExpectedInfo::read_with_extension(&mut p, "xdv");
-    let expected_fot = ExpectedInfo::read_with_extension(&mut p, "fot");
+    let expected_log = ExpectedFile::read_with_extension(&mut p, "log");
+    let expected_xdv = ExpectedFile::read_with_extension(&mut p, "xdv");
+    let expected_fot = ExpectedFile::read_with_extension(&mut p, "fot");
     p.set_file_name("tripos");
-    let expected_os = ExpectedInfo::read_with_extension(&mut p, "tex");
+    let expected_os = ExpectedFile::read_with_extension(&mut p, "tex");
 
     // MemoryIo layer that will accept the outputs. Save `files` since the
     // engine consumes `mem`.
@@ -81,10 +81,12 @@ fn trip_test() {
 
     // Check that outputs match expectations.
     let files = &*mem.files.borrow();
-    expected_log.test_from_collection(files);
-    expected_xdv.test_from_collection(files);
-    expected_os.test_from_collection(files);
-    expected_fot.test_data(&files.get("").unwrap().data);
+    Expected::new()
+        .file(expected_log.collection(files))
+        .file(expected_xdv.collection(files))
+        .file(expected_os.collection(files))
+        .file(expected_fot.data(&files.get("").unwrap().data))
+        .finish();
 }
 
 #[test]
@@ -102,10 +104,10 @@ fn etrip_test() {
     let mut tfm = SingleInputFileIo::new(&p);
 
     // Read in the expected outputs.
-    let expected_log = ExpectedInfo::read_with_extension(&mut p, "log");
-    let expected_xdv = ExpectedInfo::read_with_extension(&mut p, "xdv");
-    let expected_fot = ExpectedInfo::read_with_extension(&mut p, "fot");
-    let expected_out = ExpectedInfo::read_with_extension(&mut p, "out");
+    let expected_log = ExpectedFile::read_with_extension(&mut p, "log");
+    let expected_xdv = ExpectedFile::read_with_extension(&mut p, "xdv");
+    let expected_fot = ExpectedFile::read_with_extension(&mut p, "fot");
+    let expected_out = ExpectedFile::read_with_extension(&mut p, "out");
 
     // MemoryIo layer that will accept the outputs. Save `files` since the
     // engine consumes `mem`.
@@ -142,8 +144,10 @@ fn etrip_test() {
 
     // Check that outputs match expectations.
     let files = &*files.borrow();
-    expected_log.test_from_collection(files);
-    expected_xdv.test_from_collection(files);
-    expected_out.test_from_collection(files);
-    expected_fot.test_data(&files.get("").unwrap().data);
+    Expected::new()
+        .file(expected_log.collection(files))
+        .file(expected_xdv.collection(files))
+        .file(expected_out.collection(files))
+        .file(expected_fot.data(&files.get("").unwrap().data))
+        .finish();
 }


### PR DESCRIPTION
This keeps bothering me while debugging bibtex failures, and just flipping the file order there would work, but it would be a band-aid, not a real solution. So here's a real solution - make all expectations test once, and panic once at the end.

(Also removed `genio` from bibtex tests, as it just confuses the output and all the useful logs go to both stdout and the file, IME)