### PR TITLE
Add aarch64-unknown-linux-musl as a cross-buildable architecture

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[target.aarch64-unknown-linux-musl]
+image = "tectonictypesetting/crossbuild:aarch64-unknown-linux-musl"
+
 [target.arm-unknown-linux-musleabihf]
 image = "tectonictypesetting/crossbuild:arm-unknown-linux-musleabihf"
 

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -165,6 +165,10 @@ parameters:
 - name: crossBuilds
   type: object
   default:
+  - name: aarch64_unknown_linux_musl
+    vars:
+      TARGET: aarch64-unknown-linux-musl
+
   - name: arm_unknown_linux_musleabihf
     vars:
       TARGET: arm-unknown-linux-musleabihf


### PR DESCRIPTION
This includes one of the gnarliest build hacks I've ever had to perpetrate, as documented in
`crates/engine_xetex/xetex/xetex-engine-interface.c`.

xref: https://github.com/tectonic-typesetting/tectonic-ci-support/pull/24