### PR TITLE
V2 CLI: Add external commands

### DIFF
--- a/docs/src/ref/v2cli.md
+++ b/docs/src/ref/v2cli.md
@@ -40,6 +40,14 @@ nextonic build
 You can use various Unix `argv[0]` hacks to achieve this, or you can just rename
 or symlink the `tectonic` binary to `nextonic` manually.
 
+
+## External tools
+
+The V2 interface also supports external commands. If you run `tectonic -X cmd`, where `cmd` is NOT built into Tectonic, Tectonic will search for a binary called `tectonic-cmd` and run it if it exists.
+
+
+
+
 ## Migration plan
 
 The plan is to eventually migrate to make the V2 interface the default. This


### PR DESCRIPTION
Implemented the feature proposed in #737.
Is it really that easy?

**A question:**
Should `v2_main` exit earlier if an external command is given?
We probably don't need to set up colors and customizations if we're running an external command.
