### PR TITLE
Extra paths for shared resources

### DIFF
--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -633,11 +633,7 @@ impl<'a> CoreBridgeState<'a> {
             }
         };
 
-        if let Some(t) = maybe_time {
-            t
-        } else {
-            1 // Intentionally make this distinguishable from the error value 0
-        }
+        maybe_time.unwrap_or(1)
     }
 
     fn input_seek(&mut self, handle: *mut InputHandle, pos: SeekFrom) -> Result<u64> {

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -53,6 +53,10 @@ pub struct Document {
     /// Either a URL or a local path.
     pub bundle_loc: String,
 
+    /// Extra local search paths for this document.
+    /// May be absolute or relative to src_dir.
+    pub extra_paths: Vec<PathBuf>,
+
     /// The different outputs that are created from the document source. These
     /// may have different formats (e.g., PDF and HTML) or the same format but
     /// different settings (e.g., PDF with A4 paper and PDF with US Letter
@@ -98,6 +102,7 @@ impl Document {
             build_dir: build_dir.into(),
             name: doc.doc.name,
             bundle_loc: doc.doc.bundle,
+            extra_paths: doc.doc.extra_paths.unwrap_or_default(),
             metadata: doc.doc.metadata,
             outputs,
         })
@@ -116,10 +121,17 @@ impl Document {
             .map(syntax::TomlOutputProfile::from)
             .collect();
 
+        let extra_paths = if self.extra_paths.is_empty() {
+            None
+        } else {
+            Some(self.extra_paths.clone())
+        };
+
         let doc = syntax::TomlDocument {
             doc: syntax::TomlDocSection {
                 name: self.name.clone(),
                 bundle: self.bundle_loc.clone(),
+                extra_paths,
                 metadata: None,
             },
             outputs,
@@ -246,7 +258,11 @@ pub enum InputFile {
 impl Document {
     /// Create a new in-memory Document, based on the settings of a
     /// WorkspaceCreator object.
-    pub(crate) fn create_for(wc: &WorkspaceCreator, bundle_loc: String) -> Result<Self> {
+    pub(crate) fn create_for(
+        wc: &WorkspaceCreator,
+        bundle_loc: String,
+        extra_paths: Vec<PathBuf>,
+    ) -> Result<Self> {
         let src_dir = wc.root_dir.clone();
 
         let mut build_dir = src_dir.clone();
@@ -288,6 +304,7 @@ impl Document {
             build_dir,
             name,
             bundle_loc,
+            extra_paths,
             outputs: crate::document::default_outputs(),
             metadata: None,
         })

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -6,6 +6,8 @@
 //!
 //! This module is only used by [`crate::document::Document`]
 
+use std::path::PathBuf;
+
 use crate::document::{BuildTargetType, InputFile, OutputProfile};
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -30,6 +32,7 @@ pub struct TomlDocSection {
     pub name: String,
     pub bundle: String,
     pub metadata: Option<toml::Value>,
+    pub extra_paths: Option<Vec<PathBuf>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/docmodel/src/workspace.rs
+++ b/crates/docmodel/src/workspace.rs
@@ -125,8 +125,8 @@ impl WorkspaceCreator {
     }
 
     /// Consume this object and attempt to create the new workspace.
-    pub fn create(self, bundle_loc: String) -> Result<Workspace> {
-        let doc = Document::create_for(&self, bundle_loc)?;
+    pub fn create(self, bundle_loc: String, extra_paths: Vec<PathBuf>) -> Result<Workspace> {
+        let doc = Document::create_for(&self, bundle_loc, extra_paths)?;
 
         let mut tex_dir = self.root_dir.clone();
         tex_dir.push("src");

--- a/crates/engine_bibtex/src/auxi.rs
+++ b/crates/engine_bibtex/src/auxi.rs
@@ -78,7 +78,7 @@ fn aux_bib_data_command(
         buffers.set_offset(BufTy::Base, 2, buffers.offset(BufTy::Base, 2) + 1);
         let init = buffers.init(BufTy::Base);
         if !Scan::new()
-            .chars(&[b'}', b','])
+            .chars(b"},")
             .class(LexClass::Whitespace)
             .scan_till(buffers, init)
         {
@@ -149,7 +149,7 @@ fn aux_bib_style_command(
     buffers.set_offset(BufTy::Base, 2, buffers.offset(BufTy::Base, 2) + 1);
     let init = buffers.init(BufTy::Base);
     if !Scan::new()
-        .chars(&[b'}'])
+        .chars(b"}")
         .class(LexClass::Whitespace)
         .scan_till(buffers, init)
     {
@@ -218,7 +218,7 @@ fn aux_citation_command(
 
         let init = buffers.init(BufTy::Base);
         if !Scan::new()
-            .chars(&[b'}', b','])
+            .chars(b"},")
             .class(LexClass::Whitespace)
             .scan_till(buffers, init)
         {
@@ -316,7 +316,7 @@ fn aux_input_command(
 
     let init = buffers.init(BufTy::Base);
     if !Scan::new()
-        .chars(&[b'}'])
+        .chars(b"}")
         .class(LexClass::Whitespace)
         .scan_till(buffers, init)
     {
@@ -398,7 +398,7 @@ pub(crate) fn get_aux_command_and_process(
 ) -> Result<(), BibtexError> {
     globals.buffers.set_offset(BufTy::Base, 2, 0);
     let init = globals.buffers.init(BufTy::Base);
-    if !Scan::new().chars(&[b'{']).scan_till(globals.buffers, init) {
+    if !Scan::new().chars(b"{").scan_till(globals.buffers, init) {
         return Ok(());
     }
 

--- a/crates/engine_bibtex/src/bibs.rs
+++ b/crates/engine_bibtex/src/bibs.rs
@@ -174,7 +174,7 @@ pub(crate) fn get_bib_command_or_entry_and_process(
     let mut at_bib_command = false;
 
     let mut init = globals.buffers.init(BufTy::Base);
-    while !Scan::new().chars(&[b'@']).scan_till(globals.buffers, init) {
+    while !Scan::new().chars(b"@").scan_till(globals.buffers, init) {
         if !input_ln(globals.bibs.cur_bib_file(), globals.buffers) {
             return Ok(());
         }
@@ -459,9 +459,9 @@ pub(crate) fn get_bib_command_or_entry_and_process(
     let init = globals.buffers.init(BufTy::Base);
     Scan::new()
         .chars(if right_outer_delim == b')' {
-            &[b',']
+            b","
         } else {
-            &[b',', b'}']
+            b",}"
         })
         .class(LexClass::Whitespace)
         .scan_till(globals.buffers, init);

--- a/crates/engine_bibtex/src/bst.rs
+++ b/crates/engine_bibtex/src/bst.rs
@@ -477,7 +477,7 @@ fn bst_macro_command(
         .buffers
         .set_offset(BufTy::Base, 2, globals.buffers.offset(BufTy::Base, 2) + 1);
     let init = globals.buffers.init(BufTy::Base);
-    if !Scan::new().chars(&[b'"']).scan_till(globals.buffers, init) {
+    if !Scan::new().chars(b"\"").scan_till(globals.buffers, init) {
         write_logs("There's no `\"' to end macro definition");
         bst_err_print_and_look_for_blank_line(ctx.glbl_ctx_mut(), globals.buffers, globals.pool)?;
         return Ok(());

--- a/crates/engine_bibtex/src/log.rs
+++ b/crates/engine_bibtex/src/log.rs
@@ -654,7 +654,7 @@ pub(crate) fn skip_token_print(
     mark_error();
 
     Scan::new()
-        .chars(&[b'}', b'%'])
+        .chars(b"}%")
         .class(LexClass::Whitespace)
         .scan_till(buffers, buffers.init(BufTy::Base));
 

--- a/crates/engine_bibtex/src/scan.rs
+++ b/crates/engine_bibtex/src/scan.rs
@@ -226,7 +226,7 @@ fn handle_char(
             buffers.set_offset(BufTy::Base, 2, buffers.offset(BufTy::Base, 2) + 1);
 
             let init = buffers.init(BufTy::Base);
-            if !Scan::new().chars(&[b'"']).scan_till(buffers, init) {
+            if !Scan::new().chars(b"\"").scan_till(buffers, init) {
                 write_logs("No `\"` to end string literal");
                 return skip_token_print(ctx, buffers, pool);
             }
@@ -258,7 +258,7 @@ fn handle_char(
 
             let init = buffers.init(BufTy::Base);
             Scan::new()
-                .chars(&[b'}', b'%'])
+                .chars(b"}%")
                 .class(LexClass::Whitespace)
                 .scan_till(buffers, init);
 
@@ -303,7 +303,7 @@ fn handle_char(
         _ => {
             let init = buffers.init(BufTy::Base);
             Scan::new()
-                .chars(&[b'}', b'%'])
+                .chars(b"}%")
                 .class(LexClass::Whitespace)
                 .scan_till(buffers, init);
 
@@ -523,7 +523,7 @@ fn scan_balanced_braces(
                         let init = buffers.init(BufTy::Base);
                         if (c == b'{'
                             || c == b'}'
-                            || !Scan::new().chars(&[b'{', b'}']).scan_till(buffers, init))
+                            || !Scan::new().chars(b"{}").scan_till(buffers, init))
                             && !eat_bib_white_space(buffers, bibs)
                         {
                             return eat_bib_print(buffers, pool, bibs, at_bib_command)

--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -17,11 +17,30 @@ the file are detailed below.
 name = <string>  # the document name
 bundle = <url or filesystem path>  # the source of the TeX bundle
 
+# Extra search paths for TeX sources, images, etc.
+#
+# This is particularly useful if you have files used
+# by multiple Tectonic documents. For example:
+#
+# repo-root/
+#  ├── resources/
+#  │   └── classes, images, other shared resources
+#  ├── doc1/
+#  │   ├── src/
+#  │   └── Tectonic.toml  <-- Contains `extra_paths = ["../resources"]`
+#  └── doc2/
+#      ├── src/
+#      └── Tectonic.toml  <-- Contains `extra_paths = ["../resources"]`
+extra_paths = ["", ""]
+
+
+
 # The doc.metadata table may contain arbitrary data.
 # It does not affect Tectonic in any way.
 [doc.metadata]
 pubish = false
 arr = [1, 2, [6, 7]]
+
 
 
 # One (of possibly many) output specifications.

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -166,12 +166,20 @@ impl DocumentExt for Document {
         let mut sess_builder =
             ProcessingSessionBuilder::new_with_security(setup_options.security.clone());
 
+        // Interpret all extra paths as relative to our working dir
+        let extra_paths: Vec<PathBuf> = self
+            .extra_paths
+            .iter()
+            .map(|x| self.src_dir().join(x))
+            .collect();
+
         sess_builder
             .output_format(output_format)
             .format_name(&profile.tex_format)
             .build_date_from_env(setup_options.deterministic_mode)
             .unstables(UnstableOptions {
                 deterministic_mode: setup_options.deterministic_mode,
+                extra_search_paths: extra_paths,
                 ..Default::default()
             })
             .pass(PassSetting::Default)
@@ -238,6 +246,6 @@ impl WorkspaceCreatorExt for WorkspaceCreator {
             gub.resolve_url(&unresolved_loc, status)?
         };
 
-        Ok(self.create(bundle_loc)?)
+        Ok(self.create(bundle_loc, Vec::new())?)
     }
 }


### PR DESCRIPTION
For context, see the discussion in #985.
Closes #985.

## TLDR:
This PR adds an `extra_paths` config key that allows a user to specify external resources.
An example file tree and `Tectonic.toml` are below.

```toml
[doc]
name = "Test"
bundle = "https://data1.fullyjustified.net/tlextras-2022.0r0.tar"

# New config key
extra_paths = [
    "../../resources"
]


[[output]]
name = "main"
type = "pdf"

```

```
workspace-repo-root/
├── resources/
│   └── class files, etc      <-- All documents pull files from here
│
├── Subdir1/
│   ├── this document/
│   │   ├── src/
│   │   └── Tectonic.toml     <-- this file is above
│   └── more documents...
│   
└── Subdir2/
    └── and so on...
```



