### PR TITLE
docs(unicode): Fix typo

### DIFF
--- a/docs/src/getting-started/unicode.md
+++ b/docs/src/getting-started/unicode.md
@@ -100,8 +100,8 @@ text.
 ## Unicode Input Text
 
 Tectonic’s support for Unicode broadens its *output* capabilities through the
-use of modern fonts. But that’s not all: Unicode also broadens Tectonic’s the
-*inputs* that Tectonic accepts.
+use of modern fonts. But that’s not all: Unicode also broadens the *inputs* 
+that Tectonic accepts.
 
 With Tectonic, you can type non-English characters directly into your input TeX
 files, which are parsed assuming the virtually-universal [UTF-8 Unicode text


### PR DESCRIPTION
destination: [tectonic/book/.../unicode.html]


[tectonic/book/.../unicode.html]: https://tectonic-typesetting.github.io/book/latest/getting-started/unicode.html#:~:text=not%20all%3A%20Unicode-,also%20broadens,-Tectonic%E2%80%99s%20the%20inputs