### PR TITLE
Document 'shell_escape_cwd' for Tectonic.toml

### DIFF
--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -22,6 +22,7 @@ name = <string>  # the output's name
 type = <"pdf">  # the output's type
 tex_format = [string]  # optional, defaults to "latex": the TeX format to use
 shell_escape = [bool]  # optional, defaults to false: whether "shell escape" (\write18) is allowed
+shell_escape_cwd = [string]  # optional, defaults to a temporary directory: path to use for \write18
 preamble = [string] # optional, defaults to "_preamble.tex": the preamble file to use (within `src`)
 index = [string] # optional, defaults to "index.tex": the index file to use (within `src`)
 postamble = [string] # optional, defaults to "_postamble.tex": the postamble file to use (within `src`)
@@ -82,6 +83,13 @@ operating system shell. It also is inherently unportable, because it requires
 that your document compilation is run in an environment where an operating
 system shell exists and can be invoked. Its use is therefore strongly
 discouraged, but some packages require it.
+
+### `output.shell_escape_cwd`
+
+The working directory path to use for “shell escape”. The default is a
+temporary directory if `output.shell_escape` is true, else it's disabled.
+The path can be absolute or relative to the root file, but it must exist.
+Specifying this path automatically sets `output.shell_escape` to true.
 
 ### `output.preamble`
 


### PR DESCRIPTION
The 'shell_escape_cwd' output specification is implemented, but is not documented for Tectonic.toml.