### PR TITLE
Added Tectonic.toml input array

### DIFF
--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -91,7 +91,7 @@ impl Document {
         let mut outputs = HashMap::new();
 
         for toml_output in &doc.outputs {
-            let output = toml_output.to_runtime();
+            let output: OutputProfile = toml_output.into();
 
             if outputs.insert(output.name.clone(), output).is_some() {
                 bail!(
@@ -125,7 +125,7 @@ impl Document {
         let outputs = self
             .outputs
             .values()
-            .map(syntax::TomlOutputProfile::from_runtime)
+            .map(syntax::TomlOutputProfile::from)
             .collect();
 
         let doc = syntax::TomlDocument {
@@ -215,14 +215,8 @@ pub struct OutputProfile {
     /// The name of the TeX format used by this profile.
     pub tex_format: String,
 
-    /// The name of the preamble file within the `src` directory.
-    pub preamble_file: String,
-
-    /// The name of the index (main) file within the `src` directory.
-    pub index_file: String,
-
-    /// The name of the postamble file within the `src` directory.
-    pub postamble_file: String,
+    /// The input files we should use to build this document
+    pub inputs: Vec<String>,
 
     /// Whether TeX's shell-escape feature should be activated in this profile.
     ///
@@ -310,9 +304,11 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
             name: "default".to_owned(),
             target_type: BuildTargetType::Pdf,
             tex_format: "latex".to_owned(),
-            preamble_file: DEFAULT_PREAMBLE_FILE.to_owned(),
-            index_file: DEFAULT_INDEX_FILE.to_owned(),
-            postamble_file: DEFAULT_POSTAMBLE_FILE.to_owned(),
+            inputs: vec![
+                DEFAULT_PREAMBLE_FILE.to_owned(),
+                DEFAULT_INDEX_FILE.to_owned(),
+                DEFAULT_POSTAMBLE_FILE.to_owned(),
+            ],
             shell_escape: false,
             shell_escape_cwd: None,
         },

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -22,23 +22,11 @@ use tectonic_errors::prelude::*;
 use crate::syntax;
 use crate::workspace::WorkspaceCreator;
 
-/// The default filesystem name for the "preamble" file of a document.
+/// The default files used to build a document.
 ///
 /// This default can be overridden on an output-by-output basis in
 /// `Tectonic.toml`.
-pub const DEFAULT_PREAMBLE_FILE: &str = "_preamble.tex";
-
-/// The default filesystem name for the main "index" file of a document.
-///
-/// This default can be overridden on an output-by-output basis in
-/// `Tectonic.toml`.
-pub const DEFAULT_INDEX_FILE: &str = "index.tex";
-
-/// The default filesystem name for the "postamble" file of a document.
-///
-/// This default can be overridden on an output-by-output basis in
-/// `Tectonic.toml`.
-pub const DEFAULT_POSTAMBLE_FILE: &str = "_postamble.tex";
+pub const DEFAULT_INPUTS: &[&str] = &["_preamble.tex", "index.tex", "_postamble.tex"];
 
 /// A Tectonic document.
 #[derive(Debug)]
@@ -216,7 +204,7 @@ pub struct OutputProfile {
     pub tex_format: String,
 
     /// The input files we should use to build this document
-    pub inputs: Vec<String>,
+    pub inputs: Vec<InputFile>,
 
     /// Whether TeX's shell-escape feature should be activated in this profile.
     ///
@@ -243,6 +231,16 @@ pub enum BuildTargetType {
 
     /// Output to the Portable Document Format (PDF).
     Pdf,
+}
+
+/// The output target type of a document build.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InputFile {
+    /// A file system path.
+    File(String),
+
+    /// An inline file.
+    Inline(String),
 }
 
 impl Document {
@@ -304,11 +302,10 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
             name: "default".to_owned(),
             target_type: BuildTargetType::Pdf,
             tex_format: "latex".to_owned(),
-            inputs: vec![
-                DEFAULT_PREAMBLE_FILE.to_owned(),
-                DEFAULT_INDEX_FILE.to_owned(),
-                DEFAULT_POSTAMBLE_FILE.to_owned(),
-            ],
+            inputs: DEFAULT_INPUTS
+                .iter()
+                .map(|x| InputFile::File(x.to_string()))
+                .collect(),
             shell_escape: false,
             shell_escape_cwd: None,
         },

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -233,7 +233,7 @@ pub enum BuildTargetType {
     Pdf,
 }
 
-/// The output target type of a document build.
+/// An input provided to a document build
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum InputFile {
     /// A file system path.

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -19,6 +19,7 @@ use std::{
 };
 use tectonic_errors::prelude::*;
 
+use crate::syntax;
 use crate::workspace::WorkspaceCreator;
 
 /// The default filesystem name for the "preamble" file of a document.
@@ -85,7 +86,7 @@ impl Document {
     ) -> Result<Self> {
         let mut toml_text = String::new();
         toml_data.read_to_string(&mut toml_text)?;
-        let doc: syntax::Document = toml::from_str(&toml_text)?;
+        let doc: syntax::TomlDocument = toml::from_str(&toml_text)?;
 
         let mut outputs = HashMap::new();
 
@@ -124,11 +125,11 @@ impl Document {
         let outputs = self
             .outputs
             .values()
-            .map(syntax::OutputProfile::from_runtime)
+            .map(syntax::TomlOutputProfile::from_runtime)
             .collect();
 
-        let doc = syntax::Document {
-            doc: syntax::DocSection {
+        let doc = syntax::TomlDocument {
+            doc: syntax::TomlDocSection {
                 name: self.name.clone(),
                 bundle: self.bundle_loc.clone(),
                 metadata: None,
@@ -317,169 +318,6 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
         },
     );
     outputs
-}
-
-/// The concrete syntax for saving document state, wired up via serde.
-mod syntax {
-    use super::{DEFAULT_INDEX_FILE, DEFAULT_POSTAMBLE_FILE, DEFAULT_PREAMBLE_FILE};
-    use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-
-    #[derive(Debug, Deserialize, Serialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Document {
-        pub doc: DocSection,
-
-        #[serde(rename = "output")]
-        pub outputs: Vec<OutputProfile>,
-    }
-
-    #[derive(Debug, Deserialize, Serialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct DocSection {
-        pub name: String,
-        pub bundle: String,
-        pub metadata: Option<toml::Value>,
-    }
-
-    #[derive(Debug, Deserialize, Serialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct OutputProfile {
-        pub name: String,
-        #[serde(rename = "type")]
-        pub target_type: BuildTargetType,
-        pub tex_format: Option<String>,
-        #[serde(rename = "preamble")]
-        pub preamble_file: Option<String>,
-        #[serde(rename = "index")]
-        pub index_file: Option<String>,
-        #[serde(rename = "postamble")]
-        pub postamble_file: Option<String>,
-        pub shell_escape: Option<bool>,
-        pub shell_escape_cwd: Option<String>,
-    }
-
-    impl OutputProfile {
-        pub fn from_runtime(rt: &super::OutputProfile) -> Self {
-            let tex_format = if rt.tex_format == "latex" {
-                None
-            } else {
-                Some(rt.tex_format.clone())
-            };
-
-            let preamble_file = if rt.preamble_file == DEFAULT_PREAMBLE_FILE {
-                None
-            } else {
-                Some(rt.preamble_file.clone())
-            };
-
-            let index_file = if rt.index_file == DEFAULT_INDEX_FILE {
-                None
-            } else {
-                Some(rt.index_file.clone())
-            };
-
-            let postamble_file = if rt.postamble_file == DEFAULT_POSTAMBLE_FILE {
-                None
-            } else {
-                Some(rt.postamble_file.clone())
-            };
-
-            let shell_escape = if !rt.shell_escape { None } else { Some(true) };
-            let shell_escape_cwd = rt.shell_escape_cwd.clone();
-
-            OutputProfile {
-                name: rt.name.clone(),
-                target_type: BuildTargetType::from_runtime(&rt.target_type),
-                tex_format,
-                preamble_file,
-                index_file,
-                postamble_file,
-                shell_escape,
-                shell_escape_cwd,
-            }
-        }
-
-        pub fn to_runtime(&self) -> super::OutputProfile {
-            let shell_escape_default = self.shell_escape_cwd.is_some();
-
-            super::OutputProfile {
-                name: self.name.clone(),
-                target_type: self.target_type.to_runtime(),
-                tex_format: self
-                    .tex_format
-                    .as_ref()
-                    .map(|s| s.as_ref())
-                    .unwrap_or("latex")
-                    .to_owned(),
-                preamble_file: self
-                    .preamble_file
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_PREAMBLE_FILE.to_owned()),
-                index_file: self
-                    .index_file
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_INDEX_FILE.to_owned()),
-                postamble_file: self
-                    .postamble_file
-                    .clone()
-                    .unwrap_or_else(|| DEFAULT_POSTAMBLE_FILE.to_owned()),
-                shell_escape: self.shell_escape.unwrap_or(shell_escape_default),
-                shell_escape_cwd: self.shell_escape_cwd.clone(),
-            }
-        }
-    }
-
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub enum BuildTargetType {
-        Html,
-        Pdf,
-    }
-
-    impl BuildTargetType {
-        pub fn from_runtime(rt: &super::BuildTargetType) -> Self {
-            match rt {
-                super::BuildTargetType::Html => BuildTargetType::Html,
-                super::BuildTargetType::Pdf => BuildTargetType::Pdf,
-            }
-        }
-
-        pub fn to_runtime(self) -> super::BuildTargetType {
-            match self {
-                BuildTargetType::Html => super::BuildTargetType::Html,
-                BuildTargetType::Pdf => super::BuildTargetType::Pdf,
-            }
-        }
-    }
-
-    impl Serialize for BuildTargetType {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer.serialize_str(match *self {
-                BuildTargetType::Html => "html",
-                BuildTargetType::Pdf => "pdf",
-            })
-        }
-    }
-    impl<'de> Deserialize<'de> for BuildTargetType {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let s = String::deserialize(deserializer)?;
-            Ok(match s.as_str() {
-                "html" => BuildTargetType::Html,
-                "pdf" => BuildTargetType::Pdf,
-                other => {
-                    return Err(<D as Deserializer>::Error::unknown_variant(
-                        other,
-                        &["html", "pdf"],
-                    ))
-                }
-            })
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/docmodel/src/lib.rs
+++ b/crates/docmodel/src/lib.rs
@@ -19,4 +19,5 @@
 //! creating new workspaces from scratch.
 
 pub mod document;
+mod syntax;
 pub mod workspace;

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -1,0 +1,162 @@
+use crate::document::{
+    BuildTargetType, OutputProfile, DEFAULT_INDEX_FILE, DEFAULT_POSTAMBLE_FILE,
+    DEFAULT_PREAMBLE_FILE,
+};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TomlDocument {
+    pub doc: TomlDocSection,
+
+    #[serde(rename = "output")]
+    pub outputs: Vec<TomlOutputProfile>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TomlDocSection {
+    pub name: String,
+    pub bundle: String,
+    pub metadata: Option<toml::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TomlOutputProfile {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub target_type: TomlBuildTargetType,
+    pub tex_format: Option<String>,
+    #[serde(rename = "preamble")]
+    pub preamble_file: Option<String>,
+    #[serde(rename = "index")]
+    pub index_file: Option<String>,
+    #[serde(rename = "postamble")]
+    pub postamble_file: Option<String>,
+    pub shell_escape: Option<bool>,
+    pub shell_escape_cwd: Option<String>,
+}
+
+impl TomlOutputProfile {
+    pub fn from_runtime(rt: &OutputProfile) -> Self {
+        let tex_format = if rt.tex_format == "latex" {
+            None
+        } else {
+            Some(rt.tex_format.clone())
+        };
+
+        let preamble_file = if rt.preamble_file == DEFAULT_PREAMBLE_FILE {
+            None
+        } else {
+            Some(rt.preamble_file.clone())
+        };
+
+        let index_file = if rt.index_file == DEFAULT_INDEX_FILE {
+            None
+        } else {
+            Some(rt.index_file.clone())
+        };
+
+        let postamble_file = if rt.postamble_file == DEFAULT_POSTAMBLE_FILE {
+            None
+        } else {
+            Some(rt.postamble_file.clone())
+        };
+
+        let shell_escape = if !rt.shell_escape { None } else { Some(true) };
+        let shell_escape_cwd = rt.shell_escape_cwd.clone();
+
+        TomlOutputProfile {
+            name: rt.name.clone(),
+            target_type: TomlBuildTargetType::from_runtime(&rt.target_type),
+            tex_format,
+            preamble_file,
+            index_file,
+            postamble_file,
+            shell_escape,
+            shell_escape_cwd,
+        }
+    }
+
+    pub fn to_runtime(&self) -> OutputProfile {
+        let shell_escape_default = self.shell_escape_cwd.is_some();
+
+        OutputProfile {
+            name: self.name.clone(),
+            target_type: self.target_type.to_runtime(),
+            tex_format: self
+                .tex_format
+                .as_ref()
+                .map(|s| s.as_ref())
+                .unwrap_or("latex")
+                .to_owned(),
+            preamble_file: self
+                .preamble_file
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PREAMBLE_FILE.to_owned()),
+            index_file: self
+                .index_file
+                .clone()
+                .unwrap_or_else(|| DEFAULT_INDEX_FILE.to_owned()),
+            postamble_file: self
+                .postamble_file
+                .clone()
+                .unwrap_or_else(|| DEFAULT_POSTAMBLE_FILE.to_owned()),
+            shell_escape: self.shell_escape.unwrap_or(shell_escape_default),
+            shell_escape_cwd: self.shell_escape_cwd.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TomlBuildTargetType {
+    Html,
+    Pdf,
+}
+
+impl TomlBuildTargetType {
+    pub fn from_runtime(rt: &BuildTargetType) -> Self {
+        match rt {
+            BuildTargetType::Html => TomlBuildTargetType::Html,
+            BuildTargetType::Pdf => TomlBuildTargetType::Pdf,
+        }
+    }
+
+    pub fn to_runtime(self) -> BuildTargetType {
+        match self {
+            TomlBuildTargetType::Html => BuildTargetType::Html,
+            TomlBuildTargetType::Pdf => BuildTargetType::Pdf,
+        }
+    }
+}
+
+impl Serialize for TomlBuildTargetType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match *self {
+            TomlBuildTargetType::Html => "html",
+            TomlBuildTargetType::Pdf => "pdf",
+        })
+    }
+}
+impl<'de> Deserialize<'de> for TomlBuildTargetType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "html" => TomlBuildTargetType::Html,
+            "pdf" => TomlBuildTargetType::Pdf,
+            other => {
+                return Err(<D as Deserializer>::Error::unknown_variant(
+                    other,
+                    &["html", "pdf"],
+                ))
+            }
+        })
+    }
+}

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -161,13 +161,8 @@ impl From<&OutputProfile> for TomlOutputProfile {
             Some(rt.tex_format.clone())
         };
 
-        let inputs: StringOrInputVec = StringOrInputVec::Vec(
-            rt.inputs
-                .clone()
-                .iter()
-                .map(|x| TomlInputFile::from(x))
-                .collect(),
-        );
+        let inputs: StringOrInputVec =
+            StringOrInputVec::Vec(rt.inputs.clone().iter().map(TomlInputFile::from).collect());
 
         let shell_escape = if !rt.shell_escape { None } else { Some(true) };
         let shell_escape_cwd = rt.shell_escape_cwd.clone();

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -1,8 +1,19 @@
-use crate::document::{
-    BuildTargetType, OutputProfile, DEFAULT_INDEX_FILE, DEFAULT_POSTAMBLE_FILE,
-    DEFAULT_PREAMBLE_FILE,
-};
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+// Copyright 2020-2023 the Tectonic Project
+// Licensed under the MIT License.
+
+//! This file defines the syntax of Tectonic.toml,
+//! which is parsed using serde.
+//!
+//! This module is only used by [`crate::document::Document`]
+
+use crate::document::{BuildTargetType, OutputProfile};
+use serde::{Deserialize, Serialize};
+
+// This file is an exercise in Rust type conversion.
+//
+// Every stuct or enum that starts with "Toml*" is a
+// serializable version of a struct or enum in document.rs.
+// We convert between the two with ::from() and .into().
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -28,40 +39,69 @@ pub struct TomlOutputProfile {
     #[serde(rename = "type")]
     pub target_type: TomlBuildTargetType,
     pub tex_format: Option<String>,
+    pub shell_escape: Option<bool>,
+    pub shell_escape_cwd: Option<String>,
+
+    // We cannot handle these two input variants with an enum.
+    // The ideal solution requires #[serde(flatten)],
+    // which is incompatible with deny_unknown_fields.
+    // This will have to do for now.
+    pub inputs: Option<Vec<String>>,
+
+    // Old-fashioned file inputs
+    // we might want to deprecate these eventually, or at least provide a warning.
     #[serde(rename = "preamble")]
     pub preamble_file: Option<String>,
     #[serde(rename = "index")]
     pub index_file: Option<String>,
     #[serde(rename = "postamble")]
     pub postamble_file: Option<String>,
-    pub shell_escape: Option<bool>,
-    pub shell_escape_cwd: Option<String>,
 }
 
-impl TomlOutputProfile {
-    pub fn from_runtime(rt: &OutputProfile) -> Self {
+impl From<&TomlOutputProfile> for OutputProfile {
+    fn from(val: &TomlOutputProfile) -> OutputProfile {
+        let shell_escape_default = val.shell_escape_cwd.is_some();
+
+        let inputs = {
+            if let Some(ref inputs) = val.inputs {
+                inputs.clone()
+            } else {
+                let mut v = Vec::with_capacity(3);
+                if let Some(s) = &val.preamble_file {
+                    v.push(s.clone())
+                }
+                if let Some(s) = &val.index_file {
+                    v.push(s.clone())
+                }
+                if let Some(s) = &val.postamble_file {
+                    v.push(s.clone())
+                }
+                v
+            }
+        };
+
+        OutputProfile {
+            name: val.name.clone(),
+            target_type: val.target_type.into(),
+            tex_format: val
+                .tex_format
+                .as_ref()
+                .map(|s| s.as_ref())
+                .unwrap_or("latex")
+                .to_owned(),
+            inputs,
+            shell_escape: val.shell_escape.unwrap_or(shell_escape_default),
+            shell_escape_cwd: val.shell_escape_cwd.clone(),
+        }
+    }
+}
+
+impl From<&OutputProfile> for TomlOutputProfile {
+    fn from(rt: &OutputProfile) -> Self {
         let tex_format = if rt.tex_format == "latex" {
             None
         } else {
             Some(rt.tex_format.clone())
-        };
-
-        let preamble_file = if rt.preamble_file == DEFAULT_PREAMBLE_FILE {
-            None
-        } else {
-            Some(rt.preamble_file.clone())
-        };
-
-        let index_file = if rt.index_file == DEFAULT_INDEX_FILE {
-            None
-        } else {
-            Some(rt.index_file.clone())
-        };
-
-        let postamble_file = if rt.postamble_file == DEFAULT_POSTAMBLE_FILE {
-            None
-        } else {
-            Some(rt.postamble_file.clone())
         };
 
         let shell_escape = if !rt.shell_escape { None } else { Some(true) };
@@ -69,94 +109,41 @@ impl TomlOutputProfile {
 
         TomlOutputProfile {
             name: rt.name.clone(),
-            target_type: TomlBuildTargetType::from_runtime(&rt.target_type),
+            target_type: TomlBuildTargetType::from(&rt.target_type),
             tex_format,
-            preamble_file,
-            index_file,
-            postamble_file,
+            inputs: Some(rt.inputs.clone()),
             shell_escape,
             shell_escape_cwd,
-        }
-    }
-
-    pub fn to_runtime(&self) -> OutputProfile {
-        let shell_escape_default = self.shell_escape_cwd.is_some();
-
-        OutputProfile {
-            name: self.name.clone(),
-            target_type: self.target_type.to_runtime(),
-            tex_format: self
-                .tex_format
-                .as_ref()
-                .map(|s| s.as_ref())
-                .unwrap_or("latex")
-                .to_owned(),
-            preamble_file: self
-                .preamble_file
-                .clone()
-                .unwrap_or_else(|| DEFAULT_PREAMBLE_FILE.to_owned()),
-            index_file: self
-                .index_file
-                .clone()
-                .unwrap_or_else(|| DEFAULT_INDEX_FILE.to_owned()),
-            postamble_file: self
-                .postamble_file
-                .clone()
-                .unwrap_or_else(|| DEFAULT_POSTAMBLE_FILE.to_owned()),
-            shell_escape: self.shell_escape.unwrap_or(shell_escape_default),
-            shell_escape_cwd: self.shell_escape_cwd.clone(),
+            preamble_file: None,
+            index_file: None,
+            postamble_file: None,
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TomlBuildTargetType {
+    #[serde(rename = "html")]
     Html,
+
+    #[serde(rename = "pdf")]
     Pdf,
 }
 
-impl TomlBuildTargetType {
-    pub fn from_runtime(rt: &BuildTargetType) -> Self {
-        match rt {
-            BuildTargetType::Html => TomlBuildTargetType::Html,
-            BuildTargetType::Pdf => TomlBuildTargetType::Pdf,
-        }
-    }
-
-    pub fn to_runtime(self) -> BuildTargetType {
-        match self {
+impl From<TomlBuildTargetType> for BuildTargetType {
+    fn from(val: TomlBuildTargetType) -> BuildTargetType {
+        match val {
             TomlBuildTargetType::Html => BuildTargetType::Html,
             TomlBuildTargetType::Pdf => BuildTargetType::Pdf,
         }
     }
 }
 
-impl Serialize for TomlBuildTargetType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(match *self {
-            TomlBuildTargetType::Html => "html",
-            TomlBuildTargetType::Pdf => "pdf",
-        })
-    }
-}
-impl<'de> Deserialize<'de> for TomlBuildTargetType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
-            "html" => TomlBuildTargetType::Html,
-            "pdf" => TomlBuildTargetType::Pdf,
-            other => {
-                return Err(<D as Deserializer>::Error::unknown_variant(
-                    other,
-                    &["html", "pdf"],
-                ))
-            }
-        })
+impl From<&BuildTargetType> for TomlBuildTargetType {
+    fn from(s: &BuildTargetType) -> Self {
+        match s {
+            BuildTargetType::Html => TomlBuildTargetType::Html,
+            BuildTargetType::Pdf => TomlBuildTargetType::Pdf,
+        }
     }
 }

--- a/docs/src/getting-started/first-document.md
+++ b/docs/src/getting-started/first-document.md
@@ -57,44 +57,6 @@ See [the `tectonic -X compile` documentation][cli-compile] for all of the option
 [cli-compile]: ../v2cli/compile.md
 
 
-## Basic document source structure
-
-The source code to your document is stored in the `src` subdirectory of your new
-document. Check it out:
-
-```sh
-$ ls src
-```
-
-You’ll see three files that were created by the [`new`][cli-new] command:
-
-- `_preamble.tex`
-- `index.tex`
-- `_postamble.tex`
-
-These files are pre-populated with extremely basic contents following this
-suggested source structure:
-
-- The “preamble” file should contain all of your (La)TeX initialization
-  boilerplate, up to and including the LaTeX `\begin{document}` command.
-- The “index” file contains all of your actual document content, without any of
-  the annoying boilerplate. When you create a new Tectonic document, it just
-  contains the text `Hello, world.`
-- The “postamble” file should contain all of your cleanup code, starting with
-  the LaTeX `\end{document}` command. There will almost never need to be any
-  other content in this file.
-
-When Tectonic builds your document, it processes these files in the order listed
-above, so all three of them need to be available. But the breakdown suggested
-above is only a suggestion, nothing more. If you want all of your boilerplate
-and content to be in a single file, we recommend putting it all in `index.tex`
-and making your preamble and postamble empty.
-
-The motivation for this separation is partially stylistic, but not entirely so.
-In the future, we anticipate that there might be different ways to build the
-same document that invoke different preamble or postamble contents.
-
-
 ## Building your document
 
 To compile your document, run:

--- a/docs/src/getting-started/unicode.md
+++ b/docs/src/getting-started/unicode.md
@@ -64,8 +64,8 @@ one of the prime reasons that the Tectonic project was started.
 
 The choice of fonts is foundational to TeX’s document processing, so modern
 fonts aren’t automatically activated. To start using a nice new font like [TeX
-Gyre Pagella][pagella] (derived from [Palatino]), open up your
-`src/_preamble.tex` file and add the following lines after the `\documentclass`
+Gyre Pagella][pagella] (derived from [Palatino]), edit your
+`src/main.tex` file and add the following lines after the `\documentclass`
 command:
 
 [pagella]: https://www.fontsquirrel.com/fonts/tex-gyre-pagella

--- a/docs/src/getting-started/unicode.md
+++ b/docs/src/getting-started/unicode.md
@@ -65,7 +65,7 @@ one of the prime reasons that the Tectonic project was started.
 The choice of fonts is foundational to TeX’s document processing, so modern
 fonts aren’t automatically activated. To start using a nice new font like [TeX
 Gyre Pagella][pagella] (derived from [Palatino]), edit your
-`src/main.tex` file and add the following lines after the `\documentclass`
+`src/_preamble.tex` file and add the following lines after the `\documentclass`
 command:
 
 [pagella]: https://www.fontsquirrel.com/fonts/tex-gyre-pagella

--- a/docs/src/ref/documents.md
+++ b/docs/src/ref/documents.md
@@ -22,24 +22,11 @@ multiple documents inside a single workspace.
 [tectonic-toml]: ./tectonic-toml.md
 [workspace]: ./workspaces.md
 
-The TeX sources are stored in a `src` subdirectory of the document root. This
-directory should contain at least three files: `index.tex`, `_preamble.tex`,
-and `_postamble.tex`. These filenames can be changed in the
-[Tectonic.toml][tectonic-toml] configuration file. The [`build`
-command][cli-build] will process these files in the following order:
-
-1. `src/_preamble.tex`
-2. `src/index.tex`
-3. `src/_postamble.tex`
-
-The intention of this framework is to allow you to isolate the main content of
-your document from the usual LaTeX boilerplate. There are no restrictions on
-what kind of content may be placed in each file, though. The preamble and
-postamble can be empty if you’d like. The [`new` command][cli-new] will stub out
-these files for you.
+The TeX sources are stored in a `src` subdirectory of the document root.
+Fresh workspaces will contain a file named `main.tex`, but this may be
+configured in [Tectonic.toml][tectonic-toml]. The [`build` command][cli-build] will process these files in the order they're provided in the `inputs` array.
 
 [cli-build]: ../v2cli/build.md
-[cli-new]: ../v2cli/new.md
 
 
 ## Build structure

--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -1,13 +1,13 @@
 # The `Tectonic.toml` File
 
 **Starting with [the V2 interface][v2]**, the `Tectonic.toml` file defines a
-Tectonic document.
+Tectonic workspace.
 
 [v2]: ./v2cli.md
 
 ## Contents
 
-The `Tectonic.toml` file is expressed in, yes, [TOML] format. Allowed items in
+The `Tectonic.toml` file is written in the [TOML] format. Allowed items in
 the file are detailed below.
 
 [TOML]: https://toml.io/
@@ -24,101 +24,52 @@ pubish = false
 arr = [1, 2, [6, 7]]
 
 
+# One (of possibly many) output specifications.
+[[output]]
 
-[[output]]  # one or more output specifications
-name = <string>  # the output's name
-type = <"pdf">  # the output's type
-tex_format = [string]  # optional, defaults to "latex": the TeX format to use
-shell_escape = [bool]  # optional, defaults to false: whether "shell escape" (\write18) is allowed
-shell_escape_cwd = [string]  # optional, defaults to a temporary directory: path to use for \write18
-preamble = [string] # optional, defaults to "_preamble.tex": the preamble file to use (within `src`)
-index = [string] # optional, defaults to "index.tex": the index file to use (within `src`)
-postamble = [string] # optional, defaults to "_postamble.tex": the postamble file to use (within `src`)
+# This output's name. By default, build products for each output will be
+# placed in the build directory under subdirectory with this name.
+name = "output name"
+
+# The output's type. Right now, only "pdf" is valid.
+type = "pdf"
+
+# The TeX "format" of preloaded macros to use when compiling the document.
+# This is optional, with a default of "latex" (which corresponds to the
+# standard LaTeX format). The exact set of formats that are supported will
+# depend on the bundle that is being used.
+tex_format = "latex"
+
+# Whether the TeX “shell escape”, AKA `\write18`, mechanism is allowed.
+# This is optional and defaults to false.
+#
+# Shell-escape is insecure, since it give the document access to your shell.
+# It also is non-portable, because it requires your document to be built
+# is run in an environment where a shell exists.
+# Naturally, its use is strongly discouraged, but some packages depend on
+# this feature.
+shell_escape = false
+
+# The working directory path to use for “shell escape”. The default is a
+# temporary directory if `output.shell_escape` is true, else it's disabled.
+# The path can be absolute or relative to the root file, but it must exist.
+# Specifying this path automatically sets `output.shell_escape` to true.
+# This is optional, and defaults to a temporary directory.
+shell_escape_cwd = "string"
+
+# The input files we'll use to build this document.
+# Usually, this is a path relative to the `./src` directory.
+#
+# This may also be an array of paths, which are concatenated
+# while building. You could, for example, define:
+# inputs = ["preamble.tex", "main.tex"]
+#
+# Finally, you may include an "inline" document as follows:
+# inputs = [
+#   { inline = "\\documentclass[a4paper]{article}" },
+#   "main.tex"
+# ]
+# This will insert "\documentclass[a4paper]{article}" before main.tex
+# (with a newline), allowing you to set options without making a new file.
+inputs = "main.tex"
 ```
-
-Unexpected items are not allowed.
-
-## Items
-
-### `doc.name`
-
-The name of the document. This is distinct from the document title. This value
-will be used to name output files, so it should be relatively short and
-filesystem-friendly.
-
-### `doc.bundle`
-
-A string identifying the location of the “bundle” of TeX support files
-underlying the processing of the document.
-
-In most circumstances this value should be a URL. The `tectonic -X new` command
-will populate this field with the current recommended default.
-
-This field can also be a filesystem path, pointing to either a Zip-format bundle
-or a directory of support files. This mode of operation is discouraged because
-it limits reproducibility. URLs with a `file:` protocol are also treated
-identically to filesystem paths.
-
-### `doc.metadata`
-
-Arbitrary metadata, not read by Tectonic. This table allows us to
-save parameters for external scripts without creating an extra file.
-
-
-### `output`
-
-A list of dictionaries defining different outputs to be created from the
-document source.
-
-### `output.name`
-
-A name given to the output. By default, build products for each output will be
-placed in the build directory, in a subdirectory with this name.
-
-### `output.type`
-
-The kind of output to create. Currently, the only allowed option is `"pdf"`,
-which creates a [Portable Document Format][pdf] file.
-
-[pdf]: https://en.wikipedia.org/wiki/PDF
-
-### `output.tex_format`
-
-The TeX “format” of preloaded macros to use when compiling the document. The
-default is `"latex"`, corresponding to the standard LaTeX format. The exact set
-of formats that are supported will depend on the bundle that is being used.
-
-### `output.shell_escape`
-
-Whether the TeX “shell escape”, AKA `\write18`, mechanism is allowed. The
-default is false. Shell-escape is inherently insecure, because its usage
-requires that text from the document compilation is passed directly to the
-operating system shell. It also is inherently unportable, because it requires
-that your document compilation is run in an environment where an operating
-system shell exists and can be invoked. Its use is therefore strongly
-discouraged, but some packages require it.
-
-### `output.shell_escape_cwd`
-
-The working directory path to use for “shell escape”. The default is a
-temporary directory if `output.shell_escape` is true, else it's disabled.
-The path can be absolute or relative to the root file, but it must exist.
-Specifying this path automatically sets `output.shell_escape` to true.
-
-### `output.preamble`
-
-The preamble file to build the document with for this output. This defaults to
-`"_preamble.tex"` within the `src` directory. Typically this file will contain
-document setup steps.
-
-### `output.index`
-
-The index file to build the document with for this output. This defaults to
-`"index.tex"` within the `src` directory. Typically this file will contain
-the body of the document.
-
-### `output.postamble`
-
-The postamble file to build the document with for this output. This defaults to
-`"_postamble.tex"` within the `src` directory. Typically this file will contain
-document closing steps.

--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -1,7 +1,7 @@
 # The `Tectonic.toml` File
 
 **Starting with [the V2 interface][v2]**, the `Tectonic.toml` file defines a
-Tectonic workspace.
+Tectonic document.
 
 [v2]: ./v2cli.md
 
@@ -57,11 +57,12 @@ shell_escape = false
 # This is optional, and defaults to a temporary directory.
 shell_escape_cwd = "string"
 
-# The input files we'll use to build this document.
-# Usually, this is a path relative to the `./src` directory.
+# The input file we'll use to build this document,
+# Given as a path relative to the `./src` directory.
 #
-# This may also be an array of paths, which are concatenated
-# while building. You could, for example, define:
+# This may also be an array of file paths,
+# the contents of which are concatenated while building.
+# You could, for example, define:
 # inputs = ["preamble.tex", "main.tex"]
 #
 # Finally, you may include an "inline" document as follows:
@@ -72,4 +73,18 @@ shell_escape_cwd = "string"
 # This will insert "\documentclass[a4paper]{article}" before main.tex
 # (with a newline), allowing you to set options without making a new file.
 inputs = "main.tex"
+
+
+# Deprecated input specification.
+# These options serve the same purpose as `inputs` above, but shouldn't be used
+# unless you have a legacy document.
+#
+# If you do have a legacy document, you should replace these options with the following:
+# inputs = ["_preamble.tex", "index.tex", "_postamble.tex"]
+#
+# Note that these options may NOT be used with `inputs`.
+# You may only use one kind of input specification.
+preamble = "_preamble.tex" # the preamble file to use (within `src`)
+index = "index.tex" # the index file to use (within `src`)
+postamble = "_postamble.tex" # the postamble file to use (within `src`)
 ```

--- a/docs/src/v2cli/init.md
+++ b/docs/src/v2cli/init.md
@@ -22,17 +22,7 @@ workspace directory.
 
 [tectonic-toml]: ../ref/tectonic-toml.md
 
-It will also create placeholder source files in a `src` subdirectory:
-`index.tex`, `_preamble.tex`, and `_postamble.tex`. The default build command
-will process these files in the expected order:
-
-1. `src/_preamble.tex`
-2. `src/index.tex`
-3. `src/_postamble.tex`
-
-The intention of this framework is to allow you to isolate the main content of
-your document from the usual LaTeX boilerplate. There are no restrictions on
-what kind of content may be placed in each file, though.
+It will also create a placeholder source file in `src/main.tex`.
 
 #### See Also
 

--- a/docs/src/v2cli/new.md
+++ b/docs/src/v2cli/new.md
@@ -24,17 +24,7 @@ workspace directory.
 
 [tectonic-toml]: ../ref/tectonic-toml.md
 
-It will also create placeholder source files in a `src` subdirectory:
-`index.tex`, `_preamble.tex`, and `_postamble.tex`. The default build command
-will process these files in the expected order:
-
-1. `src/_preamble.tex`
-2. `src/index.tex`
-3. `src/_postamble.tex`
-
-The intention of this framework is to allow you to isolate the main content of
-your document from the usual LaTeX boilerplate. There are no restrictions on
-what kind of content may be placed in each file, though.
+It will also create a placeholder source file in `src/main.tex`.
 
 #### See Also
 

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -151,14 +151,9 @@ impl DocumentExt for Document {
         };
 
         let mut input_buffer = String::new();
-        if !profile.preamble_file.is_empty() {
-            writeln!(input_buffer, "\\input{{{}}}", profile.preamble_file)?;
-        }
-        if !profile.index_file.is_empty() {
-            writeln!(input_buffer, "\\input{{{}}}", profile.index_file)?;
-        }
-        if !profile.postamble_file.is_empty() {
-            writeln!(input_buffer, "\\input{{{}}}", profile.postamble_file)?;
+
+        for f in &profile.inputs {
+            writeln!(input_buffer, "\\input{{{}}}", f)?;
         }
 
         let mut sess_builder =

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -17,7 +17,7 @@ use tectonic_bundles::{
     cache::Cache, dir::DirBundle, itar::IndexedTarBackend, zip::ZipBundle, Bundle,
 };
 use tectonic_docmodel::{
-    document::{BuildTargetType, Document},
+    document::{BuildTargetType, Document, InputFile},
     workspace::{Workspace, WorkspaceCreator},
 };
 use tectonic_geturl::{DefaultBackend, GetUrlBackend};
@@ -152,8 +152,15 @@ impl DocumentExt for Document {
 
         let mut input_buffer = String::new();
 
-        for f in &profile.inputs {
-            writeln!(input_buffer, "\\input{{{}}}", f)?;
+        for input in &profile.inputs {
+            match input {
+                InputFile::Inline(s) => {
+                    writeln!(input_buffer, "{}", s)?;
+                }
+                InputFile::File(f) => {
+                    writeln!(input_buffer, "\\input{{{}}}", f)?;
+                }
+            };
         }
 
         let mut sess_builder =

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -248,11 +248,7 @@ fn setup_v2() -> (tempfile::TempDir, PathBuf) {
     {
         let mut toml_path = temppath.clone();
         toml_path.push("Tectonic.toml");
-        let mut file = OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(toml_path)
-            .unwrap();
+        let mut file = OpenOptions::new().append(true).open(toml_path).unwrap();
         writeln!(file, "tex_format = 'plain'").unwrap();
     }
 
@@ -805,11 +801,7 @@ fn v2_build_multiple_outputs() {
     {
         let mut toml_path = temppath.clone();
         toml_path.push("Tectonic.toml");
-        let mut file = OpenOptions::new()
-            .write(true)
-            .append(true)
-            .open(toml_path)
-            .unwrap();
+        let mut file = OpenOptions::new().append(true).open(toml_path).unwrap();
         writeln!(
             file,
             "tex_format = 'plain'


### PR DESCRIPTION
This PR implements the feature detailed in #1100. Docs have been updated.

A final question I haven't had time to check:
Do all these fancy input file manipulations break latex error line numbers?

If they do, that's bad.