### PR TITLE
Fix "internal consitency problem when checking bbl file"

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1718,6 +1718,9 @@ impl ProcessingSession {
             // this, but, uh, so far it seems to work.
             for summ in self.bs.events.values_mut() {
                 summ.read_digest = None;
+                if summ.access_pattern == AccessPattern::ReadThenWritten {
+                    summ.access_pattern = AccessPattern::Read
+                }
             }
 
             warnings = self.tex_pass(Some(&rerun_explanation), status)?;


### PR DESCRIPTION
I had the same problem as #1150 and #1146.

I think this happens because after running BibTex the state of the bbl file is set to "ReadThenWritten" and 
is never reset causing infinite reruns. 

After resetting this in the loop with the helpful comment
" I am not super confident that the access_pattern data can just be left as-is when we do this, but, uh, so far it seems to work."  everthing seems to work as expected again. 

