### PR TITLE
Fix not closing files when spotless history is returned

### DIFF
--- a/crates/engine_bibtex/src/lib.rs
+++ b/crates/engine_bibtex/src/lib.rs
@@ -333,9 +333,7 @@ pub(crate) fn bibtex_main(ctx: &mut Bibtex<'_, '_>, aux_file_name: &CStr) -> His
 
     let res = inner_bibtex_main(ctx, &mut globals, aux_file_name);
     match res {
-        Ok(History::Spotless) => (),
-        Ok(hist) => return hist,
-        Err(BibtexError::Recover) => {
+        Err(BibtexError::Recover) | Ok(History::Spotless) => {
             // SAFETY: bst_file guaranteed valid at this point
             unsafe { peekable_close(ctx, ctx.bst_file) };
             ctx.bst_file = None;
@@ -345,6 +343,7 @@ pub(crate) fn bibtex_main(ctx: &mut Bibtex<'_, '_>, aux_file_name: &CStr) -> His
             ttbc_output_close(ctx.engine, ctx.bbl_file);
         }
         Err(BibtexError::Fatal) => (),
+        Ok(hist) => return hist,
     }
 
     match get_history() {


### PR DESCRIPTION
~~If you saw that master push/revert, no you didn't~~

This should supercede #1154 - on success, log files were not being closed, thus weren't getting write_digest set. See the original bibtex code at [@0.13.0/bibtex.c](https://github.com/tectonic-typesetting/tectonic/blob/tectonic%400.13.1/crates/engine_bibtex/bibtex/bibtex.c) for reference.