### PR TITLE
Crate updates: structopt & atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,11 +324,51 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clearscreen"
@@ -294,6 +382,12 @@ dependencies = [
  "which",
  "winapi",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1022,6 +1116,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -2250,12 +2350,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -2266,7 +2372,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2329,6 +2435,7 @@ dependencies = [
  "atty",
  "byte-unit",
  "cfg-if",
+ "clap 4.5.1",
  "error-chain",
  "filetime",
  "flate2",
@@ -2343,7 +2450,6 @@ dependencies = [
  "quick-xml",
  "serde",
  "sha2",
- "structopt",
  "tectonic_bridge_core",
  "tectonic_bundles",
  "tectonic_docmodel",
@@ -2567,7 +2673,7 @@ name = "tectonic_xdv"
 version = "0.0.0-dev.0"
 dependencies = [
  "byteorder",
- "clap",
+ "clap 2.34.0",
 ]
 
 [[package]]
@@ -2961,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -2987,6 +3093,12 @@ name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,7 +2432,6 @@ dependencies = [
 name = "tectonic"
 version = "0.0.0-dev.0"
 dependencies = [
- "atty",
  "byte-unit",
  "cfg-if",
  "clap 4.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ name = "tectonic_xdv"
 version = "0.0.0-dev.0"
 dependencies = [
  "byteorder",
- "clap 2.34.0",
+ "clap 4.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ name = "tectonic"
 crate-type = ["rlib"]
 
 [dependencies]
-atty = "0.2"
 byte-unit = "^4.0"
 cfg-if = "1.0"
 error-chain = "^0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ open = "^4.0"
 quick-xml = "^0.28"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 sha2 = "^0.10"
-structopt = "0.3"
+clap = { version = "4.5.1", features = ["derive"] }
 tectonic_bridge_core = { path = "crates/bridge_core", version = "0.0.0-dev.0" }
 tectonic_bundles = { path = "crates/bundles", version = "0.0.0-dev.0", default-features = false }
 tectonic_docmodel = { path = "crates/docmodel", version = "0.0.0-dev.0", optional = true }

--- a/crates/xdv/Cargo.toml
+++ b/crates/xdv/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "tectonic_xdv"
-version = "0.0.0-dev.0"  # assigned with cranko (see README)
+version = "0.0.0-dev.0" # assigned with cranko (see README)
 authors = ["Peter Williams <peter@newton.cx>"]
 description = """
 A decoder for the XDV and SPX file formats used by XeTeX and Tectonic.
@@ -19,4 +19,4 @@ edition = "2018"
 byteorder = "^1.4"
 
 [dev-dependencies]
-clap = "^2.33"
+clap = { version = "4.5.1", features = ["cargo"] }

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 
 use clap::{Parser, ValueEnum};
-use std::{env, process};
+use std::{env, io::IsTerminal, process};
 use tectonic_status_base::plain::PlainStatusBackend;
 
 use tectonic::{
@@ -76,7 +76,7 @@ impl CliColor {
     pub fn should_enable(&self) -> bool {
         match self {
             Self::Always => true,
-            Self::Auto => atty::is(atty::Stream::Stdout),
+            Self::Auto => std::io::stdout().is_terminal(),
             Self::Never => false,
         }
     }

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -2,8 +2,8 @@
 // Copyright 2016-2023 the Tectonic Project
 // Licensed under the MIT License.
 
-use std::{env, process, str::FromStr};
-use structopt::StructOpt;
+use clap::{Parser, ValueEnum};
+use std::{env, process};
 use tectonic_status_base::plain::PlainStatusBackend;
 
 use tectonic::{
@@ -36,36 +36,58 @@ mod v2cli {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "Tectonic", about = "Process a (La)TeX document")]
+#[derive(Debug, Parser)]
+#[command(name = "Tectonic", about = "Process a (La)TeX document")]
 struct CliOptions {
     /// Use experimental V2 interface (see `tectonic -X --help`)
-    #[structopt(short = "X")]
+    #[arg(short = 'X')]
     use_v2: bool,
 
     /// How much chatter to print when running
-    #[structopt(long = "chatter", short, name = "level", default_value = "default", possible_values(&["default", "minimal"]))]
-    chatter_level: String,
+    #[arg(long = "chatter", short, name = "level", default_value = "default")]
+    chatter_level: ChatterLevel,
 
     /// Enable/disable colorful log output
-    #[structopt(long = "color", name = "when", default_value = "auto", possible_values(&["always", "auto", "never"]))]
-    cli_color: String,
+    #[arg(long = "color", name = "when", default_value = "auto")]
+    cli_color: CliColor,
 
     /// Use this URL to find resource files instead of the default
-    #[structopt(takes_value(true), long, short, name = "url", overrides_with = "url")]
+    #[arg(long, short, name = "url", overrides_with = "url")]
     // TODO add URL validation
     web_bundle: Option<String>,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     compile: compile::CompileOptions,
 }
 
-#[derive(StructOpt)]
+#[derive(ValueEnum, Clone, Debug)]
+pub enum CliColor {
+    #[value(name = "always")]
+    Always,
+
+    #[value(name = "auto")]
+    Auto,
+
+    #[value(name = "never")]
+    Never,
+}
+
+impl CliColor {
+    pub fn should_enable(&self) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Auto => atty::is(atty::Stream::Stdout),
+            Self::Never => false,
+        }
+    }
+}
+
+#[derive(Parser)]
 struct PeekUnstableOptions {
-    #[structopt(name = "option", short = "Z", number_of_values = 1)]
+    #[arg(name = "option", short = 'Z')]
     unstable: Vec<unstable_opts::UnstableArg>,
 
-    #[structopt()]
+    #[arg()]
     _remainder: Vec<std::ffi::OsString>,
 }
 
@@ -78,7 +100,7 @@ fn main() {
     // exit. Otherwise, this will all be a no-op, and we'll re-parse the args
     // "for real" momentarily.
 
-    if let Ok(args) = PeekUnstableOptions::from_args_safe() {
+    if let Ok(args) = PeekUnstableOptions::try_parse() {
         unstable_opts::UnstableOptions::from_unstable_args(args.unstable.into_iter());
     }
 
@@ -102,7 +124,7 @@ fn main() {
     {
         // Try to parse as v1 cli first, and when that doesn't work,
         // interpret it as v2 cli:
-        if CliOptions::from_args_safe().is_err() || CliOptions::from_args().use_v2 {
+        if CliOptions::try_parse().is_err() || CliOptions::parse().use_v2 {
             v2cli_enabled = true;
             v2cli_args.remove(index);
         }
@@ -115,7 +137,7 @@ fn main() {
 
     // OK, we're still using the "rustc-style" CLI. Proceed here.
 
-    let args = CliOptions::from_args();
+    let args = CliOptions::parse();
 
     // The Tectonic crate comes with a hidden internal "test mode" that forces
     // it to use a specified set of local files, rather than going to the
@@ -152,18 +174,10 @@ fn main() {
     // something I'd be relatively OK with since it'd only affect the progam
     // UI, not the processing results).
 
-    let chatter_level = ChatterLevel::from_str(&args.chatter_level).unwrap();
-    let use_cli_color = match &*args.cli_color {
-        "always" => true,
-        "auto" => atty::is(atty::Stream::Stdout),
-        "never" => false,
-        _ => unreachable!(),
-    };
-
-    let mut status = if use_cli_color {
-        Box::new(TermcolorStatusBackend::new(chatter_level)) as Box<dyn StatusBackend>
+    let mut status = if args.cli_color.should_enable() {
+        Box::new(TermcolorStatusBackend::new(args.chatter_level)) as Box<dyn StatusBackend>
     } else {
-        Box::new(PlainStatusBackend::new(chatter_level)) as Box<dyn StatusBackend>
+        Box::new(PlainStatusBackend::new(args.chatter_level)) as Box<dyn StatusBackend>
     };
 
     // Now that we've got colorized output, pass off to the inner function ...


### PR DESCRIPTION
`structopt` has been integrated into `clap` as of `0.3`, and `atty` hasn't been updated in a few years.
This PR fixes both these problems, and closes #1034.