### PR TITLE
Don't rebuild tectonic(bin) when non-binary files are changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,12 @@
 use std::env;
 
 fn main() {
+    // Depend on this file to prevent rebuilding on any change - see #1173 for details
+    println!("cargo:rerun-if-changed=build.rs");
+
     // Re-export $TARGET during the build so that our executable tests know
     // what environment variable CARGO_TARGET_@TARGET@_RUNNER to check when
     // they want to spawn off executables.
-
-    println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").unwrap();
     println!("cargo:rustc-env=TARGET={target}");
 }

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() {
     // what environment variable CARGO_TARGET_@TARGET@_RUNNER to check when
     // they want to spawn off executables.
 
+    println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").unwrap();
     println!("cargo:rustc-env=TARGET={target}");
 }


### PR DESCRIPTION
Currently, the `tectonic` and `tectonic(bin)` targets rebuild on any change anywhere in the project, including to test files and even non-code files (changing README.md or such). This is unecessary, and caused by the build script not emitting any tracking info to Cargo, which causes it to conservatively assume rebuild on anything. We can't add a track-env on `TARGET` because that variable is set by Cargo for the build script, and tracking it will cause the same issue we're currently seeing (https://github.com/rust-lang/cargo/issues/12403 / https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-env-changed). Instead, fix the problem by tracking the build script itself, which should be what Cargo does anyways, and changing `TARGET` will always cause a rebuild no matter what the build script claims to depend on.