### PR TITLE
RFC: Introduce `bundle serve` command.

### DIFF
--- a/crates/bundles/src/cache.rs
+++ b/crates/bundles/src/cache.rs
@@ -658,6 +658,10 @@ impl<CB: CacheBackend> IoProvider for CachingBundle<CB> {
             InputOrigin::Other,
         ))
     }
+
+    fn input_path(&mut self, name: &str, status: &mut dyn StatusBackend) -> OpenResult<PathBuf> {
+        self.ensure_file_availability(name, status)
+    }
 }
 
 impl<CB: CacheBackend> Bundle for CachingBundle<CB> {

--- a/crates/io_base/src/lib.rs
+++ b/crates/io_base/src/lib.rs
@@ -485,6 +485,15 @@ pub trait IoProvider: AsIoProviderMut {
         }
     }
 
+    /// Return the path of an input file if it happens to be stored on the file system.
+    ///
+    /// A minimal implementation can always return [`OpenResult::NotAvailable`].
+    /// If a file is on the file system, it is preferred by the "bundle serve" command to return a
+    /// local path rather than dumping the contents.
+    fn input_path(&mut self, _name: &str, _status: &mut dyn StatusBackend) -> OpenResult<PathBuf> {
+        OpenResult::NotAvailable
+    }
+
     /// Open the "primary" input file, which in the context of TeX is the main
     /// input that it's given. When the build is being done using the
     /// filesystem and the input is a file on the filesystem, this function


### PR DESCRIPTION
This pull request adds a new `bundle serve` command, an interactive version of `bundle cat`. It allows querying the contents of multiple files without spawning a new process each time.

## Motivation

While working on TeXpresso, a real-time LaTeX file previewing tool, we've encountered a bottleneck in our current workflow. It is possible to use Tectonic as a TeX distribution via the `bundle cat` command, but querying the contents of multiple files spawns a new process each time and leads to performance issues. We propose introducing a new `bundle serve` command to address this problem.

## Background

[TeXpresso](https://github.com/let-def/texpresso) is an experimental tool that allows users to preview LaTeX files in real-time. It achieves using a patched XeTeX and a specialized viewer. You can see it in action with [Vim, Emacs](https://github.com/let-def/texpresso) and [VSCode](https://github.com/DominikPeters/texpresso-vscode). The viewer requires a TeX distribution, which is where Tectonic comes in. We started by using `bundle cat`, but we need a more efficient solution.

## Proposal

The `bundle serve` command is an interactive version of `bundle cat` that allows querying the contents of multiple files without spawning a new process each time. To achieve this, we need to delimit the different requests.

We implemented a simple protocol to stream all contents over a single stream:

1. On standard input, `bundle serve` reads a list of file names, one per line (delimited by `\n`).
2. For each file name, in order, `bundle serve` responds with a 9-byte header followed by a payload:
	* The first byte indicates the type of response: `C` for contents, `P` for path, or `E` for errors.
	* The next 8 bytes represent the length of the payload as a little-endian 64-bit unsigned integer.
	* The payload contents depend on the first byte:
		+ `C` indicates the contents of the requested file.
		+ `P` indicates a path on the local file system where the requested file can be found.
		+ `E` indicates an error message explaining why the request failed.

## Alternative

If a more complex protocol is not desirable, a simpler line-based protocol reading file names and writing either paths or error messages would be sufficient. This approach is similar to `kpsewhich -interactive` (with improved error handling).

## Conclusion

We believe introducing the `bundle serve` command and its accompanying protocol would significantly improve the performance of TeXpresso and, potentially, other tools that rely on `bundle cat`. We're open to feedback and alternative solutions.