### PR TITLE
Add synctex option in Toml file

### DIFF
--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -223,6 +223,8 @@ pub struct OutputProfile {
     pub shell_escape_cwd: Option<String>,
 
     /// Whether synctex should be activated for this profile.
+    ///
+    /// Default is false.
     pub synctex: bool,
 }
 

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -221,6 +221,9 @@ pub struct OutputProfile {
     /// Directory is not managed and any files created in it will not be deleted.
     ///
     pub shell_escape_cwd: Option<String>,
+
+    /// Whether synctex should be activated for this profile.
+    pub synctex: bool,
 }
 
 /// The output target type of a document build.
@@ -308,6 +311,7 @@ pub(crate) fn default_outputs() -> HashMap<String, OutputProfile> {
                 .collect(),
             shell_escape: false,
             shell_escape_cwd: None,
+            synctex: false,
         },
     );
     outputs

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -357,4 +357,37 @@ mod tests {
         let doc = Document::new_from_toml(".", ".", &mut c).unwrap();
         assert!(doc.outputs.get("o").unwrap().shell_escape);
     }
+
+    #[test]
+    fn synctex_default_false() {
+        const TOML: &str = r#"
+        [doc]
+        name = "test"
+        bundle = "na"
+
+        [[output]]
+        name = "o"
+        type = "pdf"
+        "#;
+        let mut c = Cursor::new(TOML.as_bytes());
+        let doc = Document::new_from_toml(".", ".", &mut c).unwrap();
+        assert!(!doc.outputs.get("o").unwrap().synctex);
+    }
+
+    #[test]
+    fn synctex_set_true() {
+        const TOML: &str = r#"
+        [doc]
+        name = "test"
+        bundle = "na"
+
+        [[output]]
+        name = "o"
+        type = "pdf"
+        synctex = true
+        "#;
+        let mut c = Cursor::new(TOML.as_bytes());
+        let doc = Document::new_from_toml(".", ".", &mut c).unwrap();
+        assert!(doc.outputs.get("o").unwrap().synctex);
+    }
 }

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -95,6 +95,7 @@ pub struct TomlOutputProfile {
     pub tex_format: Option<String>,
     pub shell_escape: Option<bool>,
     pub shell_escape_cwd: Option<String>,
+    pub synctex: Option<bool>,
 
     // We cannot handle these two input variants with an enum.
     // The ideal solution requires #[serde(flatten)],
@@ -115,6 +116,7 @@ pub struct TomlOutputProfile {
 impl From<&TomlOutputProfile> for OutputProfile {
     fn from(val: &TomlOutputProfile) -> OutputProfile {
         let shell_escape_default = val.shell_escape_cwd.is_some();
+        let synctex_default = false;
 
         let inputs = {
             if let Some(inputs) = &val.inputs {
@@ -149,6 +151,7 @@ impl From<&TomlOutputProfile> for OutputProfile {
             inputs,
             shell_escape: val.shell_escape.unwrap_or(shell_escape_default),
             shell_escape_cwd: val.shell_escape_cwd.clone(),
+            synctex: val.synctex.unwrap_or(synctex_default),
         }
     }
 }
@@ -166,6 +169,7 @@ impl From<&OutputProfile> for TomlOutputProfile {
 
         let shell_escape = if !rt.shell_escape { None } else { Some(true) };
         let shell_escape_cwd = rt.shell_escape_cwd.clone();
+        let synctex = if !rt.synctex { None } else {Some(true)};
 
         TomlOutputProfile {
             name: rt.name.clone(),
@@ -174,6 +178,7 @@ impl From<&OutputProfile> for TomlOutputProfile {
             inputs: Some(inputs),
             shell_escape,
             shell_escape_cwd,
+            synctex,
             preamble_file: None,
             index_file: None,
             postamble_file: None,

--- a/docs/src/ref/tectonic-toml.md
+++ b/docs/src/ref/tectonic-toml.md
@@ -57,6 +57,9 @@ shell_escape = false
 # This is optional, and defaults to a temporary directory.
 shell_escape_cwd = "string"
 
+# Whether the synctex files will be created. This is optional and defaults to false.
+synctex = false
+
 # The input file we'll use to build this document,
 # Given as a path relative to the `./src` directory.
 #

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -176,7 +176,8 @@ impl DocumentExt for Document {
             })
             .pass(PassSetting::Default)
             .primary_input_buffer(input_buffer.as_bytes())
-            .tex_input_name(output_profile);
+            .tex_input_name(output_profile)
+            .synctex(profile.synctex);
 
         if profile.shell_escape {
             // For now, this is the only option we allow.

--- a/tests/synctex/Tectonic.toml
+++ b/tests/synctex/Tectonic.toml
@@ -1,0 +1,12 @@
+[doc]
+name = "synctex"
+bundle = "https://data1.fullyjustified.net/tlextras-2022.0r0.tar"
+
+[[output]]
+name = "default"
+type = "pdf"
+inputs = [
+    "_preamble.tex",
+    "index.tex",
+    "_postamble.tex",
+]

--- a/tests/synctex/Tectonic.toml
+++ b/tests/synctex/Tectonic.toml
@@ -5,6 +5,7 @@ bundle = "https://data1.fullyjustified.net/tlextras-2022.0r0.tar"
 [[output]]
 name = "default"
 type = "pdf"
+synctex = true
 inputs = [
     "_preamble.tex",
     "index.tex",

--- a/tests/synctex/src/_postamble.tex
+++ b/tests/synctex/src/_postamble.tex
@@ -1,0 +1,1 @@
+\end{document}

--- a/tests/synctex/src/_preamble.tex
+++ b/tests/synctex/src/_preamble.tex
@@ -1,0 +1,4 @@
+\documentclass{article}
+\title{My Title}
+\synctex=1
+\begin{document}

--- a/tests/synctex/src/_preamble.tex
+++ b/tests/synctex/src/_preamble.tex
@@ -1,4 +1,3 @@
 \documentclass{article}
 \title{My Title}
-\synctex=1
 \begin{document}

--- a/tests/synctex/src/index.tex
+++ b/tests/synctex/src/index.tex
@@ -1,0 +1,1 @@
+Hello, world.


### PR DESCRIPTION
This closes #889. It adds the option `synctex = bool` to create the files needed by synctex.

This PR also adds : 

- A few tests of the synctex option in toml.
- A functional test in tests/synctex
- A line of documentation in the tectonic book