### PR TITLE
Update macos CI version to macos-12

### DIFF
--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -14,288 +14,288 @@
 # compile-time `${{ if }}:` statements.
 
 parameters:
-- name: pkgconfigBuilds
-  type: object
-  default:
-  - name: linux_stable_semistatic
-    vmImage: ubuntu-22.04
-    params:
-      primaryBuild: true
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
-      TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC: true
+  - name: pkgconfigBuilds
+    type: object
+    default:
+      - name: linux_stable_semistatic
+        vmImage: ubuntu-22.04
+        params:
+          primaryBuild: true
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
+          TECTONIC_PKGCONFIG_FORCE_SEMI_STATIC: true
 
-  - name: linux_stable_extdeps
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-      installAllDeps: true
-      explicitFeatures: "external-harfbuzz"
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+      - name: linux_stable_extdeps
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+          installAllDeps: true
+          explicitFeatures: "external-harfbuzz"
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-  - name: linux_stable_intdeps
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-      installAllDeps: false
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+      - name: linux_stable_intdeps
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+          installAllDeps: false
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-  - name: linux_beta
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: beta
+      - name: linux_beta
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: beta
 
-  - name: linux_nightly
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: nightly
+      - name: linux_nightly
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: nightly
 
-  - name: macos_intdeps
-    vmImage: macos-11
-    params:
-      canaryBuild: true
-      installAllDeps: false
-    vars:
-      TARGET: x86_64-apple-darwin
-      TOOLCHAIN: stable
+      - name: macos_intdeps
+        vmImage: macos-12
+        params:
+          canaryBuild: true
+          installAllDeps: false
+        vars:
+          TARGET: x86_64-apple-darwin
+          TOOLCHAIN: stable
 
-  - name: macos_extdeps
-    vmImage: macos-11
-    params:
-      canaryBuild: true
-      installAllDeps: true
-      explicitFeatures: "external-harfbuzz"
-    vars:
-      TARGET: x86_64-apple-darwin
-      TOOLCHAIN: stable
+      - name: macos_extdeps
+        vmImage: macos-12
+        params:
+          canaryBuild: true
+          installAllDeps: true
+          explicitFeatures: "external-harfbuzz"
+        vars:
+          TARGET: x86_64-apple-darwin
+          TOOLCHAIN: stable
 
-  - name: windows_intdeps
-    vmImage: windows-2019
-    params:
-      installAllDeps: false
-    vars:
-      TARGET: x86_64-pc-windows-gnu
-      TOOLCHAIN: stable-x86_64-pc-windows-gnu
+      - name: windows_intdeps
+        vmImage: windows-2019
+        params:
+          installAllDeps: false
+        vars:
+          TARGET: x86_64-pc-windows-gnu
+          TOOLCHAIN: stable-x86_64-pc-windows-gnu
 
-  - name: windows_extdeps
-    vmImage: windows-2019
-    params:
-      canaryBuild: true
-      installAllDeps: true
-      explicitFeatures: "external-harfbuzz"
-    vars:
-      TARGET: x86_64-pc-windows-gnu
-      TOOLCHAIN: stable-x86_64-pc-windows-gnu
+      - name: windows_extdeps
+        vmImage: windows-2019
+        params:
+          canaryBuild: true
+          installAllDeps: true
+          explicitFeatures: "external-harfbuzz"
+        vars:
+          TARGET: x86_64-pc-windows-gnu
+          TOOLCHAIN: stable-x86_64-pc-windows-gnu
 
-  - name: linux_ftmtx_none
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-      installAllDeps: false
-      defaultFeatures: false
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+      - name: linux_ftmtx_none
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+          installAllDeps: false
+          defaultFeatures: false
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-  - name: linux_ftmtx_all
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-      installAllDeps: true
-      explicitFeatures: _all_
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+      - name: linux_ftmtx_all
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+          installAllDeps: true
+          explicitFeatures: _all_
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-  - name: linux_ftmtx_curl
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-      installAllDeps: true
-      defaultFeatures: false
-      explicitFeatures: "geturl-curl serialization"
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+      - name: linux_ftmtx_curl
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+          installAllDeps: true
+          defaultFeatures: false
+          explicitFeatures: "geturl-curl serialization"
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-- name: vcpkgBuilds
-  type: object
-  default:
-  - name: x86_64_unknown_linux_gnu
-    vmImage: ubuntu-22.04
-    params:
-      canaryBuild: true
-    vars:
-      TARGET: x86_64-unknown-linux-gnu
-      TOOLCHAIN: stable
+  - name: vcpkgBuilds
+    type: object
+    default:
+      - name: x86_64_unknown_linux_gnu
+        vmImage: ubuntu-22.04
+        params:
+          canaryBuild: true
+        vars:
+          TARGET: x86_64-unknown-linux-gnu
+          TOOLCHAIN: stable
 
-  - name: x86_64_apple_darwin
-    vmImage: macos-11
-    params: {}
-    vars:
-      TARGET: x86_64-apple-darwin
-      TOOLCHAIN: stable
+      - name: x86_64_apple_darwin
+        vmImage: macos-12
+        params: { }
+        vars:
+          TARGET: x86_64-apple-darwin
+          TOOLCHAIN: stable
 
-  - name: aarch64_apple_darwin
-    vmImage: macos-11
-    params:
-      testIt: false
-    vars:
-      TARGET: aarch64-apple-darwin
-      TOOLCHAIN: stable
+      - name: aarch64_apple_darwin
+        vmImage: macos-12
+        params:
+          testIt: false
+        vars:
+          TARGET: aarch64-apple-darwin
+          TOOLCHAIN: stable
 
-  - name: x86_64_pc_windows_msvc
-    vmImage: windows-2019
-    params: {}
-    vars:
-      TARGET: x86_64-pc-windows-msvc
-      TOOLCHAIN: stable-x86_64-pc-windows-msvc
+      - name: x86_64_pc_windows_msvc
+        vmImage: windows-2019
+        params: { }
+        vars:
+          TARGET: x86_64-pc-windows-msvc
+          TOOLCHAIN: stable-x86_64-pc-windows-msvc
 
-- name: crossBuilds
-  type: object
-  default:
-  - name: aarch64_unknown_linux_musl
-    vars:
-      TARGET: aarch64-unknown-linux-musl
+  - name: crossBuilds
+    type: object
+    default:
+      - name: aarch64_unknown_linux_musl
+        vars:
+          TARGET: aarch64-unknown-linux-musl
 
-  - name: arm_unknown_linux_musleabihf
-    vars:
-      TARGET: arm-unknown-linux-musleabihf
+      - name: arm_unknown_linux_musleabihf
+        vars:
+          TARGET: arm-unknown-linux-musleabihf
 
-  - name: i686_unknown_linux_gnu
-    vars:
-      TARGET: i686-unknown-linux-gnu
+      - name: i686_unknown_linux_gnu
+        vars:
+          TARGET: i686-unknown-linux-gnu
 
-  - name: x86_64_unknown_linux_musl
-    vars:
-      TARGET: x86_64-unknown-linux-musl
+      - name: x86_64_unknown_linux_musl
+        vars:
+          TARGET: x86_64-unknown-linux-musl
 
 jobs:
 
-# rustfmt check
-- job: rustfmt
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-    - bash: rustup component add rustfmt
-      displayName: "Install rustfmt"
-    - bash: cargo fmt --all -- --check
-      displayName: "Check rustfmt (cargo)"
-  variables:
-    TOOLCHAIN: stable
-
-# clippy check
-- job: clippy
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-    - template: azure-generic-build-setup.yml
-    - bash: |
-        rustup component add clippy
-        cargo clippy --version
-      displayName: "Install clippy"
-    # Ew, redundant with stock builds:
-    - bash: |
-        set -xeuo pipefail
-        sudo apt-get update
-        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
-          libgraphite2-dev \
-          libharfbuzz-dev \
-          libfontconfig1-dev \
-          libicu-dev \
-          libssl-dev \
-          openssl \
-          zlib1g-dev
-      displayName: "Install pkg-config dependencies (Ubuntu)"
-    - bash: cargo clippy --all --all-targets --all-features -- --deny warnings
-      displayName: "Check clippy (cargo)"
-  variables:
-    TOOLCHAIN: stable
-
-# pkg-config builds
-- ${{ each build in parameters.pkgconfigBuilds }}:
-  - job: ${{ format('build_{0}_pkgconfig', build.name) }}
+  # rustfmt check
+  - job: rustfmt
     pool:
-      vmImage: ${{ build.vmImage }}
+      vmImage: ubuntu-latest
     steps:
-    - template: azure-build-and-test-pkgconfig.yml
-      parameters:
-        ${{ insert }}: ${{ build.params }}
-    variables:
-      ${{ insert }}: ${{ build.vars }}
-
-# vcpkg builds
-- ${{ each build in parameters.vcpkgBuilds }}:
-  - job: ${{ format('build_{0}_vcpkg', build.name) }}
-    pool:
-      vmImage: ${{ build.vmImage }}
-    steps:
-    - template: azure-build-and-test-vcpkg.yml
-      parameters:
-        ${{ insert }}: ${{ build.params }}
-    variables:
-      ${{ insert }}: ${{ build.vars }}
-
-# cross builds
-- ${{ each build in parameters.crossBuilds }}:
-  - job: ${{ format('cross_{0}', build.name) }}
-    pool:
-      vmImage: ubuntu-22.04
-    steps:
-    - template: azure-build-and-test-cross.yml
+      - bash: rustup component add rustfmt
+        displayName: "Install rustfmt"
+      - bash: cargo fmt --all -- --check
+        displayName: "Check rustfmt (cargo)"
     variables:
       TOOLCHAIN: stable
-      ${{ insert }}: ${{ build.vars }}
 
-# coverage analysis check
-- job: coverage
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-    - template: azure-coverage.yml
-  variables:
-    TOOLCHAIN: stable
+  # clippy check
+  - job: clippy
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - template: azure-generic-build-setup.yml
+      - bash: |
+          rustup component add clippy
+          cargo clippy --version
+        displayName: "Install clippy"
+      # Ew, redundant with stock builds:
+      - bash: |
+          set -xeuo pipefail
+          sudo apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            libgraphite2-dev \
+            libharfbuzz-dev \
+            libfontconfig1-dev \
+            libicu-dev \
+            libssl-dev \
+            openssl \
+            zlib1g-dev
+        displayName: "Install pkg-config dependencies (Ubuntu)"
+      - bash: cargo clippy --all --all-targets --all-features -- --deny warnings
+        displayName: "Check clippy (cargo)"
+    variables:
+      TOOLCHAIN: stable
 
-# book build
-- job: book
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - template: azure-generic-build-setup.yml
-  - bash: |
-      fn="mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-gnu.tar.gz"
-      url="https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/$fn"
-      wget -q --progress=dot "$url"
-      tar xzf "$fn"
-      rm -f "$fn"
-    displayName: Install mdbook $(MDBOOK_VERSION)
-  - bash: cargo build -p tectonic_cfg_support
-    displayName: Mini cargo build
-  - bash: |
-      git add .
-      cranko release-workflow commit
-      git show HEAD
-    displayName: cranko release-workflow commit
-  - bash: |
-      artifact_dir="$(Build.ArtifactStagingDirectory)/book"
-      mkdir -p "$artifact_dir"
-      cd docs && ../mdbook build -d "$artifact_dir"
-    displayName: mdbook build
-  - task: PublishPipelineArtifact@1
-    displayName: Publish book artifacts
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/book'
-      artifactName: book
-  - bash: cd docs && ../mdbook test
-    displayName: mdbook test
+  # pkg-config builds
+  - ${{ each build in parameters.pkgconfigBuilds }}:
+      - job: ${{ format('build_{0}_pkgconfig', build.name) }}
+        pool:
+          vmImage: ${{ build.vmImage }}
+        steps:
+          - template: azure-build-and-test-pkgconfig.yml
+            parameters:
+              ${{ insert }}: ${{ build.params }}
+        variables:
+          ${{ insert }}: ${{ build.vars }}
+
+  # vcpkg builds
+  - ${{ each build in parameters.vcpkgBuilds }}:
+      - job: ${{ format('build_{0}_vcpkg', build.name) }}
+        pool:
+          vmImage: ${{ build.vmImage }}
+        steps:
+          - template: azure-build-and-test-vcpkg.yml
+            parameters:
+              ${{ insert }}: ${{ build.params }}
+        variables:
+          ${{ insert }}: ${{ build.vars }}
+
+  # cross builds
+  - ${{ each build in parameters.crossBuilds }}:
+      - job: ${{ format('cross_{0}', build.name) }}
+        pool:
+          vmImage: ubuntu-22.04
+        steps:
+          - template: azure-build-and-test-cross.yml
+        variables:
+          TOOLCHAIN: stable
+          ${{ insert }}: ${{ build.vars }}
+
+  # coverage analysis check
+  - job: coverage
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - template: azure-coverage.yml
+    variables:
+      TOOLCHAIN: stable
+
+  # book build
+  - job: book
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - template: azure-generic-build-setup.yml
+      - bash: |
+          fn="mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-gnu.tar.gz"
+          url="https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/$fn"
+          wget -q --progress=dot "$url"
+          tar xzf "$fn"
+          rm -f "$fn"
+        displayName: Install mdbook $(MDBOOK_VERSION)
+      - bash: cargo build -p tectonic_cfg_support
+        displayName: Mini cargo build
+      - bash: |
+          git add .
+          cranko release-workflow commit
+          git show HEAD
+        displayName: cranko release-workflow commit
+      - bash: |
+          artifact_dir="$(Build.ArtifactStagingDirectory)/book"
+          mkdir -p "$artifact_dir"
+          cd docs && ../mdbook build -d "$artifact_dir"
+        displayName: mdbook build
+      - task: PublishPipelineArtifact@1
+        displayName: Publish book artifacts
+        inputs:
+          targetPath: '$(Build.ArtifactStagingDirectory)/book'
+          artifactName: book
+      - bash: cd docs && ../mdbook test
+        displayName: mdbook test


### PR DESCRIPTION
CI is failing due to macos-11 having been deprecated and removed. Update to macos-12 as matching macos-latest.