### PR TITLE
Use `i64` to prevent overflows

### DIFF
--- a/crates/bridge_flate/src/lib.rs
+++ b/crates/bridge_flate/src/lib.rs
@@ -113,7 +113,7 @@ struct Decompressor<'a> {
     done: bool,
 }
 
-impl<'a> Decompressor<'a> {
+impl Decompressor<'_> {
     fn decompress_chunk(&mut self, output: &mut [u8]) -> Result<usize, Error> {
         if self.done {
             return Ok(0);

--- a/crates/bundles/src/itar.rs
+++ b/crates/bundles/src/itar.rs
@@ -193,7 +193,7 @@ impl Bundle for ItarBundle {
     }
 }
 
-impl<'this> CachableBundle<'this, ItarFileIndex> for ItarBundle {
+impl CachableBundle<'_, ItarFileIndex> for ItarBundle {
     fn get_location(&mut self) -> String {
         self.url.clone()
     }

--- a/crates/bundles/src/ttb_fs.rs
+++ b/crates/bundles/src/ttb_fs.rs
@@ -39,7 +39,6 @@ where
 }
 
 /// The internal file-information struct used by the [`TTBFsBundle`].
-
 impl TTBFsBundle<TTBFileIndex> {
     /// Create a new ZIP bundle for a generic readable and seekable stream.
     pub fn new(file: File) -> Result<Self> {

--- a/crates/bundles/src/ttb_net.rs
+++ b/crates/bundles/src/ttb_net.rs
@@ -50,7 +50,6 @@ where
 }
 
 /// The internal file-information struct used by the [`TTBNetBundle`].
-
 impl TTBNetBundle<TTBFileIndex> {
     /// Create a new ZIP bundle for a generic readable and seekable stream.
     /// This method does not require network access.
@@ -128,7 +127,7 @@ impl Bundle for TTBNetBundle<TTBFileIndex> {
     }
 }
 
-impl<'this> CachableBundle<'this, TTBFileIndex> for TTBNetBundle<TTBFileIndex> {
+impl CachableBundle<'_, TTBFileIndex> for TTBNetBundle<TTBFileIndex> {
     fn get_location(&mut self) -> String {
         self.url.clone()
     }

--- a/crates/engine_bibtex/src/auxi.rs
+++ b/crates/engine_bibtex/src/auxi.rs
@@ -296,8 +296,8 @@ fn aux_citation_command(
             }
 
             cites.set_cite(cites.ptr(), hash.text(uc_res.loc));
-            hash.set_ilk_info(uc_res.loc, cites.ptr() as i32);
-            hash.set_ilk_info(lc_res.loc, uc_res.loc as i32);
+            hash.set_ilk_info(uc_res.loc, cites.ptr() as i64);
+            hash.set_ilk_info(lc_res.loc, uc_res.loc as i64);
             cites.set_ptr(cites.ptr() + 1);
         }
     }

--- a/crates/engine_bibtex/src/bibs.rs
+++ b/crates/engine_bibtex/src/bibs.rs
@@ -350,7 +350,7 @@ pub(crate) fn get_bib_command_or_entry_and_process(
                 *cur_macro_loc = res.loc;
                 globals
                     .hash
-                    .set_ilk_info(res.loc, globals.hash.text(res.loc) as i32);
+                    .set_ilk_info(res.loc, globals.hash.text(res.loc) as i64);
 
                 if !eat_bib_white_space(globals.buffers, globals.bibs) {
                     eat_bib_print(globals.buffers, globals.pool, globals.bibs, at_bib_command)?;
@@ -520,8 +520,8 @@ pub(crate) fn get_bib_command_or_entry_and_process(
                         res = uc_res;
 
                         if !uc_res.exists {
-                            globals.hash.set_ilk_info(lc_res.loc, uc_res.loc as i32);
-                            globals.hash.set_ilk_info(uc_res.loc, entry_ptr as i32);
+                            globals.hash.set_ilk_info(lc_res.loc, uc_res.loc as i64);
+                            globals.hash.set_ilk_info(uc_res.loc, entry_ptr as i64);
                             globals
                                 .cites
                                 .set_cite(entry_ptr, globals.hash.text(uc_res.loc));

--- a/crates/engine_bibtex/src/bst.rs
+++ b/crates/engine_bibtex/src/bst.rs
@@ -123,7 +123,7 @@ fn bst_entry_command(
         globals.hash.set_ty(res.loc, FnClass::Field);
         globals
             .hash
-            .set_ilk_info(res.loc, globals.other.num_fields() as i32);
+            .set_ilk_info(res.loc, globals.other.num_fields() as i64);
         globals.other.set_num_fields(globals.other.num_fields() + 1);
 
         eat_bst_white!(ctx, globals, "entry");
@@ -169,7 +169,7 @@ fn bst_entry_command(
         globals.hash.set_ty(res.loc, FnClass::IntEntryVar);
         globals
             .hash
-            .set_ilk_info(res.loc, globals.entries.num_ent_ints() as i32);
+            .set_ilk_info(res.loc, globals.entries.num_ent_ints() as i64);
         globals
             .entries
             .set_num_ent_ints(globals.entries.num_ent_ints() + 1);
@@ -211,7 +211,7 @@ fn bst_entry_command(
         globals.hash.set_ty(res.loc, FnClass::StrEntryVar);
         globals
             .hash
-            .set_ilk_info(res.loc, globals.entries.num_ent_strs() as i32);
+            .set_ilk_info(res.loc, globals.entries.num_ent_strs() as i64);
         globals
             .entries
             .set_num_ent_strs(globals.entries.num_ent_strs() + 1);
@@ -455,7 +455,7 @@ fn bst_macro_command(
     }
     globals
         .hash
-        .set_ilk_info(res.loc, globals.hash.text(res.loc) as i32);
+        .set_ilk_info(res.loc, globals.hash.text(res.loc) as i64);
 
     eat_bst_white!(ctx, globals, "macro");
     bst_brace!('}', ctx, globals, "macro");
@@ -492,7 +492,7 @@ fn bst_macro_command(
     globals.hash.set_ty(res2.loc, FnClass::StrLit);
     globals
         .hash
-        .set_ilk_info(res.loc, globals.hash.text(res2.loc) as i32);
+        .set_ilk_info(res.loc, globals.hash.text(res2.loc) as i64);
     globals
         .buffers
         .set_offset(BufTy::Base, 2, globals.buffers.offset(BufTy::Base, 2) + 1);
@@ -747,7 +747,7 @@ fn bst_read_command(
 
                 globals
                     .hash
-                    .set_ilk_info(find.cite_loc, ctx.glbl_ctx().cite_xptr as i32);
+                    .set_ilk_info(find.cite_loc, ctx.glbl_ctx().cite_xptr as i64);
 
                 let start = ctx.glbl_ctx().cite_xptr * globals.other.num_fields();
                 let end = start + globals.other.num_fields();
@@ -897,7 +897,7 @@ fn bst_strings_command(
         globals.hash.set_ty(res.loc, FnClass::StrGlblVar);
         globals
             .hash
-            .set_ilk_info(res.loc, globals.globals.num_glb_strs());
+            .set_ilk_info(res.loc, globals.globals.num_glb_strs() as i64);
 
         if globals.globals.num_glb_strs() as usize == globals.globals.len() {
             globals.globals.grow();

--- a/crates/engine_bibtex/src/char_info.rs
+++ b/crates/engine_bibtex/src/char_info.rs
@@ -94,7 +94,7 @@ const ID_CLASS: [IdClass; 256] = {
     id_class
 };
 
-pub static CHAR_WIDTH: [i32; 256] = {
+pub static CHAR_WIDTH: [i64; 256] = {
     let mut char_width = [0; 256];
 
     // Values taken from the bibtex web2c implementation

--- a/crates/engine_bibtex/src/cite.rs
+++ b/crates/engine_bibtex/src/cite.rs
@@ -149,8 +149,8 @@ pub(crate) fn add_database_cite(
     other.check_field_overflow(other.num_fields() * (new_cite + 1));
 
     cites.set_cite(new_cite, hash.text(cite_loc));
-    hash.set_ilk_info(cite_loc, new_cite as i32);
-    hash.set_ilk_info(lc_cite_loc, cite_loc as i32);
+    hash.set_ilk_info(cite_loc, new_cite as i64);
+    hash.set_ilk_info(lc_cite_loc, cite_loc as i64);
     new_cite + 1
 }
 

--- a/crates/engine_bibtex/src/entries.rs
+++ b/crates/engine_bibtex/src/entries.rs
@@ -6,7 +6,7 @@ pub(crate) struct EntryData {
     num_entry_ints: usize,
     num_entry_strs: usize,
     sort_key_num: usize,
-    entry_ints: Option<XBuf<i32>>,
+    entry_ints: Option<XBuf<i64>>,
     entry_strs: Option<XBuf<ASCIICode>>,
 }
 
@@ -21,11 +21,11 @@ impl EntryData {
         }
     }
 
-    pub fn ints(&self, pos: usize) -> i32 {
+    pub fn ints(&self, pos: usize) -> i64 {
         self.entry_ints.as_ref().unwrap()[pos]
     }
 
-    pub fn set_int(&mut self, pos: usize, val: i32) {
+    pub fn set_int(&mut self, pos: usize, val: i64) {
         self.entry_ints.as_mut().unwrap()[pos] = val;
     }
 

--- a/crates/engine_bibtex/src/exec.rs
+++ b/crates/engine_bibtex/src/exec.rs
@@ -34,7 +34,7 @@ pub(crate) enum StkType {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum ExecVal {
-    Integer(i32),
+    Integer(i64),
     String(StrNumber),
     Function(HashPointer),
     Missing(StrNumber),
@@ -648,12 +648,12 @@ fn interp_eq(
 
     match (pop1, pop2) {
         (ExecVal::Integer(i1), ExecVal::Integer(i2)) => {
-            ctx.push_stack(ExecVal::Integer((i1 == i2) as i32));
+            ctx.push_stack(ExecVal::Integer((i1 == i2) as i64));
         }
         (ExecVal::String(s1), ExecVal::String(s2)) => {
             // TODO: Can we just compare str numbers here?
             ctx.push_stack(ExecVal::Integer(
-                (pool.get_str(s1) == pool.get_str(s2)) as i32,
+                (pool.get_str(s1) == pool.get_str(s2)) as i64,
             ));
         }
         _ if pop1.ty() != pop2.ty() => {
@@ -689,7 +689,7 @@ fn interp_gt(
 
     match (pop1, pop2) {
         (ExecVal::Integer(i1), ExecVal::Integer(i2)) => {
-            ctx.push_stack(ExecVal::Integer((i2 > i1) as i32));
+            ctx.push_stack(ExecVal::Integer((i2 > i1) as i64));
         }
         (ExecVal::Integer(_), _) => {
             print_wrong_stk_lit(ctx, pool, hash, cites, pop2, StkType::Integer)?;
@@ -714,7 +714,7 @@ fn interp_lt(
 
     match (pop1, pop2) {
         (ExecVal::Integer(i1), ExecVal::Integer(i2)) => {
-            ctx.push_stack(ExecVal::Integer((i2 < i1) as i32));
+            ctx.push_stack(ExecVal::Integer((i2 < i1) as i64));
         }
         (ExecVal::Integer(_), _) => {
             print_wrong_stk_lit(ctx, pool, hash, cites, pop2, StkType::Integer)?;
@@ -1195,7 +1195,7 @@ fn interp_chr_to_int(
                 bst_ex_warn_print(ctx, pool, cites)?;
                 ctx.push_stack(ExecVal::Integer(0));
             } else {
-                ctx.push_stack(ExecVal::Integer(str[0] as i32))
+                ctx.push_stack(ExecVal::Integer(str[0] as i64))
             }
         }
         _ => {
@@ -1264,7 +1264,7 @@ fn interp_empty(
         ExecVal::String(s1) => {
             let str = pool.get_str(s1);
             let res = str.iter().all(|c| LexClass::of(*c) == LexClass::Whitespace);
-            ctx.push_stack(ExecVal::Integer(res as i32));
+            ctx.push_stack(ExecVal::Integer(res as i64));
         }
         ExecVal::Missing(_) => {
             ctx.push_stack(ExecVal::Integer(1));

--- a/crates/engine_bibtex/src/hash.rs
+++ b/crates/engine_bibtex/src/hash.rs
@@ -83,7 +83,7 @@ pub(crate) struct HashData {
     hash_next: XBuf<HashPointer>,
     hash_text: XBuf<StrNumber>,
     hash_ilk: XBuf<StrIlk>,
-    ilk_info: XBuf<i32>,
+    ilk_info: XBuf<i64>,
     fn_type: XBuf<FnClass>,
     hash_used: usize,
 }
@@ -152,11 +152,11 @@ impl HashData {
         self.hash_ilk[pos] = val;
     }
 
-    pub fn ilk_info(&self, pos: usize) -> i32 {
+    pub fn ilk_info(&self, pos: usize) -> i64 {
         self.ilk_info[pos]
     }
 
-    pub fn set_ilk_info(&mut self, pos: usize, info: i32) {
+    pub fn set_ilk_info(&mut self, pos: usize, info: i64) {
         self.ilk_info[pos] = info;
     }
 }

--- a/crates/engine_bibtex/src/pool.rs
+++ b/crates/engine_bibtex/src/pool.rs
@@ -386,24 +386,24 @@ pub(crate) fn pre_def_certain_strings(
     let res = pool.lookup_str_insert(hash, b"crossref", StrIlk::BstFn)?;
     let num_fields = other.num_fields();
     hash.set_ty(res.loc, FnClass::Field);
-    hash.set_ilk_info(res.loc, num_fields as i32);
+    hash.set_ilk_info(res.loc, num_fields as i64);
     other.set_crossref_num(num_fields);
     other.set_num_fields(num_fields + 1);
     other.set_pre_defined_fields(num_fields + 1);
 
     let res = pool.lookup_str_insert(hash, b"sort.key$", StrIlk::BstFn)?;
     hash.set_ty(res.loc, FnClass::StrEntryVar);
-    hash.set_ilk_info(res.loc, entries.num_ent_strs() as i32);
+    hash.set_ilk_info(res.loc, entries.num_ent_strs() as i64);
     entries.set_sort_key_num(entries.num_ent_strs());
     entries.set_num_ent_strs(entries.num_ent_strs() + 1);
 
     let res = pool.lookup_str_insert(hash, b"entry.max$", StrIlk::BstFn)?;
     hash.set_ty(res.loc, FnClass::IntGlblVar);
-    hash.set_ilk_info(res.loc, ENT_STR_SIZE as i32);
+    hash.set_ilk_info(res.loc, ENT_STR_SIZE as i64);
 
     let res = pool.lookup_str_insert(hash, b"global.max$", StrIlk::BstFn)?;
     hash.set_ty(res.loc, FnClass::IntGlblVar);
-    hash.set_ilk_info(res.loc, GLOB_STR_SIZE as i32);
+    hash.set_ilk_info(res.loc, GLOB_STR_SIZE as i64);
 
     Ok(())
 }

--- a/crates/engine_bibtex/src/scan.rs
+++ b/crates/engine_bibtex/src/scan.rs
@@ -62,10 +62,8 @@ impl<'a> Scan<'a> {
 
     fn match_char(&self, char: ASCIICode) -> bool {
         self.not_class
-            .map_or(false, |class| LexClass::of(char) != class)
-            || self
-                .class
-                .map_or(false, |class| LexClass::of(char) == class)
+            .is_some_and(|class| LexClass::of(char) != class)
+            || self.class.is_some_and(|class| LexClass::of(char) == class)
             || self.chars.contains(&char)
     }
 
@@ -904,11 +902,10 @@ pub(crate) fn name_scan_for_and(
                 buffers.set_offset(BufTy::Ex, 1, buffers.offset(BufTy::Ex, 1) + 1);
                 if preceding_white
                     && buffers.offset(BufTy::Ex, 1) <= buffers.init(BufTy::Ex).saturating_sub(3)
-                    && buffers.at_offset(BufTy::Ex, 1).to_ascii_lowercase() == b'n'
+                    && buffers.at_offset(BufTy::Ex, 1).eq_ignore_ascii_case(&b'n')
                     && buffers
                         .at(BufTy::Ex, buffers.offset(BufTy::Ex, 1) + 1)
-                        .to_ascii_lowercase()
-                        == b'd'
+                        .eq_ignore_ascii_case(&b'd')
                     && LexClass::of(buffers.at(BufTy::Ex, buffers.offset(BufTy::Ex, 1) + 2))
                         == LexClass::Whitespace
                 {

--- a/crates/engine_bibtex/src/scan.rs
+++ b/crates/engine_bibtex/src/scan.rs
@@ -126,7 +126,7 @@ pub(crate) fn scan_identifier(
     }
 }
 
-fn scan_integer(buffers: &mut GlobalBuffer, token_value: &mut i32) -> bool {
+fn scan_integer(buffers: &mut GlobalBuffer, token_value: &mut i64) -> bool {
     let last = buffers.init(BufTy::Base);
     let start = buffers.offset(BufTy::Base, 2);
     buffers.set_offset(BufTy::Base, 1, start);
@@ -142,7 +142,7 @@ fn scan_integer(buffers: &mut GlobalBuffer, token_value: &mut i32) -> bool {
     *token_value = 0;
     let mut char = buffers.at(BufTy::Base, idx);
     while idx < last && LexClass::of(char) == LexClass::Numeric {
-        *token_value = *token_value * 10 + (char - 48) as i32;
+        *token_value = *token_value * 10 + (char - 48) as i64;
         idx += 1;
         char = buffers.at(BufTy::Base, idx);
     }
@@ -369,7 +369,7 @@ pub(crate) fn scan_fn_def(
     single_function.push(HashData::end_of_def());
 
     other.check_wiz_overflow(single_function.len());
-    hash.set_ilk_info(fn_hash_loc, other.wiz_def_ptr() as i32);
+    hash.set_ilk_info(fn_hash_loc, other.wiz_def_ptr() as i64);
 
     for ptr in single_function {
         let wiz_ptr = other.wiz_def_ptr();
@@ -780,7 +780,7 @@ pub(crate) fn scan_and_store_the_field_value_and_eat_white(
         if at_bib_command {
             match command_num {
                 1 => bibs.add_preamble(hash.text(res.loc)),
-                2 => hash.set_ilk_info(cur_macro_loc, hash.text(res.loc) as i32),
+                2 => hash.set_ilk_info(cur_macro_loc, hash.text(res.loc) as i64),
                 _ => {
                     // TODO: Replace command_num with an enum
                     bib_cmd_confusion();

--- a/crates/engine_spx2html/src/fonts.rs
+++ b/crates/engine_spx2html/src/fonts.rs
@@ -576,7 +576,7 @@ struct GlyphTextProcessingIterator<'a> {
     next: usize,
 }
 
-impl<'a> Iterator for GlyphTextProcessingIterator<'a> {
+impl Iterator for GlyphTextProcessingIterator<'_> {
     type Item = (usize, Option<(char, String)>, FixedPoint);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/engine_spx2html/src/lib.rs
+++ b/crates/engine_spx2html/src/lib.rs
@@ -241,7 +241,7 @@ impl<'a> EngineState<'a> {
     }
 }
 
-impl<'a> XdvEvents for EngineState<'a> {
+impl XdvEvents for EngineState<'_> {
     type Error = Error;
 
     fn handle_header(&mut self, filetype: FileType, _comment: &[u8]) -> Result<()> {

--- a/crates/engine_spx2html/src/specials.rs
+++ b/crates/engine_spx2html/src/specials.rs
@@ -96,7 +96,7 @@ impl<'a> Special<'a> {
     }
 }
 
-impl<'a> Display for Special<'a> {
+impl Display for Special<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let (cmd, rest) = match self {
             Special::AddTemplate(t) => ("addTemplate", Some(t)),

--- a/crates/io_base/src/stack.rs
+++ b/crates/io_base/src/stack.rs
@@ -25,7 +25,7 @@ impl<'a> IoStack<'a> {
     }
 }
 
-impl<'a> IoProvider for IoStack<'a> {
+impl IoProvider for IoStack<'_> {
     fn output_open_name(&mut self, name: &str) -> OpenResult<OutputHandle> {
         for item in &mut self.items {
             let r = item.output_open_name(name);

--- a/src/bin/tectonic/v2cli/mod.rs
+++ b/src/bin/tectonic/v2cli/mod.rs
@@ -34,7 +34,6 @@ mod commands;
     about = "Process (La)TeX documents",
     no_binary_name(true)
 )]
-
 struct V2CliOptions {
     /// How much chatter to print when running
     #[arg(long = "chatter", short, default_value = "default")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -184,7 +184,6 @@ impl Error {
 /// equivalent, and false otherwise. This can happen if the value are known to
 /// be different, but also if we can't tell. It doesn't cover all cases, but
 /// it does cover the ones that come up in our test suite.
-
 pub trait DefinitelySame {
     fn definitely_same(&self, other: &Self) -> bool;
 }

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -56,8 +56,8 @@ struct FormatTestDriver<'a> {
     events: HashMap<String, FileSummary>,
 }
 
-impl<'a> FormatTestDriver<'a> {
-    fn new(io: IoStack<'a>) -> FormatTestDriver {
+impl FormatTestDriver<'_> {
+    fn new(io: IoStack) -> FormatTestDriver {
         FormatTestDriver {
             io,
             events: HashMap::new(),
@@ -67,7 +67,7 @@ impl<'a> FormatTestDriver<'a> {
 
 // We need to provide this whole wrapper implementation just to be able to add
 // file open events in `output_open_name`.
-impl<'a> IoProvider for FormatTestDriver<'a> {
+impl IoProvider for FormatTestDriver<'_> {
     fn output_open_name(&mut self, name: &str) -> OpenResult<OutputHandle> {
         let r = self.io.output_open_name(name);
 
@@ -112,7 +112,7 @@ impl<'a> IoProvider for FormatTestDriver<'a> {
     }
 }
 
-impl<'a> DriverHooks for FormatTestDriver<'a> {
+impl DriverHooks for FormatTestDriver<'_> {
     fn io(&mut self) -> &mut dyn IoProvider {
         self
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -231,10 +231,7 @@ impl<'a> ExpectedFile<'a> {
         let contents = String::from_utf8(contents)
             .unwrap()
             .replace("${ROOT}", &root)
-            .replace(
-                "${len(ROOT)+106}",
-                &(root.as_bytes().len() + 106).to_string(),
-            )
+            .replace("${len(ROOT)+106}", &(root.len() + 106).to_string())
             .into_bytes();
 
         ExpectedFile {


### PR DESCRIPTION
Fixes #1249