### PR TITLE
Cache vcpkg build to improve CI speed

### DIFF
--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -49,6 +49,7 @@ steps:
     echo "##vso[task.setvariable variable=VCPKG_ROOT;]$(pwd)/target/vcpkg"
     echo "##vso[task.setvariable variable=TECTONIC_DEP_BACKEND;]vcpkg"
     echo "##vso[task.setvariable variable=VCPKG_DEFAULT_BINARY_CACHE;]$(pwd)/target/vcpkg-cache"
+    mkdir -p "$(pwd)/target/vcpkg-cache"
   displayName: Setup build variables
 
 # Without RUST_TEST_THREAD=1, on Windows the doctests fail with a

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -67,8 +67,9 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | Cargo.toml'
+    key: '"vcpkg" | "$(TARGET)" | Cargo.toml'
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
+    restoreKeys: '"vcpkg" | "$(Agent.OS)" | $(Agent.OSArchitecture) | Cargo.toml'
   displayName: Load vcpkg cache
 
 - bash: |

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -48,6 +48,7 @@ steps:
 - bash: |
     echo "##vso[task.setvariable variable=VCPKG_ROOT;]$(pwd)/target/vcpkg"
     echo "##vso[task.setvariable variable=TECTONIC_DEP_BACKEND;]vcpkg"
+    echo "##vso[task.setvariable variable=VCPKG_DEFAULT_BINARY_CACHE;]$(pwd)/target/vcpkg-cache"
   displayName: Setup build variables
 
 # Without RUST_TEST_THREAD=1, on Windows the doctests fail with a
@@ -62,6 +63,12 @@ steps:
     echo "##vso[task.setvariable variable=RUST_TEST_THREADS;]1"
   displayName: Setup build variables (Windows)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: Cache@2
+  inputs:
+    key: '"vcpkg" | "$(Agent.OS)" | Cargo.toml'
+    path: $(VCPKG_DEFAULT_BINARY_CACHE)
+    displayName: Load vcpkg cache
 
 - bash: |
     set -xeuo pipefail

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -69,7 +69,7 @@ steps:
   inputs:
     key: '"vcpkg" | "$(TARGET)" | Cargo.toml'
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
-    restoreKeys: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | Cargo.toml'
+    restoreKeys: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)"'
   displayName: Load vcpkg cache
 
 - bash: |

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -46,10 +46,10 @@ steps:
 
 # Note: setvariable + `set -x` adds spurious single quotes at ends of variable values
 - bash: |
-    echo "##vso[task.setvariable variable=VCPKG_ROOT;]$(pwd)/target/vcpkg"
+    echo "##vso[task.setvariable variable=VCPKG_ROOT;]$(Build.SourcesDirectory)/target/vcpkg"
     echo "##vso[task.setvariable variable=TECTONIC_DEP_BACKEND;]vcpkg"
-    echo "##vso[task.setvariable variable=VCPKG_DEFAULT_BINARY_CACHE;]$(pwd)/target/vcpkg-cache"
-    mkdir -p "$(pwd)/target/vcpkg-cache"
+    echo "##vso[task.setvariable variable=VCPKG_DEFAULT_BINARY_CACHE;]$(Build.SourcesDirectory)/target/vcpkg-cache"
+    mkdir -p "$(Build.SourcesDirectory)/target/vcpkg-cache"
   displayName: Setup build variables
 
 # Without RUST_TEST_THREAD=1, on Windows the doctests fail with a

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -69,7 +69,6 @@ steps:
   inputs:
     key: '"vcpkg" | "$(TARGET)" | Cargo.toml'
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
-    restoreKeys: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)"'
   displayName: Load vcpkg cache
 
 - bash: |

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -67,9 +67,11 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: '"vcpkg" | "$(Agent.OS)" | Cargo.toml'
+    key: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | Cargo.toml'
+    restoreKeys: |
+      "vcpkg" | "$(Agent.OS)" | Cargo.toml
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
-    displayName: Load vcpkg cache
+  displayName: Load vcpkg cache
 
 - bash: |
     set -xeuo pipefail

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -68,8 +68,6 @@ steps:
 - task: Cache@2
   inputs:
     key: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | Cargo.toml'
-    restoreKeys: |
-      "vcpkg" | "$(Agent.OS)" | Cargo.toml
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
   displayName: Load vcpkg cache
 

--- a/dist/azure-build-and-test-vcpkg.yml
+++ b/dist/azure-build-and-test-vcpkg.yml
@@ -69,7 +69,7 @@ steps:
   inputs:
     key: '"vcpkg" | "$(TARGET)" | Cargo.toml'
     path: $(VCPKG_DEFAULT_BINARY_CACHE)
-    restoreKeys: '"vcpkg" | "$(Agent.OS)" | $(Agent.OSArchitecture) | Cargo.toml'
+    restoreKeys: '"vcpkg" | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | Cargo.toml'
   displayName: Load vcpkg cache
 
 - bash: |

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -224,16 +224,16 @@ jobs:
       TOOLCHAIN: stable
 
   # pkg-config builds
-#  - ${{ each build in parameters.pkgconfigBuilds }}:
-#      - job: ${{ format('build_{0}_pkgconfig', build.name) }}
-#        pool:
-#          vmImage: ${{ build.vmImage }}
-#        steps:
-#          - template: azure-build-and-test-pkgconfig.yml
-#            parameters:
-#              ${{ insert }}: ${{ build.params }}
-#        variables:
-#          ${{ insert }}: ${{ build.vars }}
+  - ${{ each build in parameters.pkgconfigBuilds }}:
+      - job: ${{ format('build_{0}_pkgconfig', build.name) }}
+        pool:
+          vmImage: ${{ build.vmImage }}
+        steps:
+          - template: azure-build-and-test-pkgconfig.yml
+            parameters:
+              ${{ insert }}: ${{ build.params }}
+        variables:
+          ${{ insert }}: ${{ build.vars }}
 
   # vcpkg builds
   - ${{ each build in parameters.vcpkgBuilds }}:
@@ -248,15 +248,15 @@ jobs:
           ${{ insert }}: ${{ build.vars }}
 
   # cross builds
-#  - ${{ each build in parameters.crossBuilds }}:
-#      - job: ${{ format('cross_{0}', build.name) }}
-#        pool:
-#          vmImage: ubuntu-22.04
-#        steps:
-#          - template: azure-build-and-test-cross.yml
-#        variables:
-#          TOOLCHAIN: stable
-#          ${{ insert }}: ${{ build.vars }}
+  - ${{ each build in parameters.crossBuilds }}:
+      - job: ${{ format('cross_{0}', build.name) }}
+        pool:
+          vmImage: ubuntu-22.04
+        steps:
+          - template: azure-build-and-test-cross.yml
+        variables:
+          TOOLCHAIN: stable
+          ${{ insert }}: ${{ build.vars }}
 
   # coverage analysis check
   - job: coverage

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -224,16 +224,16 @@ jobs:
       TOOLCHAIN: stable
 
   # pkg-config builds
-  - ${{ each build in parameters.pkgconfigBuilds }}:
-      - job: ${{ format('build_{0}_pkgconfig', build.name) }}
-        pool:
-          vmImage: ${{ build.vmImage }}
-        steps:
-          - template: azure-build-and-test-pkgconfig.yml
-            parameters:
-              ${{ insert }}: ${{ build.params }}
-        variables:
-          ${{ insert }}: ${{ build.vars }}
+#  - ${{ each build in parameters.pkgconfigBuilds }}:
+#      - job: ${{ format('build_{0}_pkgconfig', build.name) }}
+#        pool:
+#          vmImage: ${{ build.vmImage }}
+#        steps:
+#          - template: azure-build-and-test-pkgconfig.yml
+#            parameters:
+#              ${{ insert }}: ${{ build.params }}
+#        variables:
+#          ${{ insert }}: ${{ build.vars }}
 
   # vcpkg builds
   - ${{ each build in parameters.vcpkgBuilds }}:
@@ -248,15 +248,15 @@ jobs:
           ${{ insert }}: ${{ build.vars }}
 
   # cross builds
-  - ${{ each build in parameters.crossBuilds }}:
-      - job: ${{ format('cross_{0}', build.name) }}
-        pool:
-          vmImage: ubuntu-22.04
-        steps:
-          - template: azure-build-and-test-cross.yml
-        variables:
-          TOOLCHAIN: stable
-          ${{ insert }}: ${{ build.vars }}
+#  - ${{ each build in parameters.crossBuilds }}:
+#      - job: ${{ format('cross_{0}', build.name) }}
+#        pool:
+#          vmImage: ubuntu-22.04
+#        steps:
+#          - template: azure-build-and-test-cross.yml
+#        variables:
+#          TOOLCHAIN: stable
+#          ${{ insert }}: ${{ build.vars }}
 
   # coverage analysis check
   - job: coverage


### PR DESCRIPTION
Cache is per-target, and will be invalidated by changes to Cargo.toml, so vcpkg metadata changes should invalidate it.

Fixes #1255 