### PR TITLE
Bump to windows 2022

### DIFF
--- a/dist/azure-build-and-test-pkgconfig.yml
+++ b/dist/azure-build-and-test-pkgconfig.yml
@@ -86,6 +86,7 @@ steps:
 - bash: |
     set -xeuo pipefail
     pacman -S --noconfirm \
+      mingw-w64-x86_64-pkgconf \
       mingw-w64-x86_64-fontconfig \
       mingw-w64-x86_64-freetype \
       mingw-w64-x86_64-icu

--- a/dist/azure-build-and-test.yml
+++ b/dist/azure-build-and-test.yml
@@ -81,7 +81,7 @@ parameters:
           TOOLCHAIN: stable
 
       - name: windows_intdeps
-        vmImage: windows-2019
+        vmImage: windows-2022
         params:
           installAllDeps: false
         vars:
@@ -89,7 +89,7 @@ parameters:
           TOOLCHAIN: stable-x86_64-pc-windows-gnu
 
       - name: windows_extdeps
-        vmImage: windows-2019
+        vmImage: windows-2022
         params:
           canaryBuild: true
           installAllDeps: true
@@ -156,7 +156,7 @@ parameters:
           TOOLCHAIN: stable
 
       - name: x86_64_pc_windows_msvc
-        vmImage: windows-2019
+        vmImage: windows-2022
         params: { }
         vars:
           TARGET: x86_64-pc-windows-msvc


### PR DESCRIPTION
Windows 2019 images are going away at the end of the month. Update early.