### PR TITLE
Fixed a regression brought in #1123

### DIFF
--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -343,6 +343,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn default_inputs() {
+        const TOML: &str = r#"
+        [doc]
+        name = "test"
+        bundle = "na"
+
+        [[output]]
+        name = "o"
+        type = "pdf"
+        "#;
+
+        let mut c = Cursor::new(TOML.as_bytes());
+        let doc = Document::new_from_toml(".", ".", &mut c).unwrap();
+        assert_eq!(
+            doc.outputs.get("o").unwrap().inputs,
+            DEFAULT_INPUTS
+                .iter()
+                .map(|x| InputFile::File(x.to_string()))
+                .collect::<Vec<InputFile>>()
+        );
+    }
+
+    #[test]
     fn shell_escape_default_false() {
         const TOML: &str = r#"
         [doc]

--- a/crates/docmodel/src/document.rs
+++ b/crates/docmodel/src/document.rs
@@ -22,6 +22,24 @@ use tectonic_errors::prelude::*;
 use crate::syntax;
 use crate::workspace::WorkspaceCreator;
 
+/// The default filesystem name for the "preamble" file of a document.
+///
+/// This is a deprecated field and may be removed in a future version. Users
+/// should prefer using the `inputs` field.
+pub const DEFAULT_PREAMBLE_FILE: &str = "_preamble.tex";
+
+/// The default filesystem name for the main "index" file of a document.
+///
+/// This is a deprecated field and may be removed in a future version. Users
+/// should prefer using the `inputs` field.
+pub const DEFAULT_INDEX_FILE: &str = "index.tex";
+
+/// The default filesystem name for the "postamble" file of a document.
+///
+/// This is a deprecated field and may be removed in a future version. Users
+/// should prefer using the `inputs` field.
+pub const DEFAULT_POSTAMBLE_FILE: &str = "_postamble.tex";
+
 /// The default files used to build a document.
 ///
 /// This default can be overridden on an output-by-output basis in

--- a/crates/docmodel/src/syntax.rs
+++ b/crates/docmodel/src/syntax.rs
@@ -8,7 +8,10 @@
 
 use std::path::PathBuf;
 
-use crate::document::{BuildTargetType, InputFile, OutputProfile};
+use crate::document::{
+    BuildTargetType, InputFile, OutputProfile, DEFAULT_INDEX_FILE, DEFAULT_POSTAMBLE_FILE,
+    DEFAULT_PREAMBLE_FILE,
+};
 use serde::{Deserialize, Serialize, Serializer};
 
 // This file is an exercise in Rust type conversion.
@@ -128,17 +131,26 @@ impl From<&TomlOutputProfile> for OutputProfile {
                     StringOrInputVec::Vec(v) => v.iter().map(|x| x.clone().into()).collect(),
                 }
             } else {
-                let mut v = Vec::with_capacity(3);
-                if let Some(s) = &val.preamble_file {
-                    v.push(TomlInputFile::Path(s.to_string()).into())
-                }
-                if let Some(s) = &val.index_file {
-                    v.push(TomlInputFile::Path(s.to_string()).into())
-                }
-                if let Some(s) = &val.postamble_file {
-                    v.push(TomlInputFile::Path(s.to_string()).into())
-                }
-                v
+                vec![
+                    TomlInputFile::Path(
+                        val.preamble_file
+                            .clone()
+                            .unwrap_or(DEFAULT_PREAMBLE_FILE.to_string()),
+                    )
+                    .into(),
+                    TomlInputFile::Path(
+                        val.index_file
+                            .clone()
+                            .unwrap_or(DEFAULT_INDEX_FILE.to_string()),
+                    )
+                    .into(),
+                    TomlInputFile::Path(
+                        val.postamble_file
+                            .clone()
+                            .unwrap_or(DEFAULT_POSTAMBLE_FILE.to_string()),
+                    )
+                    .into(),
+                ]
             }
         };
 


### PR DESCRIPTION
Hello!

When introducing the `inputs` config key in #1123, the default behavior when none of the `inputs`, `preamble`, `index` and `postamble` key is given has been changed to use an empty list instead of the `DEFAULT_INPUTS` new default `const`. Reading the PR discussions, i saw that you wanted to keep backward compatibility, so i guess it's a bug.

i see a few ways to get backward compatibility back, i picked one that requires re-adding the `DEFAULT_INDEX_FILE`, `DEFAULT_PREAMBLE_FILE` and `DEFAULT_POSTAMBLE` `const` to be used when no `inputs` is given, i think this is the simplest way to get the exact same behavior, despite it not being the cleanest.

i also added a non-regression test for good measure.