### PR TITLE
Use same name for release bundle everywhere

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -46,9 +46,9 @@ runs:
       uses: actions/download-artifact@v4
       with:
         name: release-bundle
-        path: ${{ github.workspace }}/git-release
+        path: ${{ github.workspace }}/release-bundle
     - name: Restore release commit
       shell: bash
       run: |
         git switch -c release
-        git pull --ff-only $GITHUB_WORKSPACE/git-release/release.bundle
+        git pull --ff-only $GITHUB_WORKSPACE/release-bundle/release.bundle

--- a/.github/actions/deploy-setup/action.yml
+++ b/.github/actions/deploy-setup/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         git switch -c release
-        git pull --ff-only $GITHUB_WORKSPACE/git-release/release.bundle
+        git pull --ff-only $GITHUB_WORKSPACE/release-bundle/release.bundle
     - name: Install latest Cranko (Ubuntu)
       if: ${{ runner.os == 'Linux' }}
       shell: bash


### PR DESCRIPTION
This should fix it not being found in the release workflow