### PR TITLE
GitHub Actions Improvements

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -8,6 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: r7kamura/rust-problem-matchers@v1
     - name: "Set up rust"
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,17 +3,6 @@ name: "Build and Test"
 on: [workflow_call]
 
 jobs:
-  rustfmt:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: "Install rustfmt"
-        run: rustup component add rustfmt
-      - name: "cargo fmt"
-        run: cargo fmt --all -- --check
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prep.yml
+++ b/.github/workflows/prep.yml
@@ -35,3 +35,14 @@ jobs:
         with:
           name: release-bundle
           path: release.bundle
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: "Install rustfmt"
+        run: rustup component add rustfmt
+      - name: "cargo fmt"
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Follow up to #1294. This adds warning/error annotations and moves jobs that don't need setup to `prep`.