### PR TITLE
Standardize project linting using Cargo lint table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ members = [
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_error_description_deprecated)'] }
 missing_docs = "deny"
 
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 [lib]
 name = "tectonic"
 crate-type = ["rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 # Copyright 2016-2023 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic"
 version = "0.0.0-dev.0" # assigned with cranko (see README)
@@ -26,10 +28,6 @@ categories = [
 license = "MIT"
 edition = "2021"
 exclude = ["/dist/", "/reference_sources/"]
-
-[lints.rust]
-# FIXME(CraftSpider): Switch from error-chain to a newer package, as it's a deprecated project
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(backtrace)', 'cfg(has_error_description_deprecated)'] }
 
 [badges]
 travis-ci = { repository = "tectonic-typesetting/tectonic" }
@@ -64,6 +62,8 @@ members = [
 ]
 
 [workspace.lints.rust]
+# FIXME(CraftSpider): Switch from error-chain to a newer package, as it's a deprecated project
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(backtrace)', 'cfg(has_error_description_deprecated)'] }
 missing_docs = "deny"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ members = [
     "tests/bundle_env_overrides_test",
 ]
 
+[workspace.lints.rust]
+missing_docs = "deny"
+
 [lib]
 name = "tectonic"
 crate-type = ["rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ members = [
 
 [workspace.lints.rust]
 # FIXME(CraftSpider): Switch from error-chain to a newer package, as it's a deprecated project
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(backtrace)', 'cfg(has_error_description_deprecated)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_error_description_deprecated)'] }
 missing_docs = "deny"
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2016-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Build script for tectonic binary. Handles some simple environment setup.
+
 use std::env;
 
 fn main() {

--- a/crates/bridge_core/Cargo.toml
+++ b/crates/bridge_core/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_core"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/bridge_core/build.rs
+++ b/crates/bridge_core/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Build script for bridging Tectonic core engine functionality into C code
+
 use std::{env, path::PathBuf};
 
 fn main() {

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2016-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Core APIs for bridging the C and Rust portions of Tectonic’s processing
 //! backends.
 //!

--- a/crates/bridge_core/src/lib.rs
+++ b/crates/bridge_core/src/lib.rs
@@ -221,9 +221,13 @@ impl EngineAbortedError {
         }
     }
 
-    unsafe fn new_with_details() -> Self {
-        let ptr = _ttbc_get_error_message();
-        let message = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+    fn new_with_details() -> Self {
+        // SAFETY: This is always safe to call
+        let ptr = unsafe { _ttbc_get_error_message() };
+        // SAFETY: The pointer returned above will always have a null-terminated C-string in it
+        let message = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
         EngineAbortedError { message }
     }
 }
@@ -312,7 +316,7 @@ impl<'a> CoreBridgeLauncher<'a> {
 
         if let Err(ref e) = result {
             if e.downcast_ref::<EngineAbortedError>().is_some() {
-                return Err(unsafe { EngineAbortedError::new_with_details() }.into());
+                return Err(EngineAbortedError::new_with_details().into());
             }
         }
 

--- a/crates/bridge_flate/Cargo.toml
+++ b/crates/bridge_flate/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_flate"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/bridge_flate/build.rs
+++ b/crates/bridge_flate/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Build script for bridging flate2 into C code
+
 use std::{env, path::PathBuf};
 
 fn main() {

--- a/crates/bridge_flate/src/lib.rs
+++ b/crates/bridge_flate/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn tectonic_flate_new_decompressor(
         done: false,
     };
 
-    Box::leak(Box::new(dc)) as *mut Decompressor as *mut _
+    Box::into_raw(Box::new(dc)).cast::<libc::c_void>()
 }
 
 /// Decompress some DEFLATEd data.
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn tectonic_flate_decompress_chunk(
     output_ptr: *mut u8,
     output_len: *mut u64,
 ) -> libc::c_int {
-    let mut dc = Box::from_raw(handle as *mut Decompressor);
+    let mut dc = Box::from_raw(handle.cast::<Decompressor>());
     let output = slice::from_raw_parts_mut(output_ptr, *output_len as usize);
 
     let (amount, flag) = match dc.decompress_chunk(output) {
@@ -195,6 +195,6 @@ pub unsafe extern "C" fn tectonic_flate_decompress_chunk(
 /// This is a C API function, so it is unsafe.
 #[no_mangle]
 pub unsafe extern "C" fn tectonic_flate_free_decompressor(handle: *mut libc::c_void) {
-    let _dc = Box::from_raw(handle as *mut Decompressor);
+    let _dc = Box::from_raw(handle.cast::<Decompressor>());
     // The box will be freed as we exit.
 }

--- a/crates/bridge_flate/src/lib.rs
+++ b/crates/bridge_flate/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! This crate provides a few extern "C" functions that expose the functionality
 //! of the flate2 crate in a C API that can be consumed by other C/C++ code in
 //! the Tectonic codebase.

--- a/crates/bridge_fontconfig/Cargo.toml
+++ b/crates/bridge_fontconfig/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_fontconfig"
 version = "0.0.0-dev.0"

--- a/crates/bridge_fontconfig/build.rs
+++ b/crates/bridge_fontconfig/build.rs
@@ -1,3 +1,5 @@
+//! fontconfig build script. For now, we always find it externally.
+
 use tectonic_dep_support::{Configuration, Dependency, Spec};
 
 struct FontconfigSpec;

--- a/crates/bridge_fontconfig/src/lib.rs
+++ b/crates/bridge_fontconfig/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate exists to both export the FreeType2 *C* API into the
 //! Cargo framework, and provide a safe wrapper around it for use in Rust code.
 
-#![deny(clippy::undocumented_unsafe_blocks, missing_docs)]
+#![deny(clippy::undocumented_unsafe_blocks)]
 
 use std::convert::TryFrom;
 use std::ffi::CStr;

--- a/crates/bridge_freetype2/Cargo.toml
+++ b/crates/bridge_freetype2/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_freetype2"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/bridge_freetype2/src/lib.rs
+++ b/crates/bridge_freetype2/src/lib.rs
@@ -4,7 +4,7 @@
 //! This crate exists to export the `FreeType2` *C* API into the Cargo framework, as well as provide
 //! bindings to other tectonic crates.
 
-#![deny(clippy::undocumented_unsafe_blocks, missing_docs)]
+#![deny(clippy::undocumented_unsafe_blocks)]
 #![allow(clippy::unnecessary_cast)]
 
 use std::ffi::CStr;

--- a/crates/bridge_graphite2/Cargo.toml
+++ b/crates/bridge_graphite2/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_graphite2"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/bridge_harfbuzz/Cargo.toml
+++ b/crates/bridge_harfbuzz/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_harfbuzz"
 version = "0.0.0-dev.0" # assigned with cranko (see README)

--- a/crates/bridge_icu/Cargo.toml
+++ b/crates/bridge_icu/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_icu"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/bridge_png/Cargo.toml
+++ b/crates/bridge_png/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "tectonic_bridge_png"
 version = "0.0.0-dev.0"

--- a/crates/bridge_png/build.rs
+++ b/crates/bridge_png/build.rs
@@ -1,3 +1,5 @@
+//! `libpng` build script.
+
 use tectonic_dep_support::{Configuration, Dependency, Spec};
 
 struct LibpngSpec;

--- a/crates/bundles/Cargo.toml
+++ b/crates/bundles/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_bundles"
 version = "0.0.0-dev.0" # assigned with cranko (see README)

--- a/crates/bundles/src/lib.rs
+++ b/crates/bundles/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2016-2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Implementations of Tectonic bundle formats.
 //!
 //! A Tectonic "bundle" is a collection of TeX support files. In code, bundles

--- a/crates/cfg_support/Cargo.toml
+++ b/crates/cfg_support/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2019-2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_cfg_support"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/cfg_support/src/lib.rs
+++ b/crates/cfg_support/src/lib.rs
@@ -19,6 +19,7 @@
 use lazy_static::lazy_static;
 
 lazy_static! {
+    /// Singleton initialized instance of the compilation target info
     pub static ref TARGET_CONFIG: TargetConfiguration = TargetConfiguration::default();
 }
 
@@ -31,13 +32,21 @@ lazy_static! {
 /// uppercased when they're loaded, to allow for case-insensitive comparisons
 /// later.
 pub struct TargetConfiguration {
+    /// Equivalent to `target_arch`
     pub arch: String,
+    /// Equivalent to `target_feature`
     pub feature: String,
+    /// Equivalent to `target_os`
     pub os: String,
+    /// Equivalent to `target_family`
     pub family: String,
+    /// Equivalent to `target_env`
     pub env: String,
+    /// Equivalent to `target_endian`
     pub endian: String,
+    /// Equivalent to `target_pointer_width`
     pub pointer_width: String,
+    /// Equivalent to `target_vendor`
     pub vendor: String,
 }
 

--- a/crates/dep_support/Cargo.toml
+++ b/crates/dep_support/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_dep_support"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/dep_support/src/lib.rs
+++ b/crates/dep_support/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Support for locating third-party libraries ("dependencies") when building
 //! Tectonic. The main point of interest is that both pkg-config and vcpkg are
 //! supported as dep-finding backends. This crate does *not* deal with the

--- a/crates/docmodel/Cargo.toml
+++ b/crates/docmodel/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_docmodel"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/docmodel/src/lib.rs
+++ b/crates/docmodel/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020-2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! The Tectonic document model and its serialization into `Tectonic.toml`.
 //!
 //! This crate provides data structures and serialization support for the

--- a/crates/engine_bibtex/Cargo.toml
+++ b/crates/engine_bibtex/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_engine_bibtex"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/engine_bibtex/src/lib.rs
+++ b/crates/engine_bibtex/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
 #![allow(clippy::assertions_on_constants)]
 
 //! The [bibtex] program as a reusable crate.

--- a/crates/engine_spx2html/Cargo.toml
+++ b/crates/engine_spx2html/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_engine_spx2html"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/engine_spx2html/src/lib.rs
+++ b/crates/engine_spx2html/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Convert Tectonic’s SPX format to HTML.
 //!
 //! SPX is essentially the same thing as XDV, but we identify it differently to

--- a/crates/engine_xdvipdfmx/Cargo.toml
+++ b/crates/engine_xdvipdfmx/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_engine_xdvipdfmx"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/engine_xdvipdfmx/build.rs
+++ b/crates/engine_xdvipdfmx/build.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! xdvipdfmx build script. Builds and links our locally modified copy of the tool.
+
 use std::env;
 
 fn main() {

--- a/crates/engine_xdvipdfmx/src/lib.rs
+++ b/crates/engine_xdvipdfmx/src/lib.rs
@@ -129,6 +129,8 @@ impl XdvipdfmxEngine {
         let cpdf = CString::new(pdf)?;
 
         launcher.with_global_lock(|state| {
+            // SAFETY: This is called while the global lock is held, and with valid C-strings for
+            //         dvi and pdf.
             let r = unsafe {
                 c_api::tt_engine_xdvipdfmx_main(state, &config, cdvi.as_ptr(), cpdf.as_ptr())
             };

--- a/crates/engine_xdvipdfmx/src/lib.rs
+++ b/crates/engine_xdvipdfmx/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! The `xdvipdfmx` program from [XeTeX] as a reusable crate.
 //!
 //! [XeTeX]: http://xetex.sourceforge.net/

--- a/crates/engine_xetex/Cargo.toml
+++ b/crates/engine_xetex/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_engine_xetex"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/engine_xetex/build.rs
+++ b/crates/engine_xetex/build.rs
@@ -1,6 +1,9 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! XeTeX engine build script. Builds and links our locally modified copy of the XeTeX typesetting
+//! engine.
+
 use std::{env, path::PathBuf};
 use tectonic_cfg_support::*;
 

--- a/crates/engine_xetex/src/lib.rs
+++ b/crates/engine_xetex/src/lib.rs
@@ -189,6 +189,7 @@ impl TexEngine {
             // Note that we have to do all of this setup while holding the
             // lock, because we're modifying static state variables.
 
+            // SAFETY: All methods are called with valid C-strings and while the global lock is held.
             let r = unsafe {
                 use c_api::*;
                 tt_xetex_set_int_variable(

--- a/crates/engine_xetex/src/lib.rs
+++ b/crates/engine_xetex/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2021-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! The [XeTeX] program as a reusable crate.
 //!
 //! [XeTeX]: http://www.xetex.org/

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_errors"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/errors/src/lib.rs
+++ b/crates/errors/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 the Tectonic Project.
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Generic error handling for Tectonic.
 //!
 //! This crate provides a generic boxed error type, plus supporting utilities.

--- a/crates/geturl/Cargo.toml
+++ b/crates/geturl/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_geturl"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/geturl/src/lib.rs
+++ b/crates/geturl/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2020-2021 the Tectonic Project.
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! A simple, pluggable interface for HTTP GETs and range requests.
 //!
 //! At the moment, there are three backends that might be available:

--- a/crates/io_base/Cargo.toml
+++ b/crates/io_base/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_io_base"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/io_base/src/lib.rs
+++ b/crates/io_base/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2016-2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Tectonic’s pluggable I/O backend.
 //!
 //! This crates defines the core traits and types used by Tectonic’s I/O

--- a/crates/pdf_io/Cargo.toml
+++ b/crates/pdf_io/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_pdf_io"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/status_base/Cargo.toml
+++ b/crates/status_base/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2020 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_status_base"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/status_base/src/lib.rs
+++ b/crates/status_base/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2017-2020 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! A framework for showing status messages to the user.
 //!
 //! A lot of the functionality here could be replaced by generic logging

--- a/crates/xdv/Cargo.toml
+++ b/crates/xdv/Cargo.toml
@@ -1,6 +1,8 @@
 # Copyright 2018-2019 the Tectonic Project
 # Licensed under the MIT License.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_xdv"
 version = "0.0.0-dev.0" # assigned with cranko (see README)

--- a/crates/xdv/src/lib.rs
+++ b/crates/xdv/src/lib.rs
@@ -400,11 +400,8 @@ impl<T: XdvEvents> XdvParser<T> {
                 // already-read bytes so that the parser gets a nice
                 // contiguous set of bytes to look at. The copy may involve
                 // overlapping memory regions (imagine we read 4096 bytes but
-                // only consume 1) so we have to get unsafe.
-                let ptr = buf.as_mut_ptr();
-                unsafe {
-                    std::ptr::copy(ptr.add(n_consumed), ptr, n_saved_bytes);
-                }
+                // only consume 1).
+                buf.copy_within(n_consumed..n_in_buffer, 0);
             }
 
             if n_in_buffer != 0 && n_consumed == 0 {

--- a/crates/xdv/src/lib.rs
+++ b/crates/xdv/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright 2018 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! A decoder for the XDV and SPX file formats used by Tectonic and XeTeX.
 //!
 //! Both of these file formats are derived from the venerable "device

--- a/crates/xetex_format/Cargo.toml
+++ b/crates/xetex_format/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_xetex_format"
 version = "0.0.0-dev.0"  # assigned with cranko (see README)

--- a/crates/xetex_format/examples/decode.rs
+++ b/crates/xetex_format/examples/decode.rs
@@ -40,7 +40,7 @@ enum Commands {
 }
 
 #[derive(Debug, Eq, PartialEq, Parser)]
-pub struct GenericCommand {
+struct GenericCommand {
     /// The format filename.
     #[arg()]
     path: PathBuf,
@@ -80,7 +80,7 @@ impl GenericCommand {
 }
 
 #[derive(Debug, Eq, PartialEq, Parser)]
-pub struct CseqsCommand {
+struct CseqsCommand {
     /// Whether to dump extended information such as macro contents
     #[arg(long = "extended", short = 'e')]
     extended: bool,

--- a/crates/xetex_format/src/catcodes.rs
+++ b/crates/xetex_format/src/catcodes.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! Character category codes.
 
 use std::fmt;

--- a/crates/xetex_format/src/commands.rs
+++ b/crates/xetex_format/src/commands.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
+#![allow(missing_docs)]
 
 //! The low-level primitive commands provided by the engine.
 

--- a/crates/xetex_format/src/commands/charcode.rs
+++ b/crates/xetex_format/src/commands/charcode.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! The first 16 special character-code commands
 
 use tectonic_errors::prelude::*;

--- a/crates/xetex_format/src/commands/dynamicenum.rs
+++ b/crates/xetex_format/src/commands/dynamicenum.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! Commands whose arguments map to the values of dynamic enums.
 
 use tectonic_errors::prelude::*;

--- a/crates/xetex_format/src/commands/noprim.rs
+++ b/crates/xetex_format/src/commands/noprim.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! Commands without primitives.
 
 use tectonic_errors::prelude::*;

--- a/crates/xetex_format/src/commands/simple.rs
+++ b/crates/xetex_format/src/commands/simple.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! Commands that have a simple set of associated primitives and arguments.
 
 use std::collections::BTreeMap;

--- a/crates/xetex_format/src/commands/simpleenum.rs
+++ b/crates/xetex_format/src/commands/simpleenum.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! Commands that have have primitives with argument codes associated with
 //! "simple" enums, whose numerical values we know at compile-time.
 

--- a/crates/xetex_format/src/commands/symbolic.rs
+++ b/crates/xetex_format/src/commands/symbolic.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
-
 //! Commands whose arguments come from the symbol table, but not one of the
 //! enumerations.
 

--- a/crates/xetex_format/src/cshash.rs
+++ b/crates/xetex_format/src/cshash.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! The hash table for multi-letter control sequences.
 
 use nom::{

--- a/crates/xetex_format/src/dimenpars.rs
+++ b/crates/xetex_format/src/dimenpars.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Dimensional parameters defined by the engine.
 
 use std::io::Write;

--- a/crates/xetex_format/src/engine.rs
+++ b/crates/xetex_format/src/engine.rs
@@ -1,8 +1,6 @@
 // Copyright 2021-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! The overall interface provided by the engine.
 
 use std::{cmp::Ordering, io::Write};

--- a/crates/xetex_format/src/enums.rs
+++ b/crates/xetex_format/src/enums.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! Enumerations within the engine.
 //!
 //! We divide these into two categories: "simple" enums that basically have

--- a/crates/xetex_format/src/eqtb.rs
+++ b/crates/xetex_format/src/eqtb.rs
@@ -1,6 +1,8 @@
 // Copyright 2021-2022 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! The "equivalencies table".
 //!
 //! Its structure is:

--- a/crates/xetex_format/src/etexpenalties.rs
+++ b/crates/xetex_format/src/etexpenalties.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! e-TeX penalties parameters defined by the engine.
 //!
 //! These are modified using the `SET_SHAPE` command, which in plain TeX is only

--- a/crates/xetex_format/src/format.rs
+++ b/crates/xetex_format/src/format.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! Decode a format file.
 
 use nom::{

--- a/crates/xetex_format/src/gluepars.rs
+++ b/crates/xetex_format/src/gluepars.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Glue parameters defined by the engine.
 
 use std::io::Write;

--- a/crates/xetex_format/src/intpars.rs
+++ b/crates/xetex_format/src/intpars.rs
@@ -1,8 +1,6 @@
 // Copyright 2021-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Integer parameters defined by the engine.
 
 use std::io::Write;

--- a/crates/xetex_format/src/locals.rs
+++ b/crates/xetex_format/src/locals.rs
@@ -1,8 +1,6 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! "Local" parameters defined by the engine.
 //!
 //! These are mostly token lists, but there is also the `parshape` parameter

--- a/crates/xetex_format/src/mem.rs
+++ b/crates/xetex_format/src/mem.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! The TeX dynamic memory array.
 
 use nom::{

--- a/crates/xetex_format/src/stringtable.rs
+++ b/crates/xetex_format/src/stringtable.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! Dealing with the TeX string table.
 
 use nom::{

--- a/crates/xetex_format/src/symbols.rs
+++ b/crates/xetex_format/src/symbols.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
-//#![deny(missing_docs)]
+#![allow(missing_docs)]
 
 //! In this crate, a symbol is a number with an assigned name that is exposed to
 //! the engine implementation as a C preprocessor `#define`.

--- a/crates/xetex_format/src/tokenlist.rs
+++ b/crates/xetex_format/src/tokenlist.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 the Tectonic Project
 // Licensed under the MIT License.
 
+#![allow(missing_docs)]
+
 //! Handling TeX token lists.
 //!
 //! Token lists are linked lists of compressed entries that can express either

--- a/crates/xetex_layout/Cargo.toml
+++ b/crates/xetex_layout/Cargo.toml
@@ -3,6 +3,8 @@
 
 # See README.md for discussion of features (or lack thereof) in this crate.
 
+lints.workspace = true
+
 [package]
 name = "tectonic_xetex_layout"
 version = "0.0.0-dev.0" # assigned with cranko (see README)

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -2,6 +2,8 @@
 // Copyright 2016-2023 the Tectonic Project
 // Licensed under the MIT License.
 
+//! `tectonic` binary - the main entry point for command-line users.
+
 use clap::{Parser, ValueEnum};
 use std::{env, io::IsTerminal, process};
 use tectonic_status_base::plain::PlainStatusBackend;
@@ -55,7 +57,7 @@ struct CliOptions {
 }
 
 #[derive(ValueEnum, Clone, Debug)]
-pub enum CliColor {
+enum CliColor {
     #[value(name = "always")]
     Always,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub fn is_config_test_mode_activated() -> bool {
     CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst)
 }
 
+#[doc(hidden)]
 pub fn is_test_bundle_wanted(bundle: Option<String>) -> bool {
     if !is_config_test_mode_activated() {
         return false;
@@ -49,6 +50,7 @@ pub fn is_test_bundle_wanted(bundle: Option<String>) -> bool {
     }
 }
 
+#[doc(hidden)]
 pub fn maybe_return_test_bundle(bundle: Option<String>) -> Result<Box<dyn Bundle>> {
     if is_test_bundle_wanted(bundle) {
         Ok(Box::<crate::test_util::TestBundle>::default())
@@ -57,11 +59,13 @@ pub fn maybe_return_test_bundle(bundle: Option<String>) -> Result<Box<dyn Bundle
     }
 }
 
+/// Top-level persistent configuration required for the engine
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct PersistentConfig {
     default_bundles: Vec<BundleInfo>,
 }
 
+/// Information about a default bundle
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct BundleInfo {
     url: String,
@@ -128,10 +132,12 @@ impl PersistentConfig {
         Ok(PersistentConfig::default())
     }
 
+    /// Get the default bundle URL for this configuration
     pub fn default_bundle_loc(&self) -> &str {
         &self.default_bundles[0].url
     }
 
+    /// Attempt to open the default bundle
     pub fn default_bundle(&self, only_cached: bool) -> Result<Box<dyn Bundle>> {
         if CONFIG_TEST_MODE_ACTIVATED.load(Ordering::SeqCst) {
             let bundle = crate::test_util::TestBundle::default();
@@ -152,6 +158,7 @@ impl PersistentConfig {
         )
     }
 
+    /// Get the cache directory to use for format files
     pub fn format_cache_path(&self) -> Result<PathBuf> {
         if is_config_test_mode_activated() {
             Ok(crate::test_util::test_path(&[]))

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -67,6 +67,7 @@ impl DocumentSetupOptions {
     }
 }
 
+/// Extension methods for [`Document`].
 pub trait DocumentExt {
     /// Get the bundle used by this document.
     ///

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! The high-level Tectonic document processing interface.
 //!
 //! The main struct in this module is [`ProcessingSession`], which knows how to

--- a/src/engines/bibtex.rs
+++ b/src/engines/bibtex.rs
@@ -1,20 +1,38 @@
 // Copyright 2017-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Engine for invoking `bibtex`.
+
 use tectonic_bridge_core::CoreBridgeLauncher;
 use tectonic_engine_bibtex::{BibtexEngine as RealBibtexEngine, BibtexOutcome};
 
 use super::tex::TexOutcome;
 use crate::{errors::Result, unstable_opts::UnstableOptions};
 
+/// A struct for invoking the `bibtex` engine.
+///
+/// This struct has a fairly straightforward "builder" interface: you create it,
+/// apply any settings that you wish, and eventually run the
+/// [`process()`](Self::process) method.
 #[derive(Default)]
 pub struct BibtexEngine {}
 
 impl BibtexEngine {
+    /// Create a new, default engine for running `bibtex`.
     pub fn new() -> BibtexEngine {
         Default::default()
     }
 
+    /// Process a document using the current engine configuration.
+    ///
+    /// The *launcher* parameter gives overarching environmental context in
+    /// which the engine will be run.
+    ///
+    /// The *aux* parameter gives the name of the "aux" file, created by the TeX
+    /// engine, that BibTeX will process.
+    ///
+    /// The *unstables* parameter controls unstable options that may change the behavior of
+    /// `bibtex`.
     pub fn process(
         &mut self,
         launcher: &mut CoreBridgeLauncher,

--- a/src/engines/spx2html.rs
+++ b/src/engines/spx2html.rs
@@ -1,4 +1,6 @@
 // Copyright 2018-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Engine to convert Tectonic’s SPX format to HTML.
+
 pub use tectonic_engine_spx2html::Spx2HtmlEngine;

--- a/src/engines/tex.rs
+++ b/src/engines/tex.rs
@@ -2,6 +2,8 @@
 // Copyright 2017-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Engine for invoking `XeTeX`.
+
 use crate::errors::DefinitelySame;
 
 pub use tectonic_engine_xetex::{TexEngine, TexOutcome};

--- a/src/engines/xdvipdfmx.rs
+++ b/src/engines/xdvipdfmx.rs
@@ -2,4 +2,6 @@
 // Copyright 2017-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Engine for invoking `xdvipdfmx`.
+
 pub use tectonic_engine_xdvipdfmx::XdvipdfmxEngine;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -324,9 +324,6 @@ impl<T: std::error::Error + 'static> SyncError<T> {
 }
 
 impl<T: std::error::Error + 'static> std::error::Error for SyncError<T> {
-    #[cfg(backtrace)]
-    fn backtrace(&self) -> Option<&Backtrace> {}
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.proxy.as_ref().map(|e| e as _)
     }
@@ -389,9 +386,6 @@ impl<T: std::error::Error> CauseProxy<T> {
 }
 
 impl<T: std::error::Error + 'static> std::error::Error for CauseProxy<T> {
-    #[cfg(backtrace)]
-    fn backtrace(&self) -> Option<&Backtrace> {}
-
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.next.as_ref().map(|e| e as _)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,7 +7,7 @@
 // former was [deprecated in Rust 1.33](https://github.com/rust-lang/rust/pull/53533). The fix for
 // `error-chain` is in <https://github.com/rust-lang-nursery/error-chain/pull/255> and will
 // hopefully show up in a future version.
-#![allow(deprecated)]
+#![allow(missing_docs)]
 
 use error_chain::error_chain;
 use std::{
@@ -105,6 +105,7 @@ error_chain! {
 
 /// `chain_err` compatibility between our old and new error types
 pub trait ChainErrCompatExt<T> {
+    /// Chain this error with another
     fn chain_err<F, K>(self, chainer: F) -> Result<T>
     where
         F: FnOnce() -> K,

--- a/src/io/format_cache.rs
+++ b/src/io/format_cache.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2020 the Tectonic Project
 // Licensed under the MIT License.
 
-#![deny(missing_docs)]
-
 //! Code for locally caching compiled format files.
 
 use std::{

--- a/src/io/memory.rs
+++ b/src/io/memory.rs
@@ -26,7 +26,9 @@ pub struct MemoryFileInfo {
     // TODO: smarter buffering structure than Vec<u8>? E.g., linked list of 4k
     // chunks or something. In the current scheme reallocations will get
     // expensive.
+    /// Raw file bytes
     pub data: Vec<u8>,
+    /// Last modification time of the in-memory file
     pub unix_mtime: Option<i64>,
 }
 
@@ -146,12 +148,16 @@ impl Drop for MemoryIoItem {
     }
 }
 
+/// An I/O driver backed by a collection of in-memory files.
 pub struct MemoryIo {
+    /// Map of file paths to in-memory file data in this I/O provider.
     pub files: Rc<RefCell<MemoryFileCollection>>,
     stdout_allowed: bool,
 }
 
 impl MemoryIo {
+    /// Create a new memory-backed I/O. `stdout_allowed` controls whether attempts to open stdout
+    /// on this type succeed or fail.
     pub fn new(stdout_allowed: bool) -> MemoryIo {
         MemoryIo {
             files: Rc::new(RefCell::new(HashMap::new())),
@@ -159,6 +165,8 @@ impl MemoryIo {
         }
     }
 
+    /// Create a new entry into the backing file collection, with automatically generated
+    /// modification time.
     pub fn create_entry(&mut self, name: &str, data: Vec<u8>) {
         let mut mfiles = self.files.borrow_mut();
         mfiles.insert(
@@ -170,6 +178,7 @@ impl MemoryIo {
         );
     }
 
+    /// Name to use for stdout file
     pub fn stdout_key(&self) -> &str {
         ""
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -26,6 +26,7 @@ pub use self::memory::MemoryIo;
 // Helper for testing. FIXME: I want this to be conditionally compiled with
 // #[cfg(test)] but things break if I do that.
 
+#[doc(hidden)]
 pub mod testing {
     use super::*;
     use std::fs::File;

--- a/src/status/termcolor.rs
+++ b/src/status/termcolor.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 
 // TODO: make this module a feature that can be disabled if the user doesn't want to
-// link with termcolor
+//! Status backend that emits colorized errors to the terminal.
 
 use std::fmt::Arguments;
 use std::io::Write;
@@ -13,6 +13,7 @@ use tectonic_errors::Error;
 
 use super::{ChatterLevel, MessageKind, StatusBackend};
 
+/// Status backend based on `termcolor` that emits compile errors and note with terminal colors.
 pub struct TermcolorStatusBackend {
     chatter: ChatterLevel,
     always_stderr: bool,
@@ -25,6 +26,7 @@ pub struct TermcolorStatusBackend {
 }
 
 impl TermcolorStatusBackend {
+    /// Create a new instance of this backend with default colorization.
     pub fn new(chatter: ChatterLevel) -> TermcolorStatusBackend {
         let mut note_spec = ColorSpec::new();
         note_spec.set_fg(Some(Color::Green)).set_bold(true);
@@ -50,6 +52,7 @@ impl TermcolorStatusBackend {
         }
     }
 
+    /// Set whether non-error messages such as notes should be sent to stderr or stdout.
     pub fn always_stderr(&mut self, setting: bool) -> &mut Self {
         self.always_stderr = setting;
         self
@@ -125,6 +128,7 @@ impl TermcolorStatusBackend {
     // so we put them here to minimize the cross-section of the StatusBackend
     // trait.
 
+    /// Write the result of `fmt_args!` as a colorized note.
     pub fn note_styled(&mut self, args: Arguments) {
         if self.chatter > ChatterLevel::Minimal {
             if self.always_stderr {
@@ -135,12 +139,14 @@ impl TermcolorStatusBackend {
         }
     }
 
+    /// Write the results of `fmt_args!` as a colorized error.
     pub fn error_styled(&mut self, args: Arguments) {
         self.styled(MessageKind::Error, |s| {
             writeln!(s, "{args}").expect("write to stderr failed");
         });
     }
 
+    /// Write an [`Error`] to output directly.
     pub fn bare_error(&mut self, err: &Error) {
         let mut prefix = "error:";
 

--- a/src/unstable_opts.rs
+++ b/src/unstable_opts.rs
@@ -33,6 +33,7 @@ const HELPMSG: &str = r#"Available unstable options:
 "#;
 
 // Each entry of this should correspond to a field of UnstableOptions.
+#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub enum UnstableArg {
     ContinueOnErrors,
@@ -102,13 +103,32 @@ impl FromStr for UnstableArg {
     }
 }
 
+/// Unstable options available for engine backends. These options may be added or removed in minor
+/// releases, and are not considered breaking.
+///
+/// These options may affect the reproducibility of built documents.
 #[derive(Debug, Default)]
 pub struct UnstableOptions {
+    /// Don't stop on errors - attempt to generate a document anyway, for all but the most fatal of
+    /// problems.
     pub continue_on_errors: bool,
+
+    /// Set the paper size used by the output document.
     pub paper_size: Option<String>,
+
+    /// Allow using shell commands during document compilation. All shell escapes will be executed
+    /// within a custom temporary directory that lives for the duration of the compilation session.
+    /// [`Self::shell_escape_cwd`] will take precedence over this flag.
     pub shell_escape: bool,
+
+    /// Minimum number of cross-references in `bibtex` before an item gets its own standalone entry.
     pub min_crossrefs: Option<u32>,
+
+    /// Extra directories to search for input files during a processing session.
     pub extra_search_paths: Vec<PathBuf>,
+
+    /// The working directory to use for shell escapes. The directory will be preserved after
+    /// compilation is complete. This overrides [`Self::shell_escape`].
     pub shell_escape_cwd: Option<String>,
 
     /// Ensure a deterministic build environment.
@@ -125,6 +145,7 @@ pub struct UnstableOptions {
 }
 
 impl UnstableOptions {
+    #[doc(hidden)]
     pub fn from_unstable_args<I>(uargs: I) -> Self
     where
         I: Iterator<Item = UnstableArg>,
@@ -152,6 +173,7 @@ impl UnstableOptions {
     }
 }
 
+#[doc(hidden)]
 pub fn print_unstable_help_and_exit() {
     print!("{HELPMSG}");
     std::process::exit(0);

--- a/tests/bibtex.rs
+++ b/tests/bibtex.rs
@@ -1,6 +1,8 @@
 // Copyright 2016-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Bibtex test suite - compare running bibtex against many different test files
+
 use std::collections::HashSet;
 use std::path::PathBuf;
 

--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -1,5 +1,7 @@
 // Licensed under the MIT License.
 
+//! Test suite for the top-level `tectonic` executable.
+
 use lazy_static::lazy_static;
 use std::io::ErrorKind;
 use std::{

--- a/tests/formats.rs
+++ b/tests/formats.rs
@@ -1,19 +1,20 @@
 // Copyright 2017-2022 the Tectonic Project
 // Licensed under the MIT License.
 
-/// Test that we can operate in "initex" mode to generate format files as
-/// expected. Unlike TeX we set things up so that formats should be
-/// byte-for-byte reproducible given the same inputs. Since formats are big,
-/// we check for equality by examining their SHA256 digests.
-///
-/// Note that since gzip compression is done transparently in the I/O layer,
-/// the desired SHA256 is that of the *uncompressed* format data, not the
-/// gzipped file that ends up on disk. When implementing this test I wasted a
-/// lot of time on that mistake!
-///
-/// Temporarily set the constant DEBUG to true to dump out the generated files
-/// to disk, which may be helpful in debugging. There is probably a less gross
-/// way to implement that option.
+//! Test that we can operate in "initex" mode to generate format files as
+//! expected. Unlike TeX we set things up so that formats should be
+//! byte-for-byte reproducible given the same inputs. Since formats are big,
+//! we check for equality by examining their SHA256 digests.
+//!
+//! Note that since gzip compression is done transparently in the I/O layer,
+//! the desired SHA256 is that of the *uncompressed* format data, not the
+//! gzipped file that ends up on disk. When implementing this test I wasted a
+//! lot of time on that mistake!
+//!
+//! Temporarily set the constant DEBUG to true to dump out the generated files
+//! to disk, which may be helpful in debugging. There is probably a less gross
+//! way to implement that option.
+
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,

--- a/tests/tex-outputs.rs
+++ b/tests/tex-outputs.rs
@@ -1,6 +1,8 @@
 // Copyright 2016-2021 the Tectonic Project
 // Licensed under the MIT License.
 
+//! Test suite for the TeX engine
+
 use std::collections::HashSet;
 use std::path::Path;
 use std::time;


### PR DESCRIPTION
Removes crate-specific `warn` or `deny` attributes, in favor of a global workspace configuration using the `lints.rust` and `lints.clippy` tables..