### PR TITLE
Switch mac setup to use precompiled cranko

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -20,19 +20,14 @@ runs:
         rustup -V
         rustc -Vv
         cargo -V
-    - name: Install latest Cranko (Ubuntu)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Install latest Cranko (Ubuntu/macOS)
+      if: ${{ runner.os != 'Windows' }}
       shell: bash
       run: |
         d="$(mktemp -d /tmp/cranko.XXXXXX)"
         cd "$d"
         curl --proto '=https' --tlsv1.2 -sSf https://pkgw.github.io/cranko/fetch-latest.sh | sh
         echo "PATH=$d:$PATH" >> "$GITHUB_ENV"
-    - name: Install latest Cranko (macOS)
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        cargo install cranko --force
     - name: Install latest Cranko (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: pwsh


### PR DESCRIPTION
Now that https://github.com/pkgw/cranko/pull/53 has merged, we should be able to speed up this step.