### PR TITLE
Mac core lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,6 +3143,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tectonic_mac_core"
+version = "0.0.0-dev.0"
+dependencies = [
+ "libc",
+ "tectonic_cfg_support",
+]
+
+[[package]]
 name = "tectonic_pdf_io"
 version = "0.0.0-dev.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ members = [
     "crates/errors",
     "crates/geturl",
     "crates/io_base",
+    "crates/mac_core",
     "crates/pdf_io",
     "crates/status_base",
     "crates/xdv",

--- a/crates/mac_core/Cargo.toml
+++ b/crates/mac_core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tectonic_mac_core"
+license = "MIT"
+version = "0.0.0-dev.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[build-dependencies]
+tectonic_cfg_support = { path = "../cfg_support", version = "0.0.0-dev.0" }
+
+[package.metadata.internal_dep_versions]
+tectonic_cfg_support = "thiscommit:aeRoo7oa"

--- a/crates/mac_core/Cargo.toml
+++ b/crates/mac_core/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "tectonic_mac_core"
 license = "MIT"

--- a/crates/mac_core/build.rs
+++ b/crates/mac_core/build.rs
@@ -1,0 +1,13 @@
+use tectonic_cfg_support::target_cfg;
+
+fn main() {
+    let is_mac_os = target_cfg!(target_os = "macos");
+
+    if is_mac_os {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+        println!("cargo:rustc-link-lib=framework=CoreGraphics");
+        println!("cargo:rustc-link-lib=framework=CoreText");
+        println!("cargo:rustc-link-lib=framework=AppKit");
+    }
+}

--- a/crates/mac_core/build.rs
+++ b/crates/mac_core/build.rs
@@ -1,3 +1,5 @@
+//! Mac core library build script. Links to framework libraries when targeting MacOS.
+
 use tectonic_cfg_support::target_cfg;
 
 fn main() {

--- a/crates/mac_core/src/array.rs
+++ b/crates/mac_core/src/array.rs
@@ -5,11 +5,14 @@ use std::ptr;
 use std::ptr::NonNull;
 
 cfty! {
+    /// A homogeneous array of CFType values, similar to [`Vec`].
     CFArray<T> : CFArrayGetTypeID
 }
 
 impl<T: CoreType> CFArray<T> {
+    /// Create a new, empty [`CFArray`].
     pub fn empty() -> CFArray<T> {
+        // SAFETY: Valid to call with all null and zero length + default callbacks
         let ptr = unsafe {
             sys::CFArrayCreate(
                 ptr::null_mut(),
@@ -18,10 +21,15 @@ impl<T: CoreType> CFArray<T> {
                 &sys::kCFTypeArrayCallBacks,
             )
         };
-        CFArray::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer from CFArrayCreate is a new, owned CFArray.
+        unsafe { CFArray::new_owned(ptr) }
     }
 
+    /// Create a new [`CFArray`] that contains the provided values.
     pub fn new(values: &[T]) -> CFArray<T> {
+        // SAFETY: Length matches provided slice and values are `CoreType` so must be valid
+        //         CFTypeRefs.
         let ptr = unsafe {
             sys::CFArrayCreate(
                 ptr::null_mut(),
@@ -30,13 +38,18 @@ impl<T: CoreType> CFArray<T> {
                 &sys::kCFTypeArrayCallBacks,
             )
         };
-        CFArray::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer from CFCArrayCreate is a new, owned CFArray.
+        unsafe { CFArray::new_owned(ptr) }
     }
 
+    /// Get the length of this array
     pub fn len(&self) -> usize {
+        // SAFETY: Internal pointer is guaranteed valid.
         unsafe { sys::CFArrayGetCount(self.0.as_ptr()) as usize }
     }
 
+    /// Check whether this array is empty
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -46,12 +59,14 @@ impl<T: CoreType> Index<usize> for CFArray<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
+        if index >= self.len() {
+            panic!("Index {index} out of bounds for CFArray");
+        }
+        // SAFETY: Internal pointer is guaranteed valid. Index has been verified in-bounds.
         let ptr =
             unsafe { sys::CFArrayGetValueAtIndex(self.0.cast().as_ptr(), index as sys::CFIndex) }
                 .cast::<T>();
-        if ptr.is_null() {
-            panic!("Index {index} out of bounds for CFArray");
-        }
+        // SAFETY: API contracts ensure all values are of the correct type and live for our lifetime.
         unsafe { &*ptr }
     }
 }

--- a/crates/mac_core/src/array.rs
+++ b/crates/mac_core/src/array.rs
@@ -1,0 +1,57 @@
+use super::{sys, CoreType};
+use std::marker::PhantomData;
+use std::ops::Index;
+use std::ptr;
+use std::ptr::NonNull;
+
+cfty! {
+    CFArray<T> : CFArrayGetTypeID
+}
+
+impl<T: CoreType> CFArray<T> {
+    pub fn empty() -> CFArray<T> {
+        let ptr = unsafe {
+            sys::CFArrayCreate(
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                &sys::kCFTypeArrayCallBacks,
+            )
+        };
+        CFArray::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn new(values: &[T]) -> CFArray<T> {
+        let ptr = unsafe {
+            sys::CFArrayCreate(
+                ptr::null_mut(),
+                values.as_ptr().cast_mut().cast(),
+                values.len() as sys::CFIndex,
+                &sys::kCFTypeArrayCallBacks,
+            )
+        };
+        CFArray::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { sys::CFArrayGetCount(self.0.as_ptr()) as usize }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T: CoreType> Index<usize> for CFArray<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        let ptr =
+            unsafe { sys::CFArrayGetValueAtIndex(self.0.cast().as_ptr(), index as sys::CFIndex) }
+                .cast::<T>();
+        if ptr.is_null() {
+            panic!("Index {index} out of bounds for CFArray");
+        }
+        unsafe { &*ptr }
+    }
+}

--- a/crates/mac_core/src/dict.rs
+++ b/crates/mac_core/src/dict.rs
@@ -1,0 +1,91 @@
+use super::{sys, CoreType};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+use std::{mem, ptr};
+
+pub trait AsPtr {
+    fn as_ptr(&self) -> *const ();
+    #[allow(clippy::len_without_is_empty)]
+    fn len(&self) -> usize;
+}
+
+impl<T> AsPtr for Vec<T> {
+    fn as_ptr(&self) -> *const () {
+        self.as_ptr().cast()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T, const N: usize> AsPtr for [T; N] {
+    fn as_ptr(&self) -> *const () {
+        <[T]>::as_ptr(self).cast()
+    }
+
+    fn len(&self) -> usize {
+        N
+    }
+}
+
+pub trait Pairs {
+    type Keys: AsPtr;
+    type Values: AsPtr;
+
+    fn into_pairs(self) -> (Self::Keys, Self::Values);
+}
+
+impl<K, V, const N: usize> Pairs for [(K, V); N] {
+    type Keys = [K; N];
+    type Values = [V; N];
+
+    fn into_pairs(self) -> (Self::Keys, Self::Values) {
+        let mut keys: [MaybeUninit<K>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut values: [MaybeUninit<V>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+
+        for (idx, (key, val)) in self.into_iter().enumerate() {
+            keys[idx].write(key);
+            values[idx].write(val);
+        }
+
+        unsafe {
+            (
+                mem::transmute_copy::<_, [K; N]>(&keys),
+                mem::transmute_copy::<_, [V; N]>(&values),
+            )
+        }
+    }
+}
+
+impl<K, V> Pairs for Vec<(K, V)> {
+    type Keys = Vec<K>;
+    type Values = Vec<V>;
+
+    fn into_pairs(self) -> (Self::Keys, Self::Values) {
+        self.into_iter().unzip()
+    }
+}
+
+cfty! {
+    CFDictionary<K, V> : CFDictionaryGetTypeID
+}
+
+impl<K: CoreType, V: CoreType> CFDictionary<K, V> {
+    pub fn new<P: Pairs>(pairs: P) -> CFDictionary<K, V> {
+        let (keys, values) = pairs.into_pairs();
+
+        let ptr = unsafe {
+            sys::CFDictionaryCreate(
+                ptr::null_mut(),
+                keys.as_ptr().cast_mut().cast(),
+                values.as_ptr().cast_mut().cast(),
+                keys.len() as sys::CFIndex,
+                &sys::kCFTypeDictionaryKeyCallBacks,
+                &sys::kCFTypeDictionaryValueCallBacks,
+            )
+        };
+        CFDictionary::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+}

--- a/crates/mac_core/src/font.rs
+++ b/crates/mac_core/src/font.rs
@@ -2,60 +2,92 @@ use super::{sys, CFString, CFType, CTFontDescriptor, CoreType};
 use std::ptr;
 use std::ptr::NonNull;
 
+/// An attribute that may be found in a font, such as family name or URL.
 #[derive(Copy, Clone)]
 pub enum FontAttribute {
+    /// Name
     Name,
+    /// Family Name
     FamilyName,
+    /// Display Name
     DisplayName,
+    /// URL
     URL,
+    /// Cascade List - fallbacks to use if glyph not present in this font.
     CascadeList,
 }
 
 impl FontAttribute {
+    /// Convert this attribute into its matching [`CFString`].
     pub fn to_str(self) -> CFString {
-        CFString::new_borrowed(NonNull::new(self.to_raw().cast_mut()).unwrap())
+        let ptr = NonNull::new(self.to_raw().cast_mut()).unwrap();
+        // SAFETY: The value returned by `to_raw` is guaranteed to be a valid CFStringRef
+        unsafe { CFString::new_borrowed(ptr) }
     }
 
+    /// Convert this attribute into a raw pointer to a [`CFString`].
     pub fn to_raw(self) -> sys::CFStringRef {
         match self {
+            // SAFETY: Static guaranteed to exist and by a valid CFStringRef
             FontAttribute::Name => unsafe { sys::kCTFontNameAttribute },
+            // SAFETY: sic
             FontAttribute::FamilyName => unsafe { sys::kCTFontFamilyNameAttribute },
+            // SAFETY: sic
             FontAttribute::DisplayName => unsafe { sys::kCTFontDisplayNameAttribute },
+            // SAFETY: sic
             FontAttribute::URL => unsafe { sys::kCTFontURLAttribute },
+            // SAFETY: sic
             FontAttribute::CascadeList => unsafe { sys::kCTFontCascadeListAttribute },
         }
     }
 }
 
+/// A type of font name that may be available.
 #[derive(Copy, Clone)]
 pub enum FontNameKey {
+    /// Full name
     Full,
+    /// Family name
     Family,
+    /// Style name
     Style,
+    /// PostScript name
     PostScript,
 }
 
 impl FontNameKey {
+    /// Convert this attribute into its matching [`CFString`].
     pub fn to_str(self) -> CFString {
-        CFString::new_borrowed(NonNull::new(self.to_raw().cast_mut()).unwrap())
+        let ptr = NonNull::new(self.to_raw().cast_mut()).unwrap();
+        // SAFETY: The value returned by `to_raw` is guaranteed to be a valid CFStringRef
+        unsafe { CFString::new_borrowed(ptr) }
     }
 
     fn to_raw(self) -> sys::CFStringRef {
         match self {
+            // SAFETY: Static guaranteed to exist and by a valid CFStringRef
             FontNameKey::Full => unsafe { sys::kCTFontFullNameKey },
+            // SAFETY: sic
             FontNameKey::Family => unsafe { sys::kCTFontFamilyNameKey },
+            // SAFETY: sic
             FontNameKey::Style => unsafe { sys::kCTFontStyleNameKey },
+            // SAFETY: sic
             FontNameKey::PostScript => unsafe { sys::kCTFontPostScriptNameKey },
         }
     }
 }
 
 cfty! {
+    /// A font, combining a descriptor and a size, as well as any other necessary transforms to
+    /// render glyphs.
     CTFont : CTFontGetTypeID
 }
 
 impl CTFont {
+    /// Create a new font from a [`CTFontDescriptor`] and a size to render at.
     pub fn new_descriptor(descriptor: &CTFontDescriptor, size: f64) -> CTFont {
+        // SAFETY: Provided descriptor is guaranteed valid. Any size will work. Null matrix is always
+        //         allowed.
         let ptr = unsafe {
             sys::CTFontCreateWithFontDescriptor(
                 descriptor.as_type_ref(),
@@ -63,23 +95,34 @@ impl CTFont {
                 ptr::null_mut(),
             )
         };
-        CTFont::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer from CTFontCreateWithFontDescriptor is a new, owned CTFont.
+        unsafe { CTFont::new_owned(ptr) }
     }
 
+    /// Get an attribute of this font, if present
     pub fn attr(&self, attr: FontAttribute) -> Option<CFType> {
+        // SAFETY: Internal pointer and attribute string guaranteed valid.
         let ptr = unsafe { sys::CTFontCopyAttribute(self.as_type_ref(), attr.to_raw()) };
-        NonNull::new(ptr.cast_mut()).map(CFType::new_owned)
+        // SAFETY: In non-null, returned name guaranteed valid and owned.
+        NonNull::new(ptr.cast_mut()).map(|ptr| unsafe { CFType::new_owned(ptr) })
     }
 
+    /// Get a name value of this font, if present
     pub fn name(&self, name: FontNameKey) -> Option<CFString> {
+        // SAFETY: Internal pointer and name string guaranteed valid.
         let ptr = unsafe { sys::CTFontCopyName(self.as_type_ref(), name.to_raw()) };
-        NonNull::new(ptr.cast_mut()).map(CFString::new_owned)
+        // SAFETY: In non-null, returned name guaranteed valid and owned.
+        NonNull::new(ptr.cast_mut()).map(|ptr| unsafe { CFString::new_owned(ptr) })
     }
 
+    /// Get the name of this font, localized to a specific language
     pub fn localized_name(&self, name: FontNameKey) -> Option<CFString> {
+        // SAFETY: Internal pointer and name string guaranteed valid.
         let ptr = unsafe {
             sys::CTFontCopyLocalizedName(self.as_type_ref(), name.to_raw(), ptr::null_mut())
         };
-        NonNull::new(ptr.cast_mut()).map(CFString::new_owned)
+        // SAFETY: In non-null, returned name guaranteed valid and owned.
+        NonNull::new(ptr.cast_mut()).map(|ptr| unsafe { CFString::new_owned(ptr) })
     }
 }

--- a/crates/mac_core/src/font.rs
+++ b/crates/mac_core/src/font.rs
@@ -1,0 +1,85 @@
+use super::{sys, CFString, CFType, CTFontDescriptor, CoreType};
+use std::ptr;
+use std::ptr::NonNull;
+
+#[derive(Copy, Clone)]
+pub enum FontAttribute {
+    Name,
+    FamilyName,
+    DisplayName,
+    URL,
+    CascadeList,
+}
+
+impl FontAttribute {
+    pub fn to_str(self) -> CFString {
+        CFString::new_borrowed(NonNull::new(self.to_raw().cast_mut()).unwrap())
+    }
+
+    pub fn to_raw(self) -> sys::CFStringRef {
+        match self {
+            FontAttribute::Name => unsafe { sys::kCTFontNameAttribute },
+            FontAttribute::FamilyName => unsafe { sys::kCTFontFamilyNameAttribute },
+            FontAttribute::DisplayName => unsafe { sys::kCTFontDisplayNameAttribute },
+            FontAttribute::URL => unsafe { sys::kCTFontURLAttribute },
+            FontAttribute::CascadeList => unsafe { sys::kCTFontCascadeListAttribute },
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum FontNameKey {
+    Full,
+    Family,
+    Style,
+    PostScript,
+}
+
+impl FontNameKey {
+    pub fn to_str(self) -> CFString {
+        CFString::new_borrowed(NonNull::new(self.to_raw().cast_mut()).unwrap())
+    }
+
+    fn to_raw(self) -> sys::CFStringRef {
+        match self {
+            FontNameKey::Full => unsafe { sys::kCTFontFullNameKey },
+            FontNameKey::Family => unsafe { sys::kCTFontFamilyNameKey },
+            FontNameKey::Style => unsafe { sys::kCTFontStyleNameKey },
+            FontNameKey::PostScript => unsafe { sys::kCTFontPostScriptNameKey },
+        }
+    }
+}
+
+cfty! {
+    CTFont : CTFontGetTypeID
+}
+
+impl CTFont {
+    pub fn new_descriptor(descriptor: &CTFontDescriptor, size: f64) -> CTFont {
+        let ptr = unsafe {
+            sys::CTFontCreateWithFontDescriptor(
+                descriptor.as_type_ref(),
+                size as sys::CGFloat,
+                ptr::null_mut(),
+            )
+        };
+        CTFont::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn attr(&self, attr: FontAttribute) -> Option<CFType> {
+        let ptr = unsafe { sys::CTFontCopyAttribute(self.as_type_ref(), attr.to_raw()) };
+        NonNull::new(ptr.cast_mut()).map(CFType::new_owned)
+    }
+
+    pub fn name(&self, name: FontNameKey) -> Option<CFString> {
+        let ptr = unsafe { sys::CTFontCopyName(self.as_type_ref(), name.to_raw()) };
+        NonNull::new(ptr.cast_mut()).map(CFString::new_owned)
+    }
+
+    pub fn localized_name(&self, name: FontNameKey) -> Option<CFString> {
+        let ptr = unsafe {
+            sys::CTFontCopyLocalizedName(self.as_type_ref(), name.to_raw(), ptr::null_mut())
+        };
+        NonNull::new(ptr.cast_mut()).map(CFString::new_owned)
+    }
+}

--- a/crates/mac_core/src/font_desc.rs
+++ b/crates/mac_core/src/font_desc.rs
@@ -2,26 +2,40 @@ use super::{sys, CFArray, CFDictionary, CFSet, CFString, CFType, CoreType, FontA
 use std::ptr::NonNull;
 
 cfty! {
+    /// A font descriptor, a typeface that can be paired with a size and transform to get a specific
+    /// font.
     CTFontDescriptor : CTFontDescriptorGetTypeID
 }
 
 impl CTFontDescriptor {
+    /// Create a new descriptor from a dictionary of its attributes. Unrecognized attributes will
+    /// be ignored.
     pub fn new_with_attrs(attrs: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
+        // SAFETY: Attrs is guaranteed to be valid
         let ptr = unsafe { sys::CTFontDescriptorCreateWithAttributes(attrs.as_type_ref()) };
-        CTFontDescriptor::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer from CTFontDescriptorCreateWithAttributes is a new, owned CTFontDescriptor.
+        unsafe { CTFontDescriptor::new_owned(ptr) }
     }
 
+    /// Create a copy of this descriptor, but with additional attributes as specified by `attrs`.
+    /// Overlapping attributes are replaced.
     pub fn copy_with_attrs(&self, attrs: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
+        // SAFETY: Self and attrs are guaranteed to be valid
         let ptr = unsafe {
             sys::CTFontDescriptorCreateCopyWithAttributes(self.as_type_ref(), attrs.as_type_ref())
         };
-        CTFontDescriptor::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer from CTFontDescriptorCreateCopyWithAttributes is a new, owned CTFontDescriptor.
+        unsafe { CTFontDescriptor::new_owned(ptr) }
     }
 
+    /// Find all loaded fonts that contain the provided mandatory properties.
     pub fn matching_font_descriptors(
         &self,
         mandatory: &CFSet<CFString>,
     ) -> CFArray<CTFontDescriptor> {
+        // SAFETY: Self and mandatory are guaranteed to be valid
         let ptr = unsafe {
             sys::CTFontDescriptorCreateMatchingFontDescriptors(
                 self.as_type_ref(),
@@ -29,12 +43,17 @@ impl CTFontDescriptor {
             )
         };
         NonNull::new(ptr.cast_mut())
-            .map(CFArray::new_owned)
+            // SAFETY: If non-null, pointer from CTFontDescriptorCreateMatchingFontDescriptors is a
+            //         new, owned CFArray of CTFontDescriptor
+            .map(|ptr| unsafe { CFArray::new_owned(ptr) })
             .unwrap_or_else(CFArray::empty)
     }
 
+    /// Get an attribute of this font descriptor, if present.
     pub fn attr(&self, attr: FontAttribute) -> Option<CFType> {
+        // SAFETY: Self and attr are guaranteed to be valid
         let ptr = unsafe { sys::CTFontDescriptorCopyAttribute(self.as_type_ref(), attr.to_raw()) };
-        NonNull::new(ptr.cast_mut()).map(CFType::new_owned)
+        // SAFETY: If non-null, pointer from CTFontDescriptorCreateMatchingFontDescriptors is a new, owned CFType instance
+        NonNull::new(ptr.cast_mut()).map(|ptr| unsafe { CFType::new_owned(ptr) })
     }
 }

--- a/crates/mac_core/src/font_desc.rs
+++ b/crates/mac_core/src/font_desc.rs
@@ -1,0 +1,40 @@
+use super::{sys, CFArray, CFDictionary, CFSet, CFString, CFType, CoreType, FontAttribute};
+use std::ptr::NonNull;
+
+cfty! {
+    CTFontDescriptor : CTFontDescriptorGetTypeID
+}
+
+impl CTFontDescriptor {
+    pub fn new_with_attrs(attrs: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
+        let ptr = unsafe { sys::CTFontDescriptorCreateWithAttributes(attrs.as_type_ref()) };
+        CTFontDescriptor::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn copy_with_attrs(&self, attrs: &CFDictionary<CFString, CFType>) -> CTFontDescriptor {
+        let ptr = unsafe {
+            sys::CTFontDescriptorCreateCopyWithAttributes(self.as_type_ref(), attrs.as_type_ref())
+        };
+        CTFontDescriptor::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn matching_font_descriptors(
+        &self,
+        mandatory: &CFSet<CFString>,
+    ) -> CFArray<CTFontDescriptor> {
+        let ptr = unsafe {
+            sys::CTFontDescriptorCreateMatchingFontDescriptors(
+                self.as_type_ref(),
+                mandatory.as_type_ref(),
+            )
+        };
+        NonNull::new(ptr.cast_mut())
+            .map(CFArray::new_owned)
+            .unwrap_or_else(CFArray::empty)
+    }
+
+    pub fn attr(&self, attr: FontAttribute) -> Option<CFType> {
+        let ptr = unsafe { sys::CTFontDescriptorCopyAttribute(self.as_type_ref(), attr.to_raw()) };
+        NonNull::new(ptr.cast_mut()).map(CFType::new_owned)
+    }
+}

--- a/crates/mac_core/src/lib.rs
+++ b/crates/mac_core/src/lib.rs
@@ -1,3 +1,8 @@
+//! Bindings to macOS foundation and core libraries.
+//!
+//! This currently includes only Foundation and CoreText, as those are the libraries needed by
+//! Tectonic.
+
 #![cfg(target_os = "macos")]
 
 use std::mem::ManuallyDrop;
@@ -23,34 +28,47 @@ pub use set::CFSet;
 pub use string::CFString;
 pub use url::CFUrl;
 
+/// An ID representing different [`CFType`] subclasses (and of course, [`CFType`]. itself). Can
+/// be used for dynamic upcasting and downcasting of values.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct CFTypeId(libc::c_ulong);
 
 impl CFTypeId {
+    /// Get the [`CFTypeId`] that represents an instance of a [`CoreType`].
     pub fn of<T: CoreType>() -> CFTypeId {
         T::type_id()
     }
 
+    /// Get the runtime [`CFTypeId`] of a value. This may not be the same as the type ID of T, if
+    /// the value has been upcast.
     pub fn of_val<T: CoreType>(val: &T) -> CFTypeId {
+        // SAFETY: T: CoreType is guaranteed to be valid CFTypeRef
         CFTypeId(unsafe { sys::CFGetTypeID(val.as_type_ref().cast()) })
     }
 }
 
+/// The base of all CoreFoundation types. This is roughly equivalent to `Object` in Java. May be
+/// used in situations where a type is only dynamically known at runtime.
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct CFType(NonNull<()>);
 
 impl CFType {
+    /// Attempt to convert this type into a more specific child type. If the cast fails, `Err`
+    /// contains the original [`CFType`].
     pub fn downcast<T: CoreType>(self) -> Result<T, Self> {
         if CFTypeId::of_val(&self) == CFTypeId::of::<T>() {
             let this = ManuallyDrop::new(self);
-            Ok(T::new_owned(this.0.cast()))
+            // SAFETY: If the CFTypeId of self matches T, then it is guaranteed a valid pointer to T.
+            //         ManuallyDrop above means we are giving up ownership of the pointer to the new T.
+            Ok(unsafe { T::new_owned(this.0.cast()) })
         } else {
             Err(self)
         }
     }
 }
 
+// SAFETY: This type is the canonical CFTypeRef
 unsafe impl CoreType for CFType {
     type SysTy = ();
 
@@ -58,13 +76,15 @@ unsafe impl CoreType for CFType {
         CFTypeId(0)
     }
 
-    fn new_owned(ptr: NonNull<Self::SysTy>) -> Self {
+    unsafe fn new_owned(ptr: NonNull<Self::SysTy>) -> Self {
         CFType(ptr)
     }
 
-    fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self {
+    unsafe fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self {
+        // SAFETY: Pointer is guaranteed valid by precondition
         unsafe { sys::CFRetain(ptr.as_ptr()) };
-        CFType::new_owned(ptr)
+        // SAFETY: We have just retained the pointer, meaning we now have ownership of it
+        unsafe { CFType::new_owned(ptr) }
     }
 
     fn as_type_ref(&self) -> *const Self::SysTy {
@@ -78,6 +98,7 @@ unsafe impl CoreType for CFType {
 
 impl Drop for CFType {
     fn drop(&mut self) {
+        // SAFETY: Inner pointer is guaranteed valid
         unsafe { sys::CFRelease(self.0.as_ptr()) }
     }
 }
@@ -87,20 +108,32 @@ impl Drop for CFType {
 /// Types that implement this trait must be equivalent to a CFTypeRef - they must be pointer-sized
 /// and have an equivalent repr.
 pub unsafe trait CoreType: Sized {
+    /// The system type for this value. This is a pointer type in the `sys` module generally.
     type SysTy;
 
+    /// The [`CFTypeId`] that this type represents.
     fn type_id() -> CFTypeId;
 
-    fn new_owned(ptr: NonNull<Self::SysTy>) -> Self;
+    /// # Safety
+    ///
+    /// - The provided pointer must be a valid pointer to an instance of this type.
+    /// - The pointer must be 'owned' - valid to call `CFRelease` on without a paired `CFRetain`.
+    unsafe fn new_owned(ptr: NonNull<Self::SysTy>) -> Self;
 
-    fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self;
+    /// # Safety
+    ///
+    /// - The provided pointer must be a valid pointer to an instance of this type.
+    unsafe fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self;
 
+    #[doc(hidden)]
     fn as_type_ref(&self) -> *const Self::SysTy;
 
+    #[doc(hidden)]
     fn into_type_ref(self) -> *const Self::SysTy {
         let this = ManuallyDrop::new(self);
         this.as_type_ref()
     }
 
+    /// Upcast this value into a [`CFType`] for usage in generic contexts.
     fn into_ty(self) -> CFType;
 }

--- a/crates/mac_core/src/lib.rs
+++ b/crates/mac_core/src/lib.rs
@@ -1,0 +1,106 @@
+#![cfg(target_os = "macos")]
+
+use std::mem::ManuallyDrop;
+use std::ptr::NonNull;
+
+pub mod sys;
+
+#[macro_use]
+mod macros;
+mod array;
+mod dict;
+mod font;
+mod font_desc;
+mod set;
+mod string;
+mod url;
+
+pub use array::CFArray;
+pub use dict::CFDictionary;
+pub use font::{CTFont, FontAttribute, FontNameKey};
+pub use font_desc::CTFontDescriptor;
+pub use set::CFSet;
+pub use string::CFString;
+pub use url::CFUrl;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct CFTypeId(libc::c_ulong);
+
+impl CFTypeId {
+    pub fn of<T: CoreType>() -> CFTypeId {
+        T::type_id()
+    }
+
+    pub fn of_val<T: CoreType>(val: &T) -> CFTypeId {
+        CFTypeId(unsafe { sys::CFGetTypeID(val.as_type_ref().cast()) })
+    }
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct CFType(NonNull<()>);
+
+impl CFType {
+    pub fn downcast<T: CoreType>(self) -> Result<T, Self> {
+        if CFTypeId::of_val(&self) == CFTypeId::of::<T>() {
+            let this = ManuallyDrop::new(self);
+            Ok(T::new_owned(this.0.cast()))
+        } else {
+            Err(self)
+        }
+    }
+}
+
+unsafe impl CoreType for CFType {
+    type SysTy = ();
+
+    fn type_id() -> CFTypeId {
+        CFTypeId(0)
+    }
+
+    fn new_owned(ptr: NonNull<Self::SysTy>) -> Self {
+        CFType(ptr)
+    }
+
+    fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self {
+        unsafe { sys::CFRetain(ptr.as_ptr()) };
+        CFType::new_owned(ptr)
+    }
+
+    fn as_type_ref(&self) -> *const Self::SysTy {
+        self.0.as_ptr().cast_const()
+    }
+
+    fn into_ty(self) -> CFType {
+        self
+    }
+}
+
+impl Drop for CFType {
+    fn drop(&mut self) {
+        unsafe { sys::CFRelease(self.0.as_ptr()) }
+    }
+}
+
+/// # Safety
+///
+/// Types that implement this trait must be equivalent to a CFTypeRef - they must be pointer-sized
+/// and have an equivalent repr.
+pub unsafe trait CoreType: Sized {
+    type SysTy;
+
+    fn type_id() -> CFTypeId;
+
+    fn new_owned(ptr: NonNull<Self::SysTy>) -> Self;
+
+    fn new_borrowed(ptr: NonNull<Self::SysTy>) -> Self;
+
+    fn as_type_ref(&self) -> *const Self::SysTy;
+
+    fn into_type_ref(self) -> *const Self::SysTy {
+        let this = ManuallyDrop::new(self);
+        this.as_type_ref()
+    }
+
+    fn into_ty(self) -> CFType;
+}

--- a/crates/mac_core/src/macros.rs
+++ b/crates/mac_core/src/macros.rs
@@ -1,21 +1,28 @@
 macro_rules! cfty {
-    ($sysname:ident $name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
+    ($(#[doc = $doc:expr])* $sysname:ident $name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
+
+        $(#[doc = $doc])*
         #[derive(PartialEq, Eq, Hash)]
         #[repr(transparent)]
         pub struct $name<$($($phantom),*)*>(std::ptr::NonNull<$crate::sys::$sysname> $($(, PhantomData<$phantom>)*)*);
 
+        // SAFETY: Internal macro only used for CFTypeRef-safe types. The above struct definition
+        //         ensures this type is just a pointer wrapper.
         unsafe impl <$($( $phantom: $crate::CoreType ),*)*> $crate::CoreType for $name<$($( $phantom ),*)*> {
             type SysTy = $crate::sys::$sysname;
 
             fn type_id() -> $crate::CFTypeId {
+                // SAFETY: The provided identity function, assuming it type checks, should be always
+                //         safe to call.
                 $crate::CFTypeId(unsafe { $crate::sys::$id_fn() })
             }
 
-            fn new_owned(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
+            unsafe fn new_owned(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
                 Self(ptr, $($(PhantomData::<$phantom>),*)*)
             }
 
-            fn new_borrowed(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
+            unsafe fn new_borrowed(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
+                // SAFETY: Provided pointer is required a valid pointer for this type
                 unsafe { $crate::sys::CFRetain(ptr.as_ptr().cast()) };
                 Self::new_owned(ptr)
             }
@@ -26,23 +33,28 @@ macro_rules! cfty {
 
             fn into_ty(self) -> $crate::CFType {
                 let this = std::mem::ManuallyDrop::new(self);
-                $crate::CFType::new_owned(this.0.cast())
+                // SAFETY: The internal pointer is guaranteed valid
+                unsafe { $crate::CFType::new_owned(this.0.cast()) }
             }
         }
 
         impl <$($( $phantom: $crate::CoreType ),*)*> Clone for $name<$($( $phantom ),*)*> {
             fn clone(&self) -> Self {
-                Self::new_borrowed(self.0)
+                // SAFETY: The internal pointer is guaranteed valid
+                unsafe { Self::new_borrowed(self.0) }
             }
         }
 
         impl <$($( $phantom ),*)*> Drop for $name<$($( $phantom ),*)*> {
             fn drop(&mut self) {
+                // SAFETY: The internal pointer is guaranteed valid and owned
                 unsafe { $crate::sys::CFRelease(self.0.as_ptr().cast()) }
             }
         }
     };
-    ($name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
-        cfty!($name $name$(<$($phantom),*>)* : $id_fn);
+    (
+        $( #[doc = $doc:expr] )*
+        $name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
+        cfty!($(#[doc = $doc])* $name $name$(<$($phantom),*>)* : $id_fn);
     };
 }

--- a/crates/mac_core/src/macros.rs
+++ b/crates/mac_core/src/macros.rs
@@ -1,0 +1,48 @@
+macro_rules! cfty {
+    ($sysname:ident $name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
+        #[derive(PartialEq, Eq, Hash)]
+        #[repr(transparent)]
+        pub struct $name<$($($phantom),*)*>(std::ptr::NonNull<$crate::sys::$sysname> $($(, PhantomData<$phantom>)*)*);
+
+        unsafe impl <$($( $phantom: $crate::CoreType ),*)*> $crate::CoreType for $name<$($( $phantom ),*)*> {
+            type SysTy = $crate::sys::$sysname;
+
+            fn type_id() -> $crate::CFTypeId {
+                $crate::CFTypeId(unsafe { $crate::sys::$id_fn() })
+            }
+
+            fn new_owned(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
+                Self(ptr, $($(PhantomData::<$phantom>),*)*)
+            }
+
+            fn new_borrowed(ptr: std::ptr::NonNull<Self::SysTy>) -> Self {
+                unsafe { $crate::sys::CFRetain(ptr.as_ptr().cast()) };
+                Self::new_owned(ptr)
+            }
+
+            fn as_type_ref(&self) -> *const Self::SysTy {
+                self.0.as_ptr().cast_const()
+            }
+
+            fn into_ty(self) -> $crate::CFType {
+                let this = std::mem::ManuallyDrop::new(self);
+                $crate::CFType::new_owned(this.0.cast())
+            }
+        }
+
+        impl <$($( $phantom: $crate::CoreType ),*)*> Clone for $name<$($( $phantom ),*)*> {
+            fn clone(&self) -> Self {
+                Self::new_borrowed(self.0)
+            }
+        }
+
+        impl <$($( $phantom ),*)*> Drop for $name<$($( $phantom ),*)*> {
+            fn drop(&mut self) {
+                unsafe { $crate::sys::CFRelease(self.0.as_ptr().cast()) }
+            }
+        }
+    };
+    ($name:ident $(<$($phantom:ident),+>)? : $id_fn:ident) => {
+        cfty!($name $name$(<$($phantom),*>)* : $id_fn);
+    };
+}

--- a/crates/mac_core/src/set.rs
+++ b/crates/mac_core/src/set.rs
@@ -1,0 +1,22 @@
+use super::{sys, CoreType};
+use std::marker::PhantomData;
+use std::ptr;
+use std::ptr::NonNull;
+
+cfty! {
+    CFSet<T> : CFSetGetTypeID
+}
+
+impl<T: CoreType> CFSet<T> {
+    pub fn new(values: &[T]) -> CFSet<T> {
+        let ptr = unsafe {
+            sys::CFSetCreate(
+                ptr::null_mut(),
+                values.as_ptr().cast_mut().cast(),
+                values.len() as sys::CFIndex,
+                &sys::kCFTypeSetCallBacks,
+            )
+        };
+        CFSet::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+}

--- a/crates/mac_core/src/set.rs
+++ b/crates/mac_core/src/set.rs
@@ -4,11 +4,15 @@ use std::ptr;
 use std::ptr::NonNull;
 
 cfty! {
+    /// A set of CFType values, similar to [`HashSet`](std::collections::HashSet).
     CFSet<T> : CFSetGetTypeID
 }
 
 impl<T: CoreType> CFSet<T> {
+    /// Create a new [`CFSet`] containing the provided values.
     pub fn new(values: &[T]) -> CFSet<T> {
+        // SAFETY: Length is same as number of elements in slice, `CoreType` bound ensures all items
+        //         are valid to treat as a CFTypeRef.
         let ptr = unsafe {
             sys::CFSetCreate(
                 ptr::null_mut(),
@@ -17,6 +21,8 @@ impl<T: CoreType> CFSet<T> {
                 &sys::kCFTypeSetCallBacks,
             )
         };
-        CFSet::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, the pointer returned by CFSetCreate is guaranteed to be a valid CFSet.
+        unsafe { CFSet::new_owned(ptr) }
     }
 }

--- a/crates/mac_core/src/string.rs
+++ b/crates/mac_core/src/string.rs
@@ -43,11 +43,16 @@ impl StrLike for CStr {
 }
 
 cfty! {
+    /// A string. Note this is not necessarily like [`String`], as the contained bytes may not
+    /// be in UTF-8.
     CFString : CFStringGetTypeID
 }
 
 impl CFString {
+    /// Create a new string from a value. The value may be any of multiple Rust string types, such
+    /// as `str` or `CStr`.
     pub fn new<S: ?Sized + StrLike>(val: &S) -> CFString {
+        // SAFETY: Length, pointer, and encoding are derived from same value.
         let ptr = unsafe {
             sys::CFStringCreateWithBytes(
                 ptr::null(),
@@ -57,19 +62,28 @@ impl CFString {
                 false,
             )
         };
-        CFString::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+        let ptr = NonNull::new(ptr.cast_mut()).unwrap();
+        // SAFETY: If non-null, pointer returned by CFStringCreateWithBytes is guaranteed to be a
+        //         valid CFString.
+        unsafe { CFString::new_owned(ptr) }
     }
 
+    /// Get the length of this string
     pub fn len(&self) -> usize {
+        // SAFETY: Self is guaranteed to be valid
         unsafe { sys::CFStringGetLength(self.as_type_ref()) as usize }
     }
 
+    /// Check whether this string is empty (has a length of 0)
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Get this value as a Rust [`String`]. The value will be re-encoded into UTF-8 if in another
+    /// encoding.
     pub fn get_string(&self) -> String {
         let mut buf_len = 0;
+        // SAFETY: Self is guaranteed valid. No buffer is passed.
         unsafe {
             sys::CFStringGetBytes(
                 self.as_type_ref(),
@@ -86,6 +100,7 @@ impl CFString {
             )
         };
         let mut buf = vec![0u8; buf_len as usize];
+        // SAFETY: Self is guaranteed valid. Buffer is allocated to the correct length.
         let written = unsafe {
             sys::CFStringGetBytes(
                 self.as_type_ref(),
@@ -108,19 +123,27 @@ impl CFString {
         }
     }
 
+    /// Attempt to get a reference to this value as a `str`, if the value is natively UTF-8,
+    /// otherwise re-encode into UTF-8.
     pub fn as_str(&self) -> Cow<'_, str> {
+        // SAFETY: Self is guaranteed valid
         let cstr =
             unsafe { sys::CFStringGetCStringPtr(self.as_type_ref(), sys::kCFStringEncodingUTF8) };
         if cstr.is_null() {
             Cow::Owned(self.get_string())
         } else {
+            // SAFETY: If non-null, the return value of CFStringGetCStringPtr is guaranteed to be a
+            //         valid C-string
             Cow::Borrowed(unsafe { CStr::from_ptr(cstr) }.to_str().unwrap())
         }
     }
 
+    /// Get this value as a null-terminated C-string
     pub fn get_cstring(&self) -> CString {
         let len = self.len() * 4 + 1;
         let mut buf = vec![0; len];
+        // SAFETY: Self is guaranteed valid. Buffer is definitely of sufficient length to hold the
+        //         bytes of self.
         let res = unsafe {
             sys::CFStringGetCString(
                 self.as_type_ref(),
@@ -137,12 +160,17 @@ impl CFString {
         }
     }
 
+    /// Attempt to get a reference to this value as a `CStr`, if the value is natively UTF-8,
+    /// otherwise allocate a CString in that encoding.
     pub fn as_cstr(&self) -> Cow<'_, CStr> {
+        // SAFETY: Self is guaranteed valid
         let cstr =
             unsafe { sys::CFStringGetCStringPtr(self.as_type_ref(), sys::kCFStringEncodingUTF8) };
         if cstr.is_null() {
             Cow::Owned(self.get_cstring())
         } else {
+            // SAFETY: If non-null, the return value of CFStringGetCStringPtr is guaranteed to be a
+            //         valid C-string
             Cow::Borrowed(unsafe { CStr::from_ptr(cstr) })
         }
     }

--- a/crates/mac_core/src/string.rs
+++ b/crates/mac_core/src/string.rs
@@ -1,0 +1,149 @@
+use super::{sys, CoreType};
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::ptr;
+use std::ptr::NonNull;
+
+pub trait StrLike {
+    fn encoding(&self) -> sys::CFStringEncoding;
+    fn len(&self) -> usize;
+    fn as_ptr(&self) -> *const u8;
+}
+
+impl StrLike for str {
+    fn encoding(&self) -> sys::CFStringEncoding {
+        sys::kCFStringEncodingUTF8
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.as_ptr()
+    }
+}
+
+impl StrLike for CStr {
+    fn encoding(&self) -> sys::CFStringEncoding {
+        if self.to_str().is_ok() {
+            sys::kCFStringEncodingUTF8
+        } else {
+            sys::kCFStringEncodingNonLossyASCII
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.to_bytes().len()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.as_ptr().cast()
+    }
+}
+
+cfty! {
+    CFString : CFStringGetTypeID
+}
+
+impl CFString {
+    pub fn new<S: ?Sized + StrLike>(val: &S) -> CFString {
+        let ptr = unsafe {
+            sys::CFStringCreateWithBytes(
+                ptr::null(),
+                val.as_ptr(),
+                val.len() as sys::CFIndex,
+                val.encoding(),
+                false,
+            )
+        };
+        CFString::new_owned(NonNull::new(ptr.cast_mut()).unwrap())
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { sys::CFStringGetLength(self.as_type_ref()) as usize }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn get_string(&self) -> String {
+        let mut buf_len = 0;
+        unsafe {
+            sys::CFStringGetBytes(
+                self.as_type_ref(),
+                sys::CFRange {
+                    location: 0,
+                    length: self.len() as sys::CFIndex,
+                },
+                sys::kCFStringEncodingUTF8,
+                0,
+                false,
+                ptr::null_mut(),
+                0,
+                &mut buf_len,
+            )
+        };
+        let mut buf = vec![0u8; buf_len as usize];
+        let written = unsafe {
+            sys::CFStringGetBytes(
+                self.as_type_ref(),
+                sys::CFRange {
+                    location: 0,
+                    length: self.len() as sys::CFIndex,
+                },
+                sys::kCFStringEncodingUTF8,
+                0,
+                false,
+                buf.as_mut_ptr(),
+                buf_len,
+                &mut buf_len,
+            )
+        };
+        if written as usize == self.len() {
+            String::from_utf8(buf).unwrap()
+        } else {
+            panic!("Failed to convert CFString");
+        }
+    }
+
+    pub fn as_str(&self) -> Cow<'_, str> {
+        let cstr =
+            unsafe { sys::CFStringGetCStringPtr(self.as_type_ref(), sys::kCFStringEncodingUTF8) };
+        if cstr.is_null() {
+            Cow::Owned(self.get_string())
+        } else {
+            Cow::Borrowed(unsafe { CStr::from_ptr(cstr) }.to_str().unwrap())
+        }
+    }
+
+    pub fn get_cstring(&self) -> CString {
+        let len = self.len() * 4 + 1;
+        let mut buf = vec![0; len];
+        let res = unsafe {
+            sys::CFStringGetCString(
+                self.as_type_ref(),
+                buf.as_mut_ptr().cast(),
+                len as sys::CFIndex,
+                sys::kCFStringEncodingUTF8,
+            )
+        };
+        if res {
+            let buf = buf.into_iter().take_while(|&c| c != 0).collect::<Vec<_>>();
+            CString::new(buf).unwrap()
+        } else {
+            panic!("Invalid C String")
+        }
+    }
+
+    pub fn as_cstr(&self) -> Cow<'_, CStr> {
+        let cstr =
+            unsafe { sys::CFStringGetCStringPtr(self.as_type_ref(), sys::kCFStringEncodingUTF8) };
+        if cstr.is_null() {
+            Cow::Owned(self.get_cstring())
+        } else {
+            Cow::Borrowed(unsafe { CStr::from_ptr(cstr) })
+        }
+    }
+}

--- a/crates/mac_core/src/sys.rs
+++ b/crates/mac_core/src/sys.rs
@@ -1,0 +1,198 @@
+#![allow(nonstandard_style)]
+
+#[repr(C)]
+pub struct CFAllocator(());
+
+#[repr(C)]
+pub struct CFDictionaryKeyCallBacks(());
+
+#[repr(C)]
+pub struct CFDictionaryValueCallBacks(());
+
+#[repr(C)]
+pub struct CFSetCallBacks(());
+
+#[repr(C)]
+pub struct CFArrayCallBacks(());
+
+#[repr(C)]
+pub struct CFDictionary(());
+
+#[repr(C)]
+pub struct CFSet(());
+
+#[repr(C)]
+pub struct CFArray(());
+
+#[repr(C)]
+pub struct CTFontDescriptor(());
+
+#[repr(C)]
+pub struct CTFont(());
+
+#[repr(C)]
+pub struct CFString(());
+
+#[repr(C)]
+pub struct CFURL(());
+
+#[repr(C)]
+pub struct CFRange {
+    pub location: CFIndex,
+    pub length: CFIndex,
+}
+
+#[repr(C)]
+pub struct CGAffineTransform {
+    a: CGFloat,
+    b: CGFloat,
+    c: CGFloat,
+    d: CGFloat,
+    tx: CGFloat,
+    ty: CGFloat,
+}
+
+#[repr(C)]
+pub struct NSFontManager(());
+
+pub type CTFontDescriptorRef = *const CTFontDescriptor;
+pub type CFDictionaryRef = *const CFDictionary;
+pub type CFIndex = isize;
+pub type CFTypeRef = *const ();
+pub type CFAllocatorRef = *const CFAllocator;
+pub type CFSetRef = *const CFSet;
+pub type CFArrayRef = *const CFArray;
+pub type CTFontRef = *const CTFont;
+pub type CFStringRef = *const CFString;
+pub type CFURLRef = *const CFURL;
+pub type CFStringEncoding = u32;
+#[cfg(target_os = "watchos")]
+pub type CGFloat = f32;
+#[cfg(not(target_os = "watchos"))]
+pub type CGFloat = f64;
+
+pub type CFTypeID = libc::c_ulong;
+
+pub const kCFStringEncodingMacRoman: CFStringEncoding = 0;
+pub const kCFStringEncodingASCII: CFStringEncoding = 0x0600;
+pub const kCFStringEncodingNonLossyASCII: CFStringEncoding = 0x0BFF;
+pub const kCFStringEncodingUnicode: CFStringEncoding = 0x0100;
+pub const kCFStringEncodingUTF8: CFStringEncoding = 0x08000100;
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    pub fn CFSetCreate(
+        allocator: CFAllocatorRef,
+        values: *mut *const (),
+        num_values: CFIndex,
+        callbacks: *const CFSetCallBacks,
+    ) -> CFSetRef;
+    pub fn CFDictionaryCreate(
+        allocator: CFAllocatorRef,
+        keys: *mut *const (),
+        values: *mut *const (),
+        num_values: CFIndex,
+        key_call_backs: *const CFDictionaryKeyCallBacks,
+        value_call_backs: *const CFDictionaryValueCallBacks,
+    ) -> CFDictionaryRef;
+    pub fn CFRelease(cf: CFTypeRef);
+    pub fn CFArrayGetCount(array: CFArrayRef) -> CFIndex;
+    pub fn CFArrayGetValueAtIndex(array: CFArrayRef, idx: CFIndex) -> *const ();
+    pub fn CFRetain(cf: CFTypeRef) -> CFTypeRef;
+    pub fn CFArrayCreate(
+        allocator: CFAllocatorRef,
+        values: *mut *const (),
+        num_values: CFIndex,
+        call_backs: *const CFArrayCallBacks,
+    ) -> CFArrayRef;
+    pub fn CFStringGetLength(str: CFStringRef) -> CFIndex;
+    pub fn CFStringGetCStringPtr(str: CFStringRef, enc: CFStringEncoding) -> *const libc::c_char;
+    pub fn CFStringCreateWithCString(
+        alloc: CFAllocatorRef,
+        c_str: *const libc::c_char,
+        encoding: CFStringEncoding,
+    ) -> CFStringRef;
+    pub fn CFStringCreateWithBytes(
+        alloc: CFAllocatorRef,
+        bytes: *const u8,
+        num_bytes: CFIndex,
+        encoding: CFStringEncoding,
+        is_external: bool,
+    ) -> CFStringRef;
+    pub fn CFStringGetBytes(
+        str: CFStringRef,
+        range: CFRange,
+        encoding: CFStringEncoding,
+        loss_byte: u8,
+        is_external: bool,
+        buffer: *mut u8,
+        max_buf_len: CFIndex,
+        used_buf_len: *mut CFIndex,
+    ) -> CFIndex;
+    pub fn CFStringGetCString(
+        str: CFStringRef,
+        buffer: *mut libc::c_char,
+        buffer_size: CFIndex,
+        encoding: CFStringEncoding,
+    ) -> bool;
+    pub fn CFURLGetFileSystemRepresentation(
+        url: CFURLRef,
+        resolve_against_base: bool,
+        buffer: *mut u8,
+        max_buf_len: CFIndex,
+    ) -> bool;
+    pub fn CFSetGetTypeID() -> CFTypeID;
+    pub fn CFArrayGetTypeID() -> CFTypeID;
+    pub fn CFStringGetTypeID() -> CFTypeID;
+    pub fn CFDictionaryGetTypeID() -> CFTypeID;
+    pub fn CFURLGetTypeID() -> CFTypeID;
+    pub fn CFGetTypeID(cf: CFTypeRef) -> CFTypeID;
+
+    pub static kCFTypeDictionaryKeyCallBacks: CFDictionaryKeyCallBacks;
+    pub static kCFTypeDictionaryValueCallBacks: CFDictionaryValueCallBacks;
+    pub static kCFTypeSetCallBacks: CFSetCallBacks;
+    pub static kCFTypeArrayCallBacks: CFArrayCallBacks;
+}
+
+#[link(name = "CoreText", kind = "framework")]
+extern "C" {
+    pub fn CTFontDescriptorCreateWithAttributes(attributes: CFDictionaryRef)
+        -> CTFontDescriptorRef;
+    pub fn CTFontDescriptorCreateMatchingFontDescriptors(
+        descriptor: CTFontDescriptorRef,
+        mandatory_attributes: CFSetRef,
+    ) -> CFArrayRef;
+    pub fn CTFontDescriptorCopyAttribute(
+        descriptor: CTFontDescriptorRef,
+        attribute: CFStringRef,
+    ) -> CFTypeRef;
+    pub fn CTFontCreateWithFontDescriptor(
+        descriptor: CTFontDescriptorRef,
+        size: CGFloat,
+        matrix: *const CGAffineTransform,
+    ) -> CTFontRef;
+    pub fn CTFontCopyName(font: CTFontRef, name_key: CFStringRef) -> CFStringRef;
+    pub fn CTFontCopyAttribute(font: CTFontRef, attribute: CFStringRef) -> CFTypeRef;
+    pub fn CTFontDescriptorCreateCopyWithAttributes(
+        original: CTFontDescriptorRef,
+        attributes: CFDictionaryRef,
+    ) -> CTFontDescriptorRef;
+    pub fn CTFontCopyLocalizedName(
+        font: CTFontRef,
+        name_key: CFStringRef,
+        actual_lang: *mut CFStringRef,
+    ) -> CFStringRef;
+    pub fn CTFontManagerCopyAvailableFontFamilyNames() -> CFArrayRef;
+    pub fn CTFontGetTypeID() -> CFTypeID;
+    pub fn CTFontDescriptorGetTypeID() -> CFTypeID;
+
+    pub static kCTFontNameAttribute: CFStringRef;
+    pub static kCTFontFullNameKey: CFStringRef;
+    pub static kCTFontFamilyNameKey: CFStringRef;
+    pub static kCTFontStyleNameKey: CFStringRef;
+    pub static kCTFontURLAttribute: CFStringRef;
+    pub static kCTFontPostScriptNameKey: CFStringRef;
+    pub static kCTFontCascadeListAttribute: CFStringRef;
+    pub static kCTFontFamilyNameAttribute: CFStringRef;
+    pub static kCTFontDisplayNameAttribute: CFStringRef;
+}

--- a/crates/mac_core/src/sys.rs
+++ b/crates/mac_core/src/sys.rs
@@ -1,4 +1,4 @@
-#![allow(nonstandard_style)]
+#![allow(nonstandard_style, missing_docs)]
 
 #[repr(C)]
 pub struct CFAllocator(());

--- a/crates/mac_core/src/url.rs
+++ b/crates/mac_core/src/url.rs
@@ -1,0 +1,25 @@
+use super::{sys, CoreType};
+use std::ffi::{CStr, CString};
+
+cfty! {
+    CFURL CFUrl : CFURLGetTypeID
+}
+
+impl CFUrl {
+    pub fn fs_representation(&self) -> Option<CString> {
+        let mut buf = [0u8; libc::PATH_MAX as usize];
+        let res = unsafe {
+            sys::CFURLGetFileSystemRepresentation(
+                self.as_type_ref(),
+                true,
+                buf.as_mut_ptr(),
+                buf.len() as sys::CFIndex,
+            )
+        };
+        if res {
+            CStr::from_bytes_until_nul(&buf).ok().map(CStr::to_owned)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/mac_core/src/url.rs
+++ b/crates/mac_core/src/url.rs
@@ -2,12 +2,16 @@ use super::{sys, CoreType};
 use std::ffi::{CStr, CString};
 
 cfty! {
+    /// A URL value
     CFURL CFUrl : CFURLGetTypeID
 }
 
 impl CFUrl {
+    /// If possible, returns the native file system representation of the path identified by this
+    /// URL. Returns `None` if the URL cannot be represented as a filesystem path.
     pub fn fs_representation(&self) -> Option<CString> {
         let mut buf = [0u8; libc::PATH_MAX as usize];
+        // SAFETY: Self is guaranteed valid, buf length is guaranteed to match allocated buffer.
         let res = unsafe {
             sys::CFURLGetFileSystemRepresentation(
                 self.as_type_ref(),


### PR DESCRIPTION
Part of #1138 

Implements mac_core - bindings to CoreFoundation and CoreText libraries on macOS. Similar bindings exist on crates.io, but they don't support all that we need nicely, and also I find them slightly less rusty.