### PR TITLE
fix(ci): allow running for forks

### DIFF
--- a/.github/actions/deploy-setup/action.yml
+++ b/.github/actions/deploy-setup/action.yml
@@ -50,7 +50,10 @@ runs:
       id: set-toplevel
       shell: bash
       run: |
-        if [[ "$IS_DEV" == "true" ]] ; then
+        if [[ -z $GITHUB_TOKEN ]] ; then
+          >&2 echo '$GITHUB_TOKEN is unset, skipping deployment'
+          version_text=skip
+        elif [[ "$IS_DEV" == "true" ]] ; then
           version_text=latest
         elif cranko show if-released --exit-code tectonic ; then
           version_text="$(cranko show version tectonic)"


### PR DESCRIPTION
Previously if we fork the repo and turn on github actions on the fork, the deployment stage of the CI will fail due to a lack of the `$GITHUB_TOKEN`; see e.g. https://github.com/bryango/tectonic/actions/runs/16586953977/job/46914830465.

This patch allows it to skip the deployment phase gracefully if no token is found, then the workflow can be used as-is to test changes in the fork.