### PR TITLE
chore: bump vcpkg ref, maybe fix gperf build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ tempfile = "^3.1"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
-rev = "be1ae8e5c5bc79aac1b8f593f5554aee1cfde54f"
+rev = "a62ce77d56ee07513b4b67de1ec2daeaebfae51a"
 overlay-triplets-path = "dist/vcpkg-triplets"
 
 # If other targets start using custom triplets like x86_64-pc-windows-msvc,


### PR DESCRIPTION
gperf:arm64-osx was failing on macOS due to an outdated vcpkg port definition; see e.g. https://github.com/tectonic-typesetting/tectonic/actions/runs/17890169920/job/50869494362. This bump should hopefully fix the build.