### PR TITLE
remove dollar signs

### DIFF
--- a/docs/src/getting-started/first-document.md
+++ b/docs/src/getting-started/first-document.md
@@ -25,7 +25,7 @@ of other powerful tools such as [git] and [cargo]. To create a new document, we
 use a [`new`][cli-new] subcommand that looks like this:
 
 ```sh
-$ tectonic -X new myfirstdoc
+tectonic -X new myfirstdoc
 ```
 
 [git]: https://git-scm.com/
@@ -39,7 +39,7 @@ Enter this new directory in your command prompt.
 [workspace]: ../ref/workspaces.md
 
 ```sh
-$ cd myfirstdoc
+cd myfirstdoc
 ```
 
 **Note:** *The `-X` flag activates the V2 interface. Don’t forget it! Eventually
@@ -49,7 +49,7 @@ that changeover hasn’t happened yet.*
 If you’ve got an existing TeX file, you can process it in one-off fashion with:
 
 ```sh
-$ tectonic -X compile myfile.tex
+tectonic -X compile myfile.tex
 ```
 
 See [the `tectonic -X compile` documentation][cli-compile] for all of the options.
@@ -62,7 +62,7 @@ See [the `tectonic -X compile` documentation][cli-compile] for all of the option
 To compile your document, run:
 
 ```sh
-$ tectonic -X build
+tectonic -X build
 ```
 
 If you haven’t run Tectonic on your computer before, this command will take a
@@ -72,7 +72,7 @@ these files and avoid downloading them again. Test it out by running the build
 again:
 
 ```sh
-$ tectonic -X build
+tectonic -X build
 ```
 
 This time the command should finish much more quickly, with no messages about
@@ -80,7 +80,7 @@ downloading files. The output PDF document will be placed at the path
 `build/default/default.pdf` relative to your document directory:
 
 ```sh
-$ ls -l build/default/
+ls -l build/default/
 ```
 
 If you’re familiar with traditional TeX engines, you’ll have noticed that

--- a/docs/src/getting-started/install.md
+++ b/docs/src/getting-started/install.md
@@ -48,7 +48,7 @@ You’ll know that you’re set up when you can go to your computer’s command 
 and run:
 
 ```sh
-$ tectonic --help
+tectonic --help
 ```
 
 and the result is that you get a printout of information about different options

--- a/docs/src/getting-started/unicode.md
+++ b/docs/src/getting-started/unicode.md
@@ -85,7 +85,7 @@ command:
 Now rebuild your document:
 
 ```sh
-$ tectonic -X build
+tectonic -X build
 ```
 
 You’ll probably see Tectonic download some files: namely, the new font files
@@ -118,7 +118,7 @@ copy-paste in the following [verse][bateau] with accented characters:
 Rebuild your document and see your new text in the output:
 
 ```sh
-$ tectonic -X build
+tectonic -X build
 ```
 
 *Whatever*, you might say. *I know how to get these accented characters with TeX

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ in the `docs/` subdirectory of [the main tectonic repository]. To make and view
 changes, all you need to do is [install mdbook], then run the command:
 
 ```sh
-$ mdbook serve
+mdbook serve
 ```
 
 in the `docs/` directory.

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -100,14 +100,14 @@ Conda packaging project. To install Tectonic you must activate conda-forge,
 which can be done temporarily like so:
 
 ```sh
-$ conda install -c conda-forge tectonic
+conda install -c conda-forge tectonic
 ```
 
 ### Arch Linux
 
 For users of [Arch Linux], there are two Tectonic packages available: [tectonic][arch-tectonic] from the official repositories, which can be installed with
 ```sh
-$ sudo pacman -S tectonic
+sudo pacman -S tectonic
 ```
 and [tectonic-git][arch-tectonic-git] from the [AUR].
 
@@ -122,7 +122,7 @@ There is a `tectonic` package in [Homebrew](https://brew.sh/). If you already
 have Homebrew installed, installing Tectonic should be as simple as:
 
 ```sh
-$ brew install tectonic
+brew install tectonic
 ```
 
 We also have instructions about [installing Tectonic’s dependencies using
@@ -137,7 +137,7 @@ There is a `tectonic` port in [MacPorts](https://www.macports.org/). If you
 already have MacPorts installed, installing Tectonic should be as simple as:
 
 ```sh
-$ sudo port install tectonic
+sudo port install tectonic
 ```
 
 ### nix or nixOS
@@ -145,14 +145,14 @@ $ sudo port install tectonic
 If you’re using [nix], you can imperatively install [`tectonic`][nix-tectonic] with:
 
 ```sh
-$ nix-env -f '<nixpkgs>' -iA tectonic
+nix-env -f '<nixpkgs>' -iA tectonic
 ```
 
 in your shell. You can also create a temporary environment using
 [`nix-shell`](https://nixos.org/nix/manual/#sec-nix-shell):
 
 ```sh
-$ nix-shell '<nixpkgs>' -A tectonic
+nix-shell '<nixpkgs>' -A tectonic
 ```
 
 [nix]: https://nixos.org/
@@ -164,7 +164,7 @@ Void Linux has a `tectonic` package in the [void-packages] repository. To
 install it, run:
 
 ```sh
-$ sudo xbps-install -S tectonic
+sudo xbps-install -S tectonic
 ```
 
 [void-packages]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/tectonic/template
@@ -177,7 +177,7 @@ You can always compile Tectonic yourself. If your system has C++ and Rust
 compilers installed, this may be as simple as running:
 
 ```sh
-$ cargo install tectonic
+cargo install tectonic
 ```
 
 However, Tectonic requires various C/C++ support libraries that may not be

--- a/docs/src/v2cli/bundle.md
+++ b/docs/src/v2cli/bundle.md
@@ -28,7 +28,7 @@ tectonic -X bundle cat <filename>
 #### Example
 
 ```sh
-$ tectonic -X bundle cat latex.ltx
+tectonic -X bundle cat latex.ltx
 %%
 %% This is file `latex.ltx',
 %% generated with the docstrip utility.
@@ -55,7 +55,7 @@ tectonic -X bundle search [term]
 #### Example
 
 ```sh
-$ tectonic -X bundle search minted
+tectonic -X bundle search minted
 minted1.sty
 tcbminted.code.tex
 minted.4ht


### PR DESCRIPTION
The dollar signs `$` in the docs' shell commands are copied when clicking the `copy to clipboard` button.
They then get pasted into the terminal when I'm trying to copy the command over. 

If dollar signs are needed to highlight that the command belongs in the terminal, I believe that there are ways to do that with style updates.