### PR TITLE
Add tectonic-on-arxiv as Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,7 @@ jobs:
     needs: prep
     uses: ./.github/workflows/build_and_test.yml
     secrets: inherit
+  tectonic-on-arxiv:
+    needs: prep
+    uses: ./.github/workflows/tectonic-on-arxiv.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,3 @@ jobs:
 #    needs: prep
 #    uses: ./.github/workflows/build_and_test.yml
 #    secrets: inherit
-  tectonic-on-arxiv:
-    needs: prep
-    uses: ./.github/workflows/tectonic-on-arxiv.yml
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   prep:
     uses: ./.github/workflows/prep.yml
-  build_and_test:
-    needs: prep
-    uses: ./.github/workflows/build_and_test.yml
-    secrets: inherit
+#  build_and_test:
+#    needs: prep
+#    uses: ./.github/workflows/build_and_test.yml
+#    secrets: inherit
   tectonic-on-arxiv:
     needs: prep
     uses: ./.github/workflows/tectonic-on-arxiv.yml

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,0 +1,12 @@
+name: "Tectonic on arXiv"
+
+on: [ workflow_call ]
+
+jobs:
+  tectonic-on-arxiv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Tectonic-on-ArXiv
+        uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Load Dataset
         run: |
           s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
-          tar -xzvf 1702.tar.gz
+          mkdir datasets
+          tar -xzvf 1702.tar.gz -C datasets
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,6 +1,7 @@
 name: "Tectonic on arXiv"
 
-on: [ workflow_call ]
+on:
+  pull_request_target:
 
 jobs:
   tectonic-on-arxiv:
@@ -10,6 +11,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up s3
         uses: s3-actions/s3cmd@v3.0.0
         with:

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -8,5 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -10,5 +10,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set up s3
+        uses: s3-actions/s3cmd@v3.0.0
+        with:
+          provider: cloudflare
+          access_key: ${{ secrets.CLOUDFLARE_ACCESS_KEY }}
+          secret_key: ${{ secrets.CLOUDFLARE_SECRET_KEY }}
+      - name: Load Dataset
+        run: |
+          s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
+          tar -xzvf 1702.tar.gz
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -16,6 +16,7 @@ jobs:
           provider: cloudflare
           access_key: ${{ secrets.CLOUDFLARE_ACCESS_KEY }}
           secret_key: ${{ secrets.CLOUDFLARE_SECRET_KEY }}
+          account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
           s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz


### PR DESCRIPTION
This is a WIP idea to port tectonic-on-arxiv to use the actions workflow, allowing us to rely on github's artifacts and compute.

@Mrmaxmeier for thoughts here - as this is your brainchild primarily.