### PR TITLE
Add tectonic-on-arxiv github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ on:
 jobs:
   prep:
     uses: ./.github/workflows/prep.yml
-#  build_and_test:
-#    needs: prep
-#    uses: ./.github/workflows/build_and_test.yml
-#    secrets: inherit
-#  deploy:
-#    needs: build_and_test
-#    if: ${{ github.event_name == 'push' }}
-#    uses: ./.github/workflows/deploy.yml
-#    with:
-#      is-dev: ${{ github.ref_name == 'master' }}
-#      is-release: ${{ github.ref_name == 'rc' }}
-#    secrets: inherit
+  build_and_test:
+    needs: prep
+    uses: ./.github/workflows/build_and_test.yml
+    secrets: inherit
+  deploy:
+    needs: build_and_test
+    if: ${{ github.event_name == 'push' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      is-dev: ${{ github.ref_name == 'master' }}
+      is-release: ${{ github.ref_name == 'rc' }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ on:
 jobs:
   prep:
     uses: ./.github/workflows/prep.yml
-  build_and_test:
-    needs: prep
-    uses: ./.github/workflows/build_and_test.yml
-    secrets: inherit
-  deploy:
-    needs: build_and_test
-    if: ${{ github.event_name == 'push' }}
-    uses: ./.github/workflows/deploy.yml
-    with:
-      is-dev: ${{ github.ref_name == 'master' }}
-      is-release: ${{ github.ref_name == 'rc' }}
-    secrets: inherit
+#  build_and_test:
+#    needs: prep
+#    uses: ./.github/workflows/build_and_test.yml
+#    secrets: inherit
+#  deploy:
+#    needs: build_and_test
+#    if: ${{ github.event_name == 'push' }}
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      is-dev: ${{ github.ref_name == 'master' }}
+#      is-release: ${{ github.ref_name == 'rc' }}
+#    secrets: inherit

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master
         with:
-          head: |
+          head: |-
             ${{ case(
-              github.event_name == "pull_request", github.event.pull_request.head.sha,
-              github.event_name == "workflow_dispatch", github.sha,
+              github.event_name == 'pull_request', github.event.pull_request.head.sha,
+              github.event_name == 'workflow_dispatch', github.sha,
             ) }}
-          base: |
+          base: |-
             ${{ case(
-              github.event_name == "pull_request", github.event.pull_request.base.sha,
-              github.event_name == "workflow_dispatch", inputs.base,
+              github.event_name == 'pull_request', github.event.pull_request.base.sha,
+              github.event_name == 'workflow_dispatch', inputs.base,
             }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,0 +1,12 @@
+name: "Tectonic on arXiv"
+
+on: [ workflow_call ]
+
+jobs:
+  tectonic-on-arxiv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Tectonic-on-ArXiv
+        uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -21,7 +21,7 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          s3cmd get ${{ env.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
+          s3cmd get ${{ vars.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
           mkdir datasets
           tar -xzvf 1702.tar.gz -C datasets
       - name: Tectonic-on-ArXiv

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Load Dataset
         run: |
           s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
-          tar -xzvf 1702.tar.gz
+          mkdir datasets
+          tar -xzvf 1702.tar.gz -C datasets
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -21,10 +21,8 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          s3cmd get "$CLOUDFLARE_URL/1702.tar.gz" 1702.tar.gz
+          s3cmd get "s3://tectonic-on-arxiv/1702.tar.gz" 1702.tar.gz
           mkdir datasets
           tar -xzvf 1702.tar.gz -C datasets
-        env:
-          CLOUDFLARE_URL: ${{ vars.CLOUDFLARE_URL }}
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,7 +1,7 @@
 name: "Tectonic on arXiv"
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   tectonic-on-arxiv:

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -2,6 +2,12 @@ name: "Tectonic on arXiv"
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      base:
+        description: "Base branch to compare this run against"
+        required: false
+        default: ""
 
 jobs:
   tectonic-on-arxiv:
@@ -27,4 +33,13 @@ jobs:
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master
         with:
-          head: ${{ github.event.pull_request.head.sha }}
+          head: |
+            ${{ case(
+              github.event_name == "pull_request", github.event.pull_request.head.sha,
+              github.event_name == "workflow_dispatch", github.sha,
+            ) }}
+          base: |
+            ${{ case(
+              github.event_name == "pull_request", github.event.pull_request.base.sha,
+              github.event_name == "workflow_dispatch", inputs.base,
+            }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -21,7 +21,7 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
+          s3cmd get ${{ env.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
           mkdir datasets
           tar -xzvf 1702.tar.gz -C datasets
       - name: Tectonic-on-ArXiv

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,6 +1,7 @@
 name: "Tectonic on arXiv"
 
-on: [ workflow_call ]
+on:
+  pull_request_target:
 
 jobs:
   tectonic-on-arxiv:
@@ -10,6 +11,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up s3
         uses: s3-actions/s3cmd@v3.0.0
         with:

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -26,3 +26,5 @@ jobs:
           tar -xzvf 1702.tar.gz -C datasets
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master
+        with:
+          head: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -21,8 +21,10 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          s3cmd get ${{ vars.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
+          s3cmd get "$CLOUDFLARE_URL/1702.tar.gz" 1702.tar.gz
           mkdir datasets
           tar -xzvf 1702.tar.gz -C datasets
+        env:
+          CLOUDFLARE_URL: ${{ vars.CLOUDFLARE_URL }}
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -37,9 +37,11 @@ jobs:
             ${{ case(
               github.event_name == 'pull_request', github.event.pull_request.head.sha,
               github.event_name == 'workflow_dispatch', github.sha,
+              github.sha
             ) }}
           base: |-
             ${{ case(
               github.event_name == 'pull_request', github.event.pull_request.base.sha,
               github.event_name == 'workflow_dispatch', inputs.base,
+              ''
             }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -8,5 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -10,5 +10,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Set up s3
+        uses: s3-actions/s3cmd@v3.0.0
+        with:
+          provider: cloudflare
+          access_key: ${{ secrets.CLOUDFLARE_ACCESS_KEY }}
+          secret_key: ${{ secrets.CLOUDFLARE_SECRET_KEY }}
+      - name: Load Dataset
+        run: |
+          s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz
+          tar -xzvf 1702.tar.gz
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -16,6 +16,7 @@ jobs:
           provider: cloudflare
           access_key: ${{ secrets.CLOUDFLARE_ACCESS_KEY }}
           secret_key: ${{ secrets.CLOUDFLARE_SECRET_KEY }}
+          account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
           s3cmd get ${{ secrets.CLOUDFLARE_URL }}/1702.tar.gz 1702.tar.gz

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -43,5 +43,5 @@ jobs:
             ${{ case(
               github.event_name == 'pull_request', github.event.pull_request.base.sha,
               github.event_name == 'workflow_dispatch', inputs.base,
-              ''
+              null
             }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -43,5 +43,5 @@ jobs:
             ${{ case(
               github.event_name == 'pull_request', github.event.pull_request.base.sha,
               github.event_name == 'workflow_dispatch', inputs.base,
-              null
-            }}
+              ''
+            ) }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -55,7 +55,12 @@ jobs:
         with:
           head: ${{ env.HEAD_SHA }}
           base: ${{ env.BASE_SHA }}
-      - name: Upload Report
+      - name: Upload Report to S3
         if: ${{ env.BASE_SHA == '' }}
         run: |
-          s3cmd put "${{ env.HEAD_SHA }}.jsonl" "s3://tectonic-on-arxiv/reports/${{ env.HEAD_SHA }}.jsonl"
+          s3cmd put "reports/${{ env.HEAD_SHA }}.jsonl" "s3://tectonic-on-arxiv/reports/${{ env.HEAD_SHA }}.jsonl"
+      - name: Upload Report Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: toa-report
+          path: reports/${{ env.HEAD_SHA }}.jsonl

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Load Base Report
         if: ${{ env.BASE_SHA != '' }}
         run: |
-          s3cmd get "s3://tectonic-on-arxiv/reports/${{ env.BASE_SHA }}.jsonl" reports/${{ env.BASE_SHA }}.jsonl
+          s3cmd get "s3://tectonic-on-arxiv/reports/${{ env.BASE_SHA }}.jsonl" reports/${{ env.BASE_SHA }}.jsonl || echo "Failed to load base"
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master
         with:

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -41,9 +41,8 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          mkdir reports
-          mkdir datasets
-          mkdir objects
+          pwd
+          mkdir datasets reports objects
           
           s3cmd get "s3://tectonic-on-arxiv/1702.tar.gz" 1702.tar.gz
           tar -xzvf 1702.tar.gz -C datasets

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -9,6 +9,20 @@ on:
         required: false
         default: ""
 
+env:
+  HEAD_SHA: |-
+    ${{ case(
+      github.event_name == 'pull_request', github.event.pull_request.head.sha,
+      github.event_name == 'workflow_dispatch', github.sha,
+      github.sha
+    ) }}
+  BASE_SHA: |-
+    ${{ case(
+      github.event_name == 'pull_request', github.event.pull_request.base.sha,
+      github.event_name == 'workflow_dispatch', inputs.base,
+      ''
+    ) }}
+
 jobs:
   tectonic-on-arxiv:
     runs-on: ubuntu-latest
@@ -27,21 +41,21 @@ jobs:
           account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Load Dataset
         run: |
-          s3cmd get "s3://tectonic-on-arxiv/1702.tar.gz" 1702.tar.gz
+          mkdir reports
           mkdir datasets
+          
+          s3cmd get "s3://tectonic-on-arxiv/1702.tar.gz" 1702.tar.gz
           tar -xzvf 1702.tar.gz -C datasets
+      - name: Load Base Report
+        if: ${{ env.BASE_SHA != '' }}
+        run: |
+          s3cmd get "s3://tectonic-on-arxiv/reports/${{ env.BASE_SHA }}.jsonl" reports/${{ env.BASE_SHA }}.jsonl
       - name: Tectonic-on-ArXiv
         uses: craftspider/tectonic-on-arxiv@master
         with:
-          head: |-
-            ${{ case(
-              github.event_name == 'pull_request', github.event.pull_request.head.sha,
-              github.event_name == 'workflow_dispatch', github.sha,
-              github.sha
-            ) }}
-          base: |-
-            ${{ case(
-              github.event_name == 'pull_request', github.event.pull_request.base.sha,
-              github.event_name == 'workflow_dispatch', inputs.base,
-              ''
-            ) }}
+          head: ${{ env.HEAD_SHA }}
+          base: ${{ env.BASE_SHA }}
+      - name: Upload Report
+        if: ${{ env.BASE_SHA == '' }}
+        run: |
+          s3cmd put "${{ env.HEAD_SHA }}.jsonl" "s3://tectonic-on-arxiv/reports/${{ env.HEAD_SHA }}.jsonl"

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           s3cmd put "reports/${{ env.HEAD_SHA }}.jsonl" "s3://tectonic-on-arxiv/reports/${{ env.HEAD_SHA }}.jsonl"
       - name: Upload Report Artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: toa-report

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           mkdir reports
           mkdir datasets
+          mkdir objects
           
           s3cmd get "s3://tectonic-on-arxiv/1702.tar.gz" 1702.tar.gz
           tar -xzvf 1702.tar.gz -C datasets

--- a/.github/workflows/tectonic-on-arxiv.yml
+++ b/.github/workflows/tectonic-on-arxiv.yml
@@ -1,7 +1,6 @@
 name: "Tectonic on arXiv"
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       base:


### PR DESCRIPTION
This is a WIP idea to port tectonic-on-arxiv to use the actions workflow, allowing us to rely on github's artifacts and compute.

@Mrmaxmeier for thoughts here - as this is your brainchild primarily.

Some elaboration on specific ideas:

- We can compare runs using artifacts (hardest bit - finding artifacts for a commit is non-trivial)
- Markdown run results display the diff, I haven't tested yet but I hope they support HTML collapsibles
- If a run is missing, maybe possible to trigger the workflow for it, not sure
- With manual workflow triggers, people can request a comparison of any two commits hopefully easily
- Dataset has to be stored outline in an s3 bucket