### PR TITLE
Drop error-chain dep, switch binary to use `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,21 +146,6 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
 ]
 
 [[package]]
@@ -724,16 +700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
 name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,12 +949,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix-actor"
@@ -1818,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2121,15 +2081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2857,12 +2808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3330,7 +3275,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "digest-io",
- "error-chain",
  "filetime",
  "flate2",
  "lazy_static",
@@ -4133,9 +4077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4146,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4156,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4166,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4179,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4308,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,6 @@ members = [
 ]
 
 [workspace.lints.rust]
-# FIXME(CraftSpider): Switch from error-chain to a newer package, as it's a deprecated project
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_error_description_deprecated)'] }
 missing_docs = "deny"
 
 [workspace.lints.clippy]
@@ -76,7 +74,6 @@ crate-type = ["rlib"]
 [dependencies]
 byte-unit = "^5.0"
 cfg-if = "1.0"
-error-chain = "^0.12"
 flate2 = { version = "^1.0.19", default-features = false, features = ["zlib"] }
 lazy_static = "^1.4"
 open = "^5.0"

--- a/crates/mac_core/src/array.rs
+++ b/crates/mac_core/src/array.rs
@@ -65,9 +65,9 @@ impl<T: CoreType> CFArray<T> {
         // SAFETY: Internal pointer is guaranteed valid. Index has been verified in-bounds.
         let value =
             unsafe { sys::CFArrayGetValueAtIndex(self.0.cast().as_ptr(), index as sys::CFIndex) };
+        let ptr = NonNull::new(value.cast_mut()).unwrap();
         // SAFETY: The returned value is a valid CFTypeRef for type T.
         //         new_borrowed calls CFRetain, giving us ownership of a new reference.
-        let ptr = NonNull::new(value.cast_mut()).unwrap();
         unsafe { T::new_borrowed(ptr.cast()) }
     }
 }

--- a/crates/mac_core/src/lib.rs
+++ b/crates/mac_core/src/lib.rs
@@ -173,18 +173,22 @@ mod tests {
         let arr = CFArray::<CFType>::empty();
         let ty = arr.into_ty();
 
+        // SAFETY: Same type as original array
         assert!(unsafe { ty.downcast::<CFArray<CFType>>() }.is_ok());
 
         let arr = CFArray::<CFType>::empty();
         let ty = arr.into_ty();
+        // SAFETY: String has no generics
         assert!(unsafe { ty.downcast::<CFString>() }.is_err());
 
         let str = CFString::new("");
         let ty = str.into_ty();
+        // SAFETY: String has no generics
         assert!(unsafe { ty.downcast::<CFString>() }.is_ok());
 
         let str = CFString::new("");
         let ty = str.into_ty();
+        // SAFETY: Not a CFArray, so generic doesn't matter
         assert!(unsafe { ty.downcast::<CFArray<CFString>>() }.is_err());
     }
 }

--- a/src/bin/tectonic/compile.rs
+++ b/src/bin/tectonic/compile.rs
@@ -8,18 +8,17 @@
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use tectonic_bridge_core::{SecuritySettings, SecurityStance};
+use tectonic_bundles::detect_bundle;
+use tectonic_errors::{Error, Result};
 
+use tectonic::errors::EngineError;
 use tectonic::{
     config::{maybe_return_test_bundle, PersistentConfig},
     driver::{OutputFormat, PassSetting, ProcessingSession, ProcessingSessionBuilder},
-    errmsg,
-    errors::{ErrorKind, Result},
     status::StatusBackend,
     tt_error, tt_note,
     unstable_opts::{UnstableArg, UnstableOptions},
 };
-
-use tectonic_bundles::detect_bundle;
 
 #[derive(Debug, Parser)]
 pub struct CompileOptions {
@@ -145,28 +144,28 @@ impl CompileOptions {
             if let Some(fname) = input_path.file_name() {
                 sess_builder.tex_input_name(&fname.to_string_lossy());
             } else {
-                return Err(errmsg!(
+                return Err(Error::msg(format!(
                     "can't figure out a basename for input path \"{}\"",
                     input_path.to_string_lossy()
-                ));
+                )));
             };
 
             if let Some(par) = input_path.parent() {
                 sess_builder.output_dir(par);
             } else {
-                return Err(errmsg!(
+                return Err(Error::msg(format!(
                     "can't figure out a parent directory for input path \"{}\"",
                     input_path.to_string_lossy()
-                ));
+                )));
             }
         }
 
         if let Some(output_dir) = self.outdir {
             if !output_dir.is_dir() {
-                return Err(errmsg!(
+                return Err(Error::msg(format!(
                     "output directory \"{}\" does not exist",
                     output_dir.display()
-                ));
+                )));
             }
             sess_builder.output_dir(output_dir);
         }
@@ -194,7 +193,9 @@ impl CompileOptions {
             } else if let Some(bundle) = detect_bundle(bundle.clone(), self.only_cached, None)? {
                 sess_builder.bundle(bundle);
             } else {
-                return Err(errmsg!("`{bundle}` doesn't specify a valid bundle."));
+                return Err(Error::msg(format!(
+                    "`{bundle}` doesn't specify a valid bundle."
+                )));
             }
         } else if let Ok(bundle) = maybe_return_test_bundle(None) {
             // TODO: this is ugly too.
@@ -216,20 +217,20 @@ pub(crate) fn run_and_report(
     let result = sess.run(status);
 
     if let Err(e) = &result {
-        if let ErrorKind::EngineError(engine) = e.kind() {
+        if let Some(err) = e.downcast_ref::<EngineError>() {
             let output = sess.get_stdout_content();
 
             if output.is_empty() {
                 tt_error!(
                     status,
                     "something bad happened inside {}, but no output was logged",
-                    engine
+                    err.engine()
                 );
             } else {
                 tt_error!(
                     status,
                     "something bad happened inside {}; its output follows:\n",
-                    engine
+                    err.engine()
                 );
                 status.dump_error_logs(&output);
             }

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -8,9 +8,9 @@ use clap::{Parser, ValueEnum};
 use std::{env, io::IsTerminal, process};
 use tectonic_status_base::plain::PlainStatusBackend;
 
+use tectonic::errors::dump_uncolorized;
 use tectonic::{
     config::PersistentConfig,
-    errors::SyncError,
     status::{
         termcolor::TermcolorStatusBackend,
         {ChatterLevel, StatusBackend},
@@ -160,7 +160,7 @@ fn main() {
             // have yet. If we can't even load the config we might really be
             // in trouble, so it seems safest to keep things simple anyway and
             // just use bare stderr without colorization.
-            e.dump_uncolorized();
+            dump_uncolorized(&e);
             process::exit(1);
         }
     };
@@ -181,7 +181,7 @@ fn main() {
     // parallels various bits of the `error_chain` crate.
 
     if let Err(e) = args.compile.execute(config, &mut *status) {
-        status.report_error(&SyncError::new(e).into());
+        status.report_error(&e);
         process::exit(1)
     }
 }

--- a/src/bin/tectonic/main.rs
+++ b/src/bin/tectonic/main.rs
@@ -160,7 +160,7 @@ fn main() {
             // have yet. If we can't even load the config we might really be
             // in trouble, so it seems safest to keep things simple anyway and
             // just use bare stderr without colorization.
-            dump_uncolorized(&e);
+            dump_uncolorized(e);
             process::exit(1);
         }
     };

--- a/src/bin/tectonic/v2cli/commands/build.rs
+++ b/src/bin/tectonic/v2cli/commands/build.rs
@@ -3,11 +3,11 @@ use tectonic::{
     config::is_config_test_mode_activated,
     config::PersistentConfig,
     docmodel::{DocumentExt, DocumentSetupOptions},
-    errors::Result,
     tt_error, tt_note,
 };
 use tectonic_bridge_core::{SecuritySettings, SecurityStance};
 use tectonic_docmodel::workspace::Workspace;
+use tectonic_errors::Result;
 use tectonic_status_base::StatusBackend;
 
 use crate::v2cli::{CommandCustomizations, TectonicCommand};

--- a/src/bin/tectonic/v2cli/commands/bundle/create.rs
+++ b/src/bin/tectonic/v2cli/commands/bundle/create.rs
@@ -98,7 +98,7 @@ impl TectonicCommand for BundleCreateCommand {
                 Ok(_) => {}
                 Err(e) => {
                     error!("select job failed with error: {e}");
-                    return Err(e.into());
+                    return Err(e);
                 }
             };
         }
@@ -108,7 +108,7 @@ impl TectonicCommand for BundleCreateCommand {
                 Ok(_) => {}
                 Err(e) => {
                     error!("bundle packer failed with error: {e}");
-                    return Err(e.into());
+                    return Err(e);
                 }
             };
         }

--- a/src/bin/tectonic/v2cli/commands/bundle/mod.rs
+++ b/src/bin/tectonic/v2cli/commands/bundle/mod.rs
@@ -34,7 +34,7 @@ fn get_a_bundle(
 
         Err(e) => {
             if e.downcast_ref::<NoWorkspaceFoundError>().is_none() {
-                Err(e.into())
+                Err(e)
             } else {
                 tt_note!(
                     status,

--- a/src/bin/tectonic/v2cli/commands/bundle/mod.rs
+++ b/src/bin/tectonic/v2cli/commands/bundle/mod.rs
@@ -3,11 +3,11 @@ use create::BundleCreateCommand;
 use tectonic::{
     config::PersistentConfig,
     docmodel::{DocumentExt, DocumentSetupOptions},
-    errors::Result,
     tt_note,
 };
 use tectonic_bundles::Bundle;
 use tectonic_docmodel::workspace::Workspace;
+use tectonic_errors::Result;
 use tectonic_status_base::StatusBackend;
 
 use crate::v2cli::{CommandCustomizations, TectonicCommand};

--- a/src/bin/tectonic/v2cli/commands/dump.rs
+++ b/src/bin/tectonic/v2cli/commands/dump.rs
@@ -6,11 +6,11 @@ use tectonic::{
     ctry,
     docmodel::{DocumentExt, DocumentSetupOptions},
     driver::PassSetting,
-    errors::Result,
     tt_error,
 };
 use tectonic_bridge_core::{SecuritySettings, SecurityStance};
 use tectonic_docmodel::workspace::Workspace;
+use tectonic_errors::{Error, Result};
 use tectonic_status_base::StatusBackend;
 
 use crate::v2cli::{CommandCustomizations, TectonicCommand};
@@ -100,9 +100,9 @@ impl TectonicCommand for DumpCommand {
                 return Ok(1);
             }
         } else {
-            let info = files
-                .get(&self.filename)
-                .ok_or_else(|| format!("no such intermediate file `{}`", self.filename))?;
+            let info = files.get(&self.filename).ok_or_else(|| {
+                Error::msg(format!("no such intermediate file `{}`", self.filename))
+            })?;
             ctry!(
                 std::io::stdout().write_all(&info.data[..]);
                 "error dumping intermediate file `{}`", self.filename

--- a/src/bin/tectonic/v2cli/commands/new.rs
+++ b/src/bin/tectonic/v2cli/commands/new.rs
@@ -1,10 +1,9 @@
 use clap::Parser;
 use std::env;
 use std::path::PathBuf;
-use tectonic::{
-    config::PersistentConfig, ctry, docmodel::WorkspaceCreatorExt, errors::Result, tt_note,
-};
+use tectonic::{config::PersistentConfig, ctry, docmodel::WorkspaceCreatorExt, tt_note};
 use tectonic_docmodel::workspace::WorkspaceCreator;
+use tectonic_errors::Result;
 use tectonic_status_base::StatusBackend;
 
 use crate::v2cli::{CommandCustomizations, TectonicCommand};

--- a/src/bin/tectonic/v2cli/commands/show.rs
+++ b/src/bin/tectonic/v2cli/commands/show.rs
@@ -1,5 +1,6 @@
 use clap::{CommandFactory, Parser};
-use tectonic::{config::PersistentConfig, errors::Result};
+use tectonic::config::PersistentConfig;
+use tectonic_errors::Result;
 use tectonic_io_base::app_dirs;
 use tectonic_status_base::StatusBackend;
 

--- a/src/bin/tectonic/v2cli/commands/watch.rs
+++ b/src/bin/tectonic/v2cli/commands/watch.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use std::time::Duration;
 use std::{env, path::PathBuf, sync::Arc};
-use tectonic::{config::PersistentConfig, errors::Result, tt_error};
+use tectonic::{config::PersistentConfig, tt_error};
+use tectonic_errors::Result;
 use tectonic_status_base::StatusBackend;
 use tokio::runtime;
 use watchexec::command::Program;

--- a/src/bin/tectonic/v2cli/mod.rs
+++ b/src/bin/tectonic/v2cli/mod.rs
@@ -70,7 +70,7 @@ pub fn v2_main(effective_args: &[OsString]) {
     let config = match PersistentConfig::open(false) {
         Ok(c) => c,
         Err(ref e) => {
-            dump_uncolorized(&e);
+            dump_uncolorized(e);
             process::exit(1);
         }
     };

--- a/src/bin/tectonic/v2cli/mod.rs
+++ b/src/bin/tectonic/v2cli/mod.rs
@@ -4,18 +4,6 @@
 //! The "v2cli" command-line interface -- a "multitool" interface resembling
 //! Cargo, as compared to the classic "rustc-like" CLI.
 
-use clap::{Parser, Subcommand};
-use std::{env, ffi::OsString, fs, path::Path, path::PathBuf, process};
-use tectonic::{
-    config::PersistentConfig,
-    errors::{Result, SyncError},
-    status::{termcolor::TermcolorStatusBackend, ChatterLevel, StatusBackend},
-    tt_note,
-};
-use tectonic_errors::prelude::anyhow;
-use tectonic_status_base::plain::PlainStatusBackend;
-use tracing::level_filters::LevelFilter;
-
 use self::commands::{
     build::BuildCommand,
     bundle::BundleCommand,
@@ -24,6 +12,17 @@ use self::commands::{
     show::ShowCommand,
     watch::WatchCommand,
 };
+use clap::{Parser, Subcommand};
+use std::{env, ffi::OsString, fs, path::Path, path::PathBuf, process};
+use tectonic::errors::dump_uncolorized;
+use tectonic::{
+    config::PersistentConfig,
+    status::{termcolor::TermcolorStatusBackend, ChatterLevel, StatusBackend},
+    tt_note,
+};
+use tectonic_errors::{prelude::anyhow, Result};
+use tectonic_status_base::plain::PlainStatusBackend;
+use tracing::level_filters::LevelFilter;
 
 mod commands;
 
@@ -71,7 +70,7 @@ pub fn v2_main(effective_args: &[OsString]) {
     let config = match PersistentConfig::open(false) {
         Ok(c) => c,
         Err(ref e) => {
-            e.dump_uncolorized();
+            dump_uncolorized(&e);
             process::exit(1);
         }
     };
@@ -145,7 +144,7 @@ pub fn v2_main(effective_args: &[OsString]) {
     process::exit(match r {
         Ok(c) => c,
         Err(e) => {
-            status.report_error(&SyncError::new(e).into());
+            status.report_error(&e);
             1
         }
     })

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub fn maybe_return_test_bundle(bundle: Option<String>) -> Result<Box<dyn Bundle
     if is_test_bundle_wanted(bundle) {
         Ok(Box::<crate::test_util::TestBundle>::default())
     } else {
-        Err(Error::msg("not asking for the default test bundle").into())
+        Err(Error::msg("not asking for the default test bundle"))
     }
 }
 
@@ -144,9 +144,9 @@ impl PersistentConfig {
         }
 
         if self.default_bundles.len() != 1 {
-            return Err(
-                Error::msg("exactly one default_bundle item must be specified (for now)").into(),
-            );
+            return Err(Error::msg(
+                "exactly one default_bundle item must be specified (for now)",
+            ));
         }
 
         Ok(

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,9 +16,8 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use tectonic_bundles::{detect_bundle, Bundle};
+use tectonic_errors::{Error, Result};
 use tectonic_io_base::app_dirs;
-
-use crate::errors::{ErrorKind, Result};
 
 /// Awesome hack time!!!
 ///
@@ -55,7 +54,7 @@ pub fn maybe_return_test_bundle(bundle: Option<String>) -> Result<Box<dyn Bundle
     if is_test_bundle_wanted(bundle) {
         Ok(Box::<crate::test_util::TestBundle>::default())
     } else {
-        Err(ErrorKind::Msg("not asking for the default test bundle".to_owned()).into())
+        Err(Error::msg("not asking for the default test bundle").into())
     }
 }
 
@@ -145,10 +144,9 @@ impl PersistentConfig {
         }
 
         if self.default_bundles.len() != 1 {
-            return Err(ErrorKind::Msg(
-                "exactly one default_bundle item must be specified (for now)".to_owned(),
-            )
-            .into());
+            return Err(
+                Error::msg("exactly one default_bundle item must be specified (for now)").into(),
+            );
         }
 
         Ok(

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -7,6 +7,7 @@
 //! `tectonic_docmodel` crate with the actual document-processing capabilities
 //! provided by the processing engines.
 
+use anyhow::Context;
 use std::{fmt::Write as FmtWrite, fs, io, path::PathBuf};
 use tectonic_bridge_core::SecuritySettings;
 use tectonic_bundles::{detect_bundle, Bundle};
@@ -14,12 +15,12 @@ use tectonic_docmodel::{
     document::{BuildTargetType, Document, InputFile},
     workspace::{Workspace, WorkspaceCreator},
 };
+use tectonic_errors::{Error, Result};
 use tectonic_geturl::{DefaultBackend, GetUrlBackend};
 
 use crate::{
-    config, ctry,
+    config,
     driver::{OutputFormat, PassSetting, ProcessingSessionBuilder},
-    errors::{ErrorKind, Result},
     status::StatusBackend,
     test_util, tt_note,
     unstable_opts::UnstableOptions,
@@ -110,7 +111,7 @@ impl DocumentExt for Document {
         status: &mut dyn StatusBackend,
     ) -> Result<ProcessingSessionBuilder> {
         let profile = self.outputs.get(output_profile).ok_or_else(|| {
-            ErrorKind::Msg(format!(
+            Error::msg(format!(
                 "unrecognized output profile name \"{output_profile}\""
             ))
         })?;
@@ -177,10 +178,12 @@ impl DocumentExt for Document {
 
         let mut output_dir = self.build_dir().to_owned();
         output_dir.push(output_profile);
-        ctry!(
-            fs::create_dir_all(&output_dir);
-            "couldn\'t create output directory `{}`", output_dir.display()
-        );
+        fs::create_dir_all(&output_dir).with_context(|| {
+            format!(
+                "couldn\'t create output directory `{}`",
+                output_dir.display()
+            )
+        })?;
         sess_builder.output_dir(&output_dir);
 
         Ok(sess_builder)

--- a/src/docmodel.rs
+++ b/src/docmodel.rs
@@ -218,6 +218,6 @@ impl WorkspaceCreatorExt for WorkspaceCreator {
             gub.resolve_url(&loc)?
         };
 
-        Ok(self.create(bundle_loc, Vec::new())?)
+        self.create(bundle_loc, Vec::new())
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1787,7 +1787,6 @@ impl ProcessingSession {
                 "incomprehensible format file name \"{}\"",
                 self.format_name
             ))
-            .into()
         });
         let stem = r?;
 
@@ -1812,10 +1811,10 @@ impl ProcessingSession {
             }
             Ok(TexOutcome::Errors) => {
                 tt_error!(status, "errors were issued by the TeX engine; use --print and/or --keep-logs for details.");
-                return Err(Error::msg("unhandled TeX engine error".to_owned()).into());
+                return Err(Error::msg("unhandled TeX engine error".to_owned()));
             }
             Err(e) => {
-                return Err(e.into());
+                return Err(e);
             }
         }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -13,6 +13,20 @@
 //! For an example of how to use this module, see `src/bin/tectonic/main.rs`,
 //! which contains tectonic's main CLI program.
 
+use crate::errors::EngineError;
+use crate::{
+    ctry,
+    io::{
+        format_cache::FormatCache,
+        memory::{MemoryFileCollection, MemoryIo},
+        InputOrigin,
+    },
+    status::StatusBackend,
+    tt_error, tt_note, tt_warning,
+    unstable_opts::UnstableOptions,
+    BibtexEngine, Spx2HtmlEngine, TexEngine, TexOutcome, XdvipdfmxEngine,
+};
+use anyhow::Context;
 use byte_unit::{Byte, UnitType};
 use quick_xml::{events::Event, NsReader};
 use std::{
@@ -29,6 +43,7 @@ use std::{
 use tectonic_bridge_core::{CoreBridgeLauncher, DriverHooks, SecuritySettings, SystemRequestError};
 use tectonic_bundles::Bundle;
 use tectonic_engine_spx2html::AssetSpecification;
+use tectonic_errors::{Error, Result};
 use tectonic_io_base::{
     digest::DigestData,
     filesystem::{FilesystemIo, FilesystemPrimaryInputIo},
@@ -36,20 +51,6 @@ use tectonic_io_base::{
     InputHandle, IoProvider, OpenResult, OutputHandle,
 };
 use which::which;
-
-use crate::{
-    ctry, errmsg,
-    errors::{ChainErrCompatExt, ErrorKind, Result},
-    io::{
-        format_cache::FormatCache,
-        memory::{MemoryFileCollection, MemoryIo},
-        InputOrigin,
-    },
-    status::StatusBackend,
-    tt_error, tt_note, tt_warning,
-    unstable_opts::UnstableOptions,
-    BibtexEngine, Spx2HtmlEngine, TexEngine, TexOutcome, XdvipdfmxEngine,
-};
 
 /// Different patterns with which files may have been accessed by the
 /// underlying engines. Once a file is marked as ReadThenWritten or
@@ -300,21 +301,20 @@ impl BridgeState {
         // Now that we're validated, write those files to disk so that the tool
         // can actually use them.
 
-        let tempdir = ctry!(
-            tempfile::Builder::new().tempdir();
-            "can't create temporary directory for external tool"
-        );
+        let tempdir = tempfile::Builder::new()
+            .tempdir()
+            .context("can't create temporary directory for external tool")?;
 
         {
             for name in &read_files {
                 // If a relative parent is found in the file to open, this fn
                 // does not properly handle that. Thus, throw an error.
                 if name.contains("../") {
-                    return Err(errmsg!(
+                    return Err(Error::msg(format!(
                         "relative parent paths are not supported for the \
                         external tool. Got path `{}`.",
-                        name
-                    ));
+                        name,
+                    )));
                 }
 
                 let mut ih = ctry!(
@@ -368,9 +368,12 @@ impl BridgeState {
             status.dump_error_logs(&output.stderr[..]);
 
             return if let Some(n) = output.status.code() {
-                Err(errmsg!("the external tool exited with error code {}", n))
+                Err(Error::msg(format!(
+                    "the external tool exited with error code {}",
+                    n
+                )))
             } else {
-                Err(errmsg!("the external tool was terminated by a signal"))
+                Err(Error::msg("the external tool was terminated by a signal"))
             };
         }
 
@@ -1125,10 +1128,10 @@ impl ProcessingSessionBuilder {
                 let parent = match p.parent() {
                     Some(parent) => parent.to_owned(),
                     None => {
-                        return Err(errmsg!(
+                        return Err(Error::msg(format!(
                             "can't figure out a parent directory for input path \"{}\"",
                             p.display()
-                        ));
+                        )));
                     }
                 };
 
@@ -1472,8 +1475,9 @@ impl ProcessingSession {
                 OpenResult::Ok(_) => false,
                 OpenResult::NotAvailable => true,
                 OpenResult::Err(e) => {
-                    return Err(e)
-                        .chain_err(|| format!("could not open format file {}", self.format_name));
+                    return Err(e).with_context(|| {
+                        format!("could not open format file {}", self.format_name)
+                    });
                 }
             }
         };
@@ -1779,7 +1783,7 @@ impl ProcessingSession {
         // one extension. As of 1.17, the compiler needs a type annotation for
         // some reason, which is why we use the `r` variable.
         let r: Result<&str> = self.format_name.split('.').next().ok_or_else(|| {
-            ErrorKind::Msg(format!(
+            Error::msg(format!(
                 "incomprehensible format file name \"{}\"",
                 self.format_name
             ))
@@ -1808,7 +1812,7 @@ impl ProcessingSession {
             }
             Ok(TexOutcome::Errors) => {
                 tt_error!(status, "errors were issued by the TeX engine; use --print and/or --keep-logs for details.");
-                return Err(ErrorKind::Msg("unhandled TeX engine error".to_owned()).into());
+                return Err(Error::msg("unhandled TeX engine error".to_owned()).into());
             }
             Err(e) => {
                 return Err(e.into());
@@ -1890,7 +1894,8 @@ impl ProcessingSession {
                     Some("errors were issued by the TeX engine, but were ignored; \
                          use --print and/or --keep-logs for details."),
             Err(e) =>
-                return Err(e.into()),
+                return Err(e)
+                    .with_context(|| EngineError::new("XeTeX")),
         };
 
         if !self.bs.mem.files.borrow().contains_key(&self.tex_xdv_path) {
@@ -1935,7 +1940,7 @@ impl ProcessingSession {
                 );
             }
             Err(e) => {
-                return Err(e.chain_err(|| ErrorKind::EngineError("BibTeX")));
+                return Err(e).with_context(|| EngineError::new("BibTeX"));
             }
         }
 
@@ -1973,7 +1978,9 @@ impl ProcessingSession {
                 engine.paper_spec(ps.clone());
             }
 
-            engine.process(&mut launcher, &self.tex_xdv_path, &self.tex_pdf_path)?;
+            engine
+                .process(&mut launcher, &self.tex_xdv_path, &self.tex_pdf_path)
+                .with_context(|| EngineError::new("xdvipdfmx"))?;
         }
 
         self.bs.mem.files.borrow_mut().remove(&self.tex_xdv_path);
@@ -1987,7 +1994,9 @@ impl ProcessingSession {
             match (self.html_emit_files, self.output_path.as_ref()) {
                 (true, Some(p)) => engine.output_base(p),
                 (false, _) => engine.do_not_emit_files(),
-                (true, None) => return Err(errmsg!("HTML output must be saved directly to disk")),
+                (true, None) => {
+                    return Err(Error::msg("HTML output must be saved directly to disk"))
+                }
             };
 
             if let Some(p) = self.html_assets_spec_path.as_ref() {
@@ -2001,7 +2010,9 @@ impl ProcessingSession {
             }
 
             status.note_highlighted("Running ", "spx2html", " ...");
-            engine.process_to_filesystem(&mut self.bs, status, &self.tex_xdv_path)?;
+            engine
+                .process_to_filesystem(&mut self.bs, status, &self.tex_xdv_path)
+                .with_context(|| EngineError::new("xdvipdfmx"))?;
         }
 
         self.bs.mem.files.borrow_mut().remove(&self.tex_xdv_path);

--- a/src/engines/bibtex.rs
+++ b/src/engines/bibtex.rs
@@ -7,7 +7,8 @@ use tectonic_bridge_core::CoreBridgeLauncher;
 use tectonic_engine_bibtex::{BibtexEngine as RealBibtexEngine, BibtexOutcome};
 
 use super::tex::TexOutcome;
-use crate::{errors::Result, unstable_opts::UnstableOptions};
+use crate::unstable_opts::UnstableOptions;
+use tectonic_errors::Result;
 
 /// A struct for invoking the `bibtex` engine.
 ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,29 +3,19 @@
 
 //! Tectonic error types and support code.
 
-// Silence warnings due to `error-chain` using `Error::cause` instead of `Error::source`. The
-// former was [deprecated in Rust 1.33](https://github.com/rust-lang/rust/pull/53533). The fix for
-// `error-chain` is in <https://github.com/rust-lang-nursery/error-chain/pull/255> and will
-// hopefully show up in a future version.
-#![allow(missing_docs)]
-
-use error_chain::error_chain;
+use std::fmt::Formatter;
 use std::{
-    ffi,
     fmt::{self, Debug, Display},
-    io,
-    io::Write,
-    num,
+    io::{self, Write},
     result::Result as StdResult,
-    str,
-    sync::{Arc, Mutex, Weak},
 };
-use tectonic_errors::Error as NewError;
-use zip::result::ZipError;
+pub use tectonic_errors::Error;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "toml")] {
+        /// Alias for [`toml::de::Error`]
         pub type ReadError = toml::de::Error;
+        /// Alias for [`toml::ser::Error`]
         pub type WriteError = toml::ser::Error;
     } else {
         use std::error;
@@ -54,128 +44,51 @@ cfg_if::cfg_if! {
     }
 }
 
-error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
-    }
-
-    foreign_links {
-        Io(io::Error);
-        Fmt(fmt::Error);
-        Nul(ffi::NulError);
-        ParseInt(num::ParseIntError);
-        Persist(tempfile::PersistError);
-        ConfigRead(ReadError);
-        ConfigWrite(WriteError);
-        NewStyle(NewError);
-        QuickXml(quick_xml::Error);
-        EncodingError(quick_xml::encoding::EncodingError);
-        Time(std::time::SystemTimeError);
-        Utf8(str::Utf8Error);
-        Xdv(tectonic_xdv::XdvError);
-        Zip(ZipError);
-    }
-
-    errors {
-        BadLength(expected: usize, observed: usize) {
-            description("the item is not the expected length")
-            display("expected length {}; found {}", expected, observed)
-        }
-
-        NotSeekable {
-            description("this stream is not seekable")
-            display("this stream is not seekable")
-        }
-
-        NotSizeable {
-            description("the size of this stream cannot be determined")
-            display("the size of this stream cannot be determined")
-        }
-
-        PathForbidden(path: String) {
-            description("access to this file path is forbidden")
-            display("access to the path {} is forbidden", path)
-        }
-
-        EngineError(engine: &'static str) {
-            description("some engine had an unrecoverable error")
-            display("the {} engine had an unrecoverable error", engine)
-        }
-    }
-}
-
-/// `chain_err` compatibility between our old and new error types
-pub trait ChainErrCompatExt<T> {
-    /// Chain this error with another
-    fn chain_err<F, K>(self, chainer: F) -> Result<T>
-    where
-        F: FnOnce() -> K,
-        K: Into<ErrorKind>;
-}
-
-impl<T> ChainErrCompatExt<T> for StdResult<T, NewError> {
-    fn chain_err<F, K>(self, chainer: F) -> Result<T>
-    where
-        F: FnOnce() -> K,
-        K: Into<ErrorKind>,
-    {
-        self.map_err(|e| {
-            let e: Error = e.into();
-            e.chain_err(chainer)
-        })
-    }
-}
-
-/// Use string formatting to create an `Error` of kind
-/// `errors::ErrorKind::Msg`.
-#[macro_export]
-macro_rules! errmsg {
-    ($( $fmt_args:expr ),*) => {
-        $crate::errors::ErrorKind::Msg(format!($( $fmt_args ),*)).into()
-    };
-}
-
 /// "Chained try" — like `try!`, but with the ability to add context to the error message.
 #[macro_export]
 macro_rules! ctry {
     ($op:expr ; $( $chain_fmt_args:expr ),*) => {{
         #[allow(unused_imports)]
-        use $crate::errors::{ChainErrCompatExt, ResultExt};
-        $op.chain_err(|| format!($( $chain_fmt_args ),*))?
+        use anyhow::Context;
+        $op.with_context(|| format!($( $chain_fmt_args ),*))?
     }}
 }
 
-impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        io::Error::other(err.to_string())
+/// Error context for when an underlying engine failed catastrophically.
+#[derive(Debug)]
+pub struct EngineError(&'static str);
+
+impl EngineError {
+    /// Create a new [`EngineError`], given the name of an engine
+    pub fn new(engine: &'static str) -> EngineError {
+        EngineError(engine)
+    }
+
+    /// Get the name of the engine for this context
+    pub fn engine(&self) -> &str {
+        self.0
     }
 }
 
-impl Error {
-    /// Write the information contained in this object to standard error in a
-    /// somewhat user-friendly form.
-    ///
-    /// The `error_chain` crate provides a Display impl for its Error objects
-    /// that ought to provide this functionality, but I have had enormous
-    /// trouble being able to use it. So instead we emulate their code. This
-    /// function is also paralleled by the implementation in
-    /// `status::termcolor::TermcolorStatusBackend`, which adds the sugar of
-    /// providing nice colorization if possible. This function should only be
-    /// used if a `StatusBackend` is not yet available in the running program.
-    pub fn dump_uncolorized(&self) {
-        let mut prefix = "error:";
-        let mut s = io::stderr();
-
-        for item in self.iter() {
-            writeln!(s, "{prefix} {item}").expect("write to stderr failed");
-            prefix = "caused by:";
-        }
-
-        if let Some(backtrace) = self.backtrace() {
-            writeln!(s, "debugging: backtrace follows:").expect("write to stderr failed");
-            writeln!(s, "{backtrace:?}").expect("write to stderr failed");
-        }
+impl Display for EngineError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "the {} engine had an unrecoverable error", self.0)
     }
+}
+
+/// Write the information contained in this object to standard error in a
+/// somewhat user-friendly form.
+///
+/// The `error_chain` crate provides a Display impl for its Error objects
+/// that ought to provide this functionality, but I have had enormous
+/// trouble being able to use it. So instead we emulate their code. This
+/// function is also paralleled by the implementation in
+/// `status::termcolor::TermcolorStatusBackend`, which adds the sugar of
+/// providing nice colorization if possible. This function should only be
+/// used if a `StatusBackend` is not yet available in the running program.
+pub fn dump_uncolorized(error: &Error) {
+    let mut s = io::stderr();
+    writeln!(s, "{:#}", error).expect("write to stderr failed");
 }
 
 /// The DefinitelySame trait is a helper trait implemented because Errors do
@@ -187,6 +100,7 @@ impl Error {
 /// be different, but also if we can't tell. It doesn't cover all cases, but
 /// it does cover the ones that come up in our test suite.
 pub trait DefinitelySame {
+    /// Return true if two items are definitely the same, false otherwise
     fn definitely_same(&self, other: &Self) -> bool;
 }
 
@@ -196,55 +110,14 @@ pub trait DefinitelySame {
 // our definition works for subtypes that are DefinitelySame but
 // not PartialEq too.
 //
-//impl<T: PartialEq> DefinitelySame for T {
-//    fn definitely_same(&self, other: &T) -> bool {
-//        self == other
-//    }
-//}
+// impl<T: PartialEq> DefinitelySame for T {
+//     fn definitely_same(&self, other: &T) -> bool {
+//         self == other
+//     }
+// }
+//
 
 impl DefinitelySame for Error {
-    fn definitely_same(&self, other: &Self) -> bool {
-        if !self.0.definitely_same(&other.0) {
-            return false;
-        }
-        self.1.definitely_same(&other.1)
-    }
-}
-
-impl DefinitelySame for error_chain::State {
-    fn definitely_same(&self, other: &Self) -> bool {
-        // We ignore backtraces
-        // We have to remove the Send bounds, which current Rust makes a bit annoying
-        self.next_error.definitely_same(&other.next_error)
-    }
-}
-
-impl DefinitelySame for ErrorKind {
-    fn definitely_same(&self, other: &Self) -> bool {
-        match self {
-            ErrorKind::Msg(ref s) => {
-                if let ErrorKind::Msg(ref o) = *other {
-                    s == o
-                } else {
-                    false
-                }
-            }
-
-            // Hacky for tex-outputs test
-            ErrorKind::NewStyle(ref s) => {
-                if let ErrorKind::NewStyle(ref o) = *other {
-                    s.to_string() == o.to_string()
-                } else {
-                    false
-                }
-            }
-
-            _ => false,
-        }
-    }
-}
-
-impl DefinitelySame for NewError {
     /// Hack alert! We only compare stringifications.
     fn definitely_same(&self, other: &Self) -> bool {
         self.to_string() == other.to_string()
@@ -289,142 +162,20 @@ impl<T: DefinitelySame, E: DefinitelySame> DefinitelySame for StdResult<T, E> {
     }
 }
 
-// SyncError copied from:
-// https://github.com/rust-lang-nursery/error-chain/issues/240
-//
-// This is needed to be able to turn error_chain errors into anyhow errors,
-// since the latter requires that they are sync.
-
-pub struct SyncError<T: 'static> {
-    inner: Arc<Mutex<T>>,
-    proxy: Option<CauseProxy<T>>,
-}
-
-impl<T: std::error::Error + 'static> SyncError<T> {
-    pub fn new(err: T) -> Self {
-        let arc = Arc::new(Mutex::new(err));
-        let proxy = arc
-            .lock()
-            .unwrap()
-            .source()
-            .map(|s| CauseProxy::new(s, Arc::downgrade(&arc), 0));
-
-        SyncError { inner: arc, proxy }
-    }
-
-    pub fn maybe<R>(r: std::result::Result<R, T>) -> std::result::Result<R, Self> {
-        match r {
-            Ok(v) => Ok(v),
-            Err(e) => Err(SyncError::new(e)),
-        }
-    }
-
-    pub fn unwrap(self) -> T {
-        Arc::try_unwrap(self.inner).unwrap().into_inner().unwrap()
-    }
-}
-
-impl<T: std::error::Error + 'static> std::error::Error for SyncError<T> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.proxy.as_ref().map(|e| e as _)
-    }
-}
-
-impl<T> Display for SyncError<T>
-where
-    T: Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.lock().unwrap().fmt(f)
-    }
-}
-
-impl<T> Debug for SyncError<T>
-where
-    T: Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.lock().unwrap().fmt(f)
-    }
-}
-
-struct CauseProxy<T: 'static> {
-    inner: Weak<Mutex<T>>,
-    next: Option<Box<CauseProxy<T>>>,
-    depth: u32,
-}
-
-impl<T: std::error::Error> CauseProxy<T> {
-    fn new(err: &dyn std::error::Error, weak: Weak<Mutex<T>>, depth: u32) -> Self {
-        // Can't allocate an object, or mutate the proxy safely during source(),
-        // so we just take the hit at construction, recursively. We can't hold
-        // references outside the mutex at all, so instead we remember how many
-        // steps to get to this proxy. And if some error chain plays tricks, the
-        // user gets both pieces.
-        CauseProxy {
-            inner: weak.clone(),
-            depth,
-            next: err
-                .source()
-                .map(|s| Box::new(CauseProxy::new(s, weak, depth + 1))),
-        }
-    }
-
-    fn with_instance<R, F>(&self, f: F) -> R
-    where
-        F: FnOnce(&(dyn std::error::Error + 'static)) -> R,
-    {
-        let arc = self.inner.upgrade().unwrap();
-        {
-            let e = arc.lock().unwrap();
-            let mut source = e.source().unwrap();
-            for _ in 0..self.depth {
-                source = source.source().unwrap();
-            }
-            f(source)
-        }
-    }
-}
-
-impl<T: std::error::Error + 'static> std::error::Error for CauseProxy<T> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.next.as_ref().map(|e| e as _)
-    }
-}
-
-impl<T> Display for CauseProxy<T>
-where
-    T: Display + std::error::Error,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with_instance(|i| std::fmt::Display::fmt(&i, f))
-    }
-}
-
-impl<T> Debug for CauseProxy<T>
-where
-    T: Debug + std::error::Error,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with_instance(|i| std::fmt::Debug::fmt(&i, f))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use error_chain::{ChainedError, State};
     use std::error::Error as StdError;
 
     #[test]
     fn test_def_same_option() {
-        let a = Some(Box::from(NewError::msg("A")));
-        let b = Some(Box::from(NewError::msg("A")));
+        let a = Some(Box::from(Error::msg("A")));
+        let b = Some(Box::from(Error::msg("A")));
 
         assert!(a.definitely_same(&b));
         assert!(b.definitely_same(&a));
 
-        let b = Some(Box::from(NewError::msg("B")));
+        let b = Some(Box::from(Error::msg("B")));
         assert!(!a.definitely_same(&b));
 
         let b = None;
@@ -435,26 +186,26 @@ mod tests {
 
     #[test]
     fn test_def_same_err() {
-        let a = Error::new(ErrorKind::Msg(String::from("A")), State::default());
-        let b = Error::new(ErrorKind::Msg(String::from("A")), State::default());
+        let a = Error::msg("A");
+        let b = Error::msg("A");
 
         // Different backtraces but should be same
         assert!(a.definitely_same(&b));
 
-        let b = Error::new(ErrorKind::BadLength(0, 0), State::default());
+        let b = Error::msg("B");
         assert!(!a.definitely_same(&b));
 
-        let a = Error::new(ErrorKind::NewStyle(NewError::msg("A")), State::default());
+        let a = Error::msg("A");
         assert!(!a.definitely_same(&b));
 
-        let b = Error::new(ErrorKind::NewStyle(NewError::msg("A")), State::default());
+        let b = Error::msg("A");
         assert!(a.definitely_same(&b));
     }
 
     #[test]
     fn test_def_same_box_err() {
-        let a: Box<dyn StdError + Send> = Box::from(NewError::msg("A"));
-        let b: Box<dyn StdError + Send> = Box::from(NewError::msg("B"));
+        let a: Box<dyn StdError + Send> = Box::from(Error::msg("A"));
+        let b: Box<dyn StdError + Send> = Box::from(Error::msg("B"));
 
         assert!(a.definitely_same(&a));
         assert!(!a.definitely_same(&b));

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,7 @@ cfg_if::cfg_if! {
     } else {
         use std::error;
 
+        /// Null error to replace lack of `toml` dependency
         #[derive(Debug)]
         pub enum ReadError {}
 
@@ -31,6 +32,7 @@ cfg_if::cfg_if! {
 
         impl error::Error for ReadError { }
 
+        /// Null error to replace lack of `toml` dependency
         #[derive(Debug)]
         pub enum WriteError {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@ pub use crate::engines::bibtex::BibtexEngine;
 pub use crate::engines::spx2html::Spx2HtmlEngine;
 pub use crate::engines::tex::{TexEngine, TexOutcome};
 pub use crate::engines::xdvipdfmx::XdvipdfmxEngine;
-pub use crate::errors::{Error, ErrorKind, Result};
+pub use crate::errors::Error;
+pub use tectonic_errors::Result;
 
 // Convenienece re-exports for migration into our multi-crate setup
 pub use tectonic_engine_xetex::FORMAT_SERIAL;
@@ -177,8 +178,8 @@ pub fn latex_to_pdf<T: AsRef<str>>(latex: T) -> Result<Vec<u8>> {
 
     match files.remove("texput.pdf") {
         Some(file) => Ok(file.data),
-        None => Err(errmsg!(
-            "LaTeX didn't report failure, but no PDF was created (??)"
+        None => Err(Error::msg(
+            "LaTeX didn't report failure, but no PDF was created (??)",
         )),
     }
 }

--- a/tests/bibtex.rs
+++ b/tests/bibtex.rs
@@ -7,9 +7,10 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use tectonic::io::{FilesystemIo, IoProvider, IoStack, MemoryIo};
-use tectonic::{errors::Result, BibtexEngine};
+use tectonic::BibtexEngine;
 use tectonic_bridge_core::{CoreBridgeLauncher, MinimalDriver};
 use tectonic_engine_xetex::TexOutcome;
+use tectonic_errors::Result;
 use tectonic_status_base::NoopStatusBackend;
 
 #[path = "util/mod.rs"]

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -20,9 +20,10 @@ use std::{
     path::{Path, PathBuf},
 };
 use tectonic::errors::DefinitelySame;
-use tectonic::{errors::Result, io::memory::MemoryFileCollection};
+use tectonic::io::memory::MemoryFileCollection;
 use tectonic_bridge_core::{CoreBridgeLauncher, MinimalDriver};
 use tectonic_engine_xetex::TexOutcome;
+use tectonic_errors::Result;
 
 pub use tectonic::test_util::test_path;
 use tectonic_errors::prelude::StdResult;


### PR DESCRIPTION
I'd like to get this in before 0.17 - if we're changing from `app_dirs2` to `directory`, I'd like to make this breaking change in the same release.

Drops error-chain, as it's significantly out of date and deprecated. Instead we now use `anyhow` in the binary crate through the re-export in `tectonic_errors`. This both removes several transitive dependencies and allows cleaning up some warnings related to using such an old dependency.