### PR TITLE
Remove usage of long-deprecated `CARGO_BIN_PATH`

### DIFF
--- a/tests/executable.rs
+++ b/tests/executable.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 
 #[path = "util/mod.rs"]
 mod util;
-use crate::util::{cargo_dir, ensure_plain_format};
+use crate::util::{ensure_plain_format, tectonic_exe};
 
 lazy_static! {
     static ref TEST_ROOT: PathBuf = {
@@ -53,9 +53,7 @@ fn get_plain_format_arg() -> String {
 /// tells the Tectonic binary to go into "test mode" and use local test
 /// assets, rather than an actual network bundle.
 fn prep_tectonic(cwd: &Path, args: &[&str]) -> Command {
-    let tectonic = cargo_dir()
-        .join("tectonic")
-        .with_extension(env::consts::EXE_EXTENSION);
+    let tectonic = tectonic_exe();
 
     if fs::metadata(&tectonic).is_err() {
         panic!("tectonic binary not found at {tectonic:?}. Do you need to run `cargo build`?")

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -36,20 +36,9 @@ pub fn set_test_root() {
     ::tectonic::test_util::set_test_root_augmented(env!("CARGO_MANIFEST_DIR"));
 }
 
-// Duplicated from Cargo's own testing code:
-// https://github.com/rust-lang/cargo/blob/19fdb308/tests/cargotest/support/mod.rs#L305-L318
-pub fn cargo_dir() -> PathBuf {
-    env::var_os("CARGO_BIN_PATH")
+pub fn tectonic_exe() -> PathBuf {
+    env::var_os("CARGO_BIN_EXE_tectonic")
         .map(PathBuf::from)
-        .or_else(|| {
-            env::current_exe().ok().map(|mut path| {
-                path.pop();
-                if path.ends_with("deps") {
-                    path.pop();
-                }
-                path
-            })
-        })
         .unwrap_or_else(|| panic!("CARGO_BIN_PATH wasn't set. Cannot continue running test"))
 }
 


### PR DESCRIPTION
Changes to use the better-supported `CARGO_BIN_EXE_<name>`