### PR TITLE
bibtex: don't panic on an empty @string macro

### DIFF
--- a/crates/engine_bibtex/src/scan.rs
+++ b/crates/engine_bibtex/src/scan.rs
@@ -660,6 +660,7 @@ fn scan_a_field_token_and_eat_white(
                     let mut str = globals.pool.get_str(strnum);
 
                     if globals.buffers.offset(BufTy::Ex, 1) == 0
+                        && !str.is_empty()
                         && LexClass::of(str[0]) == LexClass::Whitespace
                     {
                         if globals.buffers.offset(BufTy::Ex, 1) >= globals.buffers.len() {

--- a/tests/bibtex.rs
+++ b/tests/bibtex.rs
@@ -96,8 +96,6 @@ fn test_single_entry() {
     TestCase::new(&["cites", "single_entry"]).go()
 }
 
-/// Empty `@string` macro ("") at the start of a stored field: used to panic in
-/// `scan_a_field_token_and_eat_white` (cryptobib defines many such macros).
 #[test]
 fn test_empty_macro() {
     TestCase::new(&["cites", "empty_macro"]).go()

--- a/tests/bibtex.rs
+++ b/tests/bibtex.rs
@@ -96,6 +96,13 @@ fn test_single_entry() {
     TestCase::new(&["cites", "single_entry"]).go()
 }
 
+/// Empty `@string` macro ("") at the start of a stored field: used to panic in
+/// `scan_a_field_token_and_eat_white` (cryptobib defines many such macros).
+#[test]
+fn test_empty_macro() {
+    TestCase::new(&["cites", "empty_macro"]).go()
+}
+
 #[test]
 fn test_odd_strings() {
     TestCase::new(&["cites", "odd_strings"])

--- a/tests/bibtex/cites/empty_macro.aux
+++ b/tests/bibtex/cites/empty_macro.aux
@@ -1,0 +1,5 @@
+\relax
+\citation{Empty06}
+\bibdata{empty_macro}
+\bibcite{Empty06}{1}
+\bibstyle{../plain}

--- a/tests/bibtex/cites/empty_macro.bbl
+++ b/tests/bibtex/cites/empty_macro.bbl
@@ -1,0 +1,8 @@
+\begin{thebibliography}{1}
+
+\bibitem{Empty06}
+Nobody Jr.
+\newblock My article.
+\newblock Available online, 2006.
+
+\end{thebibliography}

--- a/tests/bibtex/cites/empty_macro.bib
+++ b/tests/bibtex/cites/empty_macro.bib
@@ -1,0 +1,7 @@
+@string{empty = ""}
+
+@misc{ Empty06,
+       author = "Nobody Jr",
+       title = "My Article",
+       howpublished = empty # "Available online",
+       year = "2006" }

--- a/tests/bibtex/cites/empty_macro.blg
+++ b/tests/bibtex/cites/empty_macro.blg
@@ -1,0 +1,5 @@
+This is BibTeX, Version 0.99d
+Capacity: max_strings=35307, hash_size=35307, hash_prime=30011
+The top-level auxiliary file: empty_macro.aux
+The style file: ../plain.bst
+Database file #1: empty_macro.bib


### PR DESCRIPTION
## Problem

Tectonic's built-in BibTeX panics whenever a `@string` macro that expands to the
empty string is referenced at the **start** of a stored field:

```
thread 'main' panicked at crates/engine_bibtex/src/scan.rs:663:41:
index out of bounds: the len is 0 but the index is 0
```

In practice this means tectonic cannot compile **any** paper that cites
[cryptobib](https://github.com/cryptobib/export), the crypto community's shared
bibliography: its `abbrev3.bib` defines well over a thousand venue
`name`/`address` macros as `""` (e.g. `@string{acispname = ""}`), and as soon as
an entry references one in a stored field such as `address`, the BibTeX pass
aborts — even when a correct `.bbl` already exists, since the pass re-runs
regardless.

## Root cause

In `scan_a_field_token_and_eat_white`, a macro token is expanded into `str` and,
at the start of a field value, its first byte is inspected to collapse leading
whitespace:

```rust
let mut str = globals.pool.get_str(strnum);

if globals.buffers.offset(BufTy::Ex, 1) == 0
    && LexClass::of(str[0]) == LexClass::Whitespace   // panics when str == ""
{
```

For an empty macro, `str` is a zero-length slice, so `str[0]` is out of bounds.
The original WEB/C BibTeX reads `str_pool[tmp_ptr]` from a shared array here and
thus reads one byte past harmlessly; the Rust port returns an exact-length
slice, turning the same access into a panic. The copy loop a few lines below
already guards with `!str.is_empty()` — the leading-whitespace check just didn't.

## Fix

One line — guard the check the same way:

```rust
if globals.buffers.offset(BufTy::Ex, 1) == 0
    && !str.is_empty()
    && LexClass::of(str[0]) == LexClass::Whitespace
{
```

An empty macro then contributes nothing to the field, matching reference
`bibtex`/`bibtex8`.

## Test

Adds `tests/bibtex/cites/empty_macro` (an empty `@string` referenced via `#` at
the start of a field). Its expected `.bbl` is **byte-identical** to the output
of `bibtex8` on the same input. The full bibtex suite (24 tests) passes.

## Reproduction

Minimal, self-contained (two files plus a driver; no cryptobib needed):
https://github.com/osdnk/tectonic-bibtex-empty-macro-repro

```sh
git clone https://github.com/osdnk/tectonic-bibtex-empty-macro-repro
cd tectonic-bibtex-empty-macro-repro && ./reproduce.sh
```

Marked draft pending maintainer feedback on the approach.

