### PR TITLE
bundles: prefetch retained Itar cache entries concurrently

### DIFF
--- a/crates/bundles/src/cache.rs
+++ b/crates/bundles/src/cache.rs
@@ -10,6 +10,7 @@
 use crate::{Bundle, CachableBundle, FileIndex, FileInfo};
 use chrono::{DateTime, Duration, Utc};
 use std::{
+    collections::HashSet,
     fs::{self, File},
     io::{self, BufReader, Read, Write},
     path::{Path, PathBuf},
@@ -23,6 +24,8 @@ use tectonic_io_base::{
     InputHandle, InputOrigin, IoProvider, OpenResult,
 };
 use tectonic_status_base::StatusBackend;
+
+mod prefetch;
 
 /// A convenience method to provide a better error message when writing to a created file.
 fn file_create_write<P, F, E>(path: P, write_fn: F) -> Result<()>
@@ -93,6 +96,21 @@ pub struct BundleCache<'this, T> {
 
     // The hash of the bundle we're caching.
     bundle_hash: DigestData,
+
+    /// Path to the prefetch manifest: the set of file names this bundle has been
+    /// observed to need. We record into it as files are fetched, and replay it
+    /// concurrently on a cold cache so the engine's serial on-demand requests
+    /// all hit warm cache.
+    manifest_path: PathBuf,
+
+    /// Names of files known to be needed (loaded from `manifest_path`).
+    touched: HashSet<String>,
+
+    /// Whether the backend can benefit from replaying a prefetch manifest.
+    prefetch_supported: bool,
+
+    /// Whether we've already attempted the concurrent prefetch this session.
+    prefetched: bool,
 }
 
 impl<'this, T: FileIndex<'this>> BundleCache<'this, T> {
@@ -113,10 +131,9 @@ impl<'this, T: FileIndex<'this>> BundleCache<'this, T> {
         };
 
         let hash_dir = ensure_dir!(inline, &cache_root.join("hashes"));
-        let hash_file = hash_dir.join(app_dirs::sanitize(&bundle.get_location()));
-        let check_file = hash_dir
-            .join(app_dirs::sanitize(&bundle.get_location()))
-            .with_extension("lock");
+        let bundle_location = app_dirs::sanitize(&bundle.get_location());
+        let hash_file = hash_dir.join(&bundle_location);
+        let check_file = hash_dir.join(&bundle_location).with_extension("lock");
 
         let saved_hash = match File::open(&hash_file) {
             Ok(f) => {
@@ -195,11 +212,27 @@ impl<'this, T: FileIndex<'this>> BundleCache<'this, T> {
             (Some((h, _)), Err(_)) => h, // Bundle is offline, but we're ok.
         };
 
+        // Key the working set by bundle location rather than content hash so a
+        // routine bundle refresh can reuse the names learned from the previous
+        // revision. Stale names are harmless: prefetch resolves every name
+        // against the current index before fetching it.
+        let manifest_path = cache_root.join(format!("data/{bundle_location}.prefetch"));
+        let prefetch_supported = bundle.supports_batch_open();
+        let touched = if prefetch_supported {
+            prefetch::load_manifest(&manifest_path)
+        } else {
+            HashSet::new()
+        };
+
         let bundle = BundleCache {
             only_cached,
             bundle,
             cache_root,
             bundle_hash,
+            manifest_path,
+            touched,
+            prefetch_supported,
+            prefetched: false,
         };
 
         // Right now, files are stored in
@@ -365,15 +398,34 @@ impl<'this, T: FileIndex<'this>> IoProvider for BundleCache<'this, T> {
         name: &str,
         status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
-        let path = match self.get_fileinfo(name) {
+        // On the first lookup of a cold cache, warm the recorded working set
+        // concurrently so the engine's subsequent serial requests hit cache.
+        self.prefetch(status);
+
+        let (in_cache, info) = match self.get_fileinfo(name) {
             OpenResult::NotAvailable => return OpenResult::NotAvailable,
             OpenResult::Err(e) => return OpenResult::Err(e),
-            OpenResult::Ok((true, f)) => self.get_file_path(&f),
-            OpenResult::Ok((false, f)) => match self.fetch_file(f, status) {
-                OpenResult::Ok(p) => p,
+            OpenResult::Ok(resolved) => resolved,
+        };
+
+        let path = if in_cache {
+            // Record the original lookup rather than the resolved file name:
+            // the index may apply search rules, and replaying the lookup
+            // preserves those semantics. Warm hits count too, allowing an
+            // existing cache to learn a working set without redownloading it.
+            self.record_resolved_name(name);
+            self.get_file_path(&info)
+        } else {
+            match self.fetch_file(info, status) {
+                OpenResult::Ok(p) => {
+                    // Failed downloads stay out of the learned set. They will
+                    // be retried normally if the engine requests them again.
+                    self.record_resolved_name(name);
+                    p
+                }
                 OpenResult::NotAvailable => return OpenResult::NotAvailable,
                 OpenResult::Err(e) => return OpenResult::Err(e),
-            },
+            }
         };
 
         let f = match File::open(path) {

--- a/crates/bundles/src/cache/prefetch.rs
+++ b/crates/bundles/src/cache/prefetch.rs
@@ -1,0 +1,175 @@
+// Copyright 2017-2021 the Tectonic Project
+// Licensed under the MIT License.
+
+//! Learned working-set prefetching for cached bundles.
+
+use super::{file_create_write, BundleCache};
+use crate::FileIndex;
+use std::{
+    collections::HashSet,
+    fs::{self, File},
+    io::{BufRead, BufReader, Write},
+    path::Path,
+};
+use tectonic_io_base::OpenResult;
+use tectonic_status_base::{tt_note, StatusBackend};
+
+/// Upper bound on the number of file names recorded in a prefetch manifest.
+const MAX_MANIFEST_ENTRIES: usize = 512;
+
+/// Maximum number of file bodies retained in memory by one batch.
+const MAX_PREFETCH_BATCH_FILES: usize = 64;
+
+fn manifest_name_is_valid(name: &str) -> bool {
+    !name.is_empty() && !name.as_bytes().iter().any(|b| matches!(b, b'\r' | b'\n'))
+}
+
+fn parse_manifest(reader: impl BufRead) -> HashSet<String> {
+    let mut out = HashSet::new();
+
+    for line in reader.lines().map_while(Result::ok) {
+        if !manifest_name_is_valid(&line) {
+            continue;
+        }
+
+        if out.insert(line.to_owned()) && out.len() == MAX_MANIFEST_ENTRIES {
+            break;
+        }
+    }
+
+    out
+}
+
+/// Load a prefetch manifest. Missing or unreadable manifests simply disable
+/// the optimization for this run.
+pub(super) fn load_manifest(path: &Path) -> HashSet<String> {
+    File::open(path)
+        .map(|f| parse_manifest(BufReader::new(f)))
+        .unwrap_or_default()
+}
+
+impl<'this, T: FileIndex<'this>> BundleCache<'this, T> {
+    /// Warm a learned working set when its metadata remains but file blobs do not.
+    pub(super) fn prefetch(&mut self, status: &mut dyn StatusBackend) {
+        if !self.prefetch_supported
+            || self.prefetched
+            || self.only_cached
+            || self.touched.is_empty()
+        {
+            return;
+        }
+        self.prefetched = true;
+
+        if let Err(e) = self.ensure_index() {
+            tt_note!(status, "skipping prefetch, couldn't load bundle index: {e}");
+            return;
+        }
+
+        let mut names: Vec<String> = self.touched.iter().cloned().collect();
+        names.sort();
+        let mut infos = Vec::new();
+        for name in &names {
+            if let Some(info) = self.bundle.search(name) {
+                if !self.get_file_path(&info).exists() {
+                    infos.push(info);
+                }
+            }
+        }
+
+        for batch in infos.chunks(MAX_PREFETCH_BATCH_FILES) {
+            let results = self.bundle.batch_open(batch, status);
+            let mut complete = results.len() == batch.len()
+                && results
+                    .iter()
+                    .all(|result| matches!(result, OpenResult::Ok(_)));
+
+            for (info, result) in batch.iter().zip(results) {
+                let OpenResult::Ok(bytes) = result else {
+                    continue;
+                };
+
+                let target = self.get_file_path(info);
+                if fs::create_dir_all(target.parent().unwrap()).is_err() {
+                    complete = false;
+                    continue;
+                }
+
+                let tmp_path = self.get_file_path_tmp(info);
+                if file_create_write(&tmp_path, |f| f.write_all(&bytes)).is_err() {
+                    let _ = fs::remove_file(&tmp_path);
+                    complete = false;
+                    continue;
+                }
+
+                if fs::rename(&tmp_path, &target).is_err() {
+                    let _ = fs::remove_file(&tmp_path);
+                    if !target.exists() {
+                        complete = false;
+                    }
+                }
+            }
+
+            if !complete {
+                break;
+            }
+        }
+    }
+}
+
+impl<T> BundleCache<'_, T> {
+    /// Remember a successfully resolved lookup for a future prefetch.
+    pub(super) fn record_resolved_name(&mut self, name: &str) {
+        if !self.prefetch_supported
+            || !manifest_name_is_valid(name)
+            || self.touched.len() >= MAX_MANIFEST_ENTRIES
+            || !self.touched.insert(name.to_owned())
+        {
+            return;
+        }
+
+        let mut line = Vec::with_capacity(name.len() + 1);
+        line.extend_from_slice(name.as_bytes());
+        line.push(b'\n');
+
+        if let Ok(mut file) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.manifest_path)
+        {
+            let _ = file.write_all(&line);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn manifest_parser_skips_blanks_and_deduplicates() {
+        let input = Cursor::new(b"\nalpha\r\nalpha\nbeta\nbad\rname\n");
+        let parsed = parse_manifest(input);
+
+        assert_eq!(parsed.len(), 2);
+        assert!(parsed.contains("alpha"));
+        assert!(parsed.contains("beta"));
+    }
+
+    #[test]
+    fn manifest_parser_caps_unique_entries() {
+        let mut input = String::from("duplicate\nduplicate\n\n");
+        for i in 0..MAX_MANIFEST_ENTRIES {
+            input.push_str(&format!("entry-{i}\n"));
+        }
+        input.push_str("past-the-cap\n");
+
+        let parsed = parse_manifest(Cursor::new(input));
+
+        assert_eq!(parsed.len(), MAX_MANIFEST_ENTRIES);
+        assert!(parsed.contains("duplicate"));
+        assert!(parsed.contains(&format!("entry-{}", MAX_MANIFEST_ENTRIES - 2)));
+        assert!(!parsed.contains(&format!("entry-{}", MAX_MANIFEST_ENTRIES - 1)));
+        assert!(!parsed.contains("past-the-cap"));
+    }
+}

--- a/crates/bundles/src/itar.rs
+++ b/crates/bundles/src/itar.rs
@@ -131,11 +131,15 @@ impl ItarBundle {
 
     /// Fill this bundle's index, if it is empty.
     fn ensure_index(&mut self) -> Result<()> {
+        // The index may have been initialized from the on-disk cache. Make sure
+        // file reads still have a range reader before taking the early return.
+        // Creating the reader does not perform network I/O.
+        self.connect_reader();
+
         // Fetch index if it is empty
         if self.index.is_initialized() {
             return Ok(());
         }
-        self.connect_reader();
 
         let mut reader = self.get_index_reader()?;
         self.index.initialize(&mut reader)?;
@@ -283,5 +287,23 @@ impl CachableBundle<'_, ItarFileIndex> for ItarBundle {
             "failed to download \"{}\"; please check your network connection.",
             info.name
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_index_still_connects_range_reader() {
+        let mut bundle = ItarBundle::new("https://example.invalid/bundle.tar".into()).unwrap();
+        bundle
+            .index
+            .initialize(&mut Cursor::new(b"plain.tex 0 1\n"))
+            .unwrap();
+
+        assert!(bundle.reader.is_none());
+        bundle.ensure_index().unwrap();
+        assert!(bundle.reader.is_some());
     }
 }

--- a/crates/bundles/src/itar.rs
+++ b/crates/bundles/src/itar.rs
@@ -29,6 +29,55 @@ use tectonic_geturl::{DefaultBackend, DefaultRangeReader, GetUrlBackend, RangeRe
 use tectonic_io_base::{digest, InputHandle, InputOrigin, IoProvider, OpenResult};
 use tectonic_status_base::{tt_note, tt_warning, NoopStatusBackend, StatusBackend};
 
+mod batch;
+
+/// Read a single file's bytes through `reader`, retrying on transient failures.
+///
+/// This is the shared core used by both the one-at-a-time [`ItarBundle::open_fileinfo`]
+/// path and the concurrent [`ItarBundle::batch_open`] path.
+fn read_file_with_retries(
+    reader: &mut DefaultRangeReader,
+    info: &ItarFileInfo,
+    status: &mut dyn StatusBackend,
+) -> OpenResult<Vec<u8>> {
+    // Edge case for zero-sized reads (these cause errors on some web hosts).
+    if info.length == 0 {
+        return OpenResult::Ok(Vec::new());
+    }
+
+    for i in 0..NET_RETRY_ATTEMPTS {
+        let mut stream = match reader.read_range(info.offset, info.length) {
+            Ok(r) => r,
+            Err(e) => {
+                tt_warning!(status,
+                    "failure fetching \"{}\" from network ({}/{NET_RETRY_ATTEMPTS})",
+                    info.name, i+1; e
+                );
+                thread::sleep(Duration::from_millis(NET_RETRY_SLEEP_MS));
+                continue;
+            }
+        };
+
+        let mut v = Vec::with_capacity(info.length);
+        match stream.read_to_end(&mut v) {
+            Ok(_) => return OpenResult::Ok(v),
+            Err(e) => {
+                tt_warning!(status,
+                    "failure downloading \"{}\" from network ({}/{NET_RETRY_ATTEMPTS})",
+                    info.name, i+1; e.into()
+                );
+                thread::sleep(Duration::from_millis(NET_RETRY_SLEEP_MS));
+                continue;
+            }
+        };
+    }
+
+    OpenResult::Err(anyhow!(
+        "failed to download \"{}\"; please check your network connection.",
+        info.name
+    ))
+}
+
 /// The internal file-information struct used by the [`ItarBundle`].
 #[derive(Clone, Debug)]
 pub struct ItarFileInfo {
@@ -198,6 +247,10 @@ impl Bundle for ItarBundle {
 }
 
 impl CachableBundle<'_, ItarFileIndex> for ItarBundle {
+    fn supports_batch_open(&self) -> bool {
+        true
+    }
+
     fn get_location(&mut self) -> String {
         self.url.clone()
     }
@@ -232,61 +285,34 @@ impl CachableBundle<'_, ItarFileIndex> for ItarBundle {
             Err(e) => return OpenResult::Err(e),
         };
 
-        let mut v = Vec::with_capacity(info.length);
         tt_note!(status, "downloading {}", info.name);
 
-        // Edge case for zero-sized reads
-        // (these cause errors on some web hosts)
-        if info.length == 0 {
-            return OpenResult::Ok(InputHandle::new_read_only(
+        match read_file_with_retries(self.reader.as_mut().unwrap(), info, status) {
+            OpenResult::Ok(v) => OpenResult::Ok(InputHandle::new_read_only(
                 info.name.to_owned(),
                 Cursor::new(v),
                 InputOrigin::Other,
-            ));
+            )),
+            OpenResult::NotAvailable => OpenResult::NotAvailable,
+            OpenResult::Err(e) => OpenResult::Err(e),
         }
+    }
 
-        // Get file with retries
-        for i in 0..NET_RETRY_ATTEMPTS {
-            let mut stream = match self
-                .reader
-                .as_mut()
-                .unwrap()
-                .read_range(info.offset, info.length)
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    tt_warning!(status,
-                        "failure fetching \"{}\" from network ({}/{NET_RETRY_ATTEMPTS})",
-                        info.name, i+1; e
-                    );
-                    thread::sleep(Duration::from_millis(NET_RETRY_SLEEP_MS));
-                    continue;
-                }
-            };
-
-            match stream.read_to_end(&mut v) {
-                Ok(_) => {}
-                Err(e) => {
-                    tt_warning!(status,
-                        "failure downloading \"{}\" from network ({}/{NET_RETRY_ATTEMPTS})",
-                        info.name, i+1; e.into()
-                    );
-                    thread::sleep(Duration::from_millis(NET_RETRY_SLEEP_MS));
-                    continue;
-                }
-            };
-
-            return OpenResult::Ok(InputHandle::new_read_only(
-                info.name.to_owned(),
-                Cursor::new(v),
-                InputOrigin::Other,
-            ));
-        }
-
-        OpenResult::Err(anyhow!(
-            "failed to download \"{}\"; please check your network connection.",
-            info.name
-        ))
+    /// Download many files concurrently.
+    ///
+    /// Each file is an independent HTTP byte-range request, so on a cold cache
+    /// the dominant cost is round-trip latency multiplied by the number of
+    /// files. Issuing them one-at-a-time (as the engine does on demand) is
+    /// therefore badly latency-bound. Here we fan the requests out across a pool
+    /// of worker threads, each with its own range reader (and thus its own
+    /// pooled HTTP connection), which collapses N serial round-trips into
+    /// roughly N/concurrency.
+    fn batch_open(
+        &mut self,
+        infos: &[ItarFileInfo],
+        status: &mut dyn StatusBackend,
+    ) -> Vec<OpenResult<Vec<u8>>> {
+        batch::open(self, infos, status)
     }
 }
 

--- a/crates/bundles/src/itar/batch.rs
+++ b/crates/bundles/src/itar/batch.rs
@@ -1,0 +1,175 @@
+// Copyright 2017-2021 the Tectonic Project
+// Licensed under the MIT License.
+
+//! Concurrent byte-range reads for indexed-tar bundles.
+
+use super::{read_file_with_retries, ItarBundle, ItarFileInfo};
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Mutex,
+    },
+    thread,
+};
+use tectonic_errors::prelude::*;
+use tectonic_geturl::{DefaultBackend, GetUrlBackend};
+use tectonic_io_base::OpenResult;
+use tectonic_status_base::{tt_note, NoopStatusBackend, StatusBackend};
+
+const DEFAULT_PREFETCH_CONCURRENCY: usize = 16;
+const MAX_PREFETCH_CONCURRENCY: usize = 64;
+const MAX_PREFETCH_BYTES: usize = 64 * 1024 * 1024;
+
+fn prefetch_concurrency(value: Option<&str>, file_count: usize) -> usize {
+    if file_count == 0 {
+        return 0;
+    }
+
+    value
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_PREFETCH_CONCURRENCY)
+        .min(MAX_PREFETCH_CONCURRENCY)
+        .min(file_count)
+}
+
+fn prefetch_indices(infos: &[ItarFileInfo]) -> Vec<usize> {
+    let mut bytes = 0usize;
+    let mut selected = Vec::new();
+
+    for (index, info) in infos.iter().enumerate() {
+        if let Some(next_bytes) = bytes.checked_add(info.length) {
+            if next_bytes <= MAX_PREFETCH_BYTES {
+                bytes = next_bytes;
+                selected.push(index);
+            }
+        }
+    }
+
+    selected
+}
+
+pub(super) fn open(
+    bundle: &mut ItarBundle,
+    infos: &[ItarFileInfo],
+    status: &mut dyn StatusBackend,
+) -> Vec<OpenResult<Vec<u8>>> {
+    if infos.is_empty() {
+        return Vec::new();
+    }
+
+    let selected = prefetch_indices(infos);
+    if selected.is_empty() {
+        return infos.iter().map(|_| OpenResult::NotAvailable).collect();
+    }
+
+    if let Err(e) = bundle.ensure_index() {
+        return infos
+            .iter()
+            .map(|_| OpenResult::Err(anyhow!("failed to load bundle index: {e}")))
+            .collect();
+    }
+
+    let configured = std::env::var("TECTONIC_PREFETCH_CONCURRENCY").ok();
+    let concurrency = prefetch_concurrency(configured.as_deref(), selected.len());
+    tt_note!(
+        status,
+        "prefetching {} of {} files ({}-way concurrent)",
+        selected.len(),
+        infos.len(),
+        concurrency
+    );
+
+    let url = &bundle.url;
+    let next = AtomicUsize::new(0);
+    let abort = AtomicBool::new(false);
+    let result_slots: Vec<Mutex<OpenResult<Vec<u8>>>> = (0..infos.len())
+        .map(|_| Mutex::new(OpenResult::NotAvailable))
+        .collect();
+
+    thread::scope(|scope| {
+        let mut workers = Vec::with_capacity(concurrency);
+        for _ in 0..concurrency {
+            let worker = thread::Builder::new().spawn_scoped(scope, || {
+                let mut reader = DefaultBackend::default().open_range_reader(url);
+                let mut status = NoopStatusBackend {};
+
+                loop {
+                    if abort.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    let selected_index = next.fetch_add(1, Ordering::Relaxed);
+                    if selected_index >= selected.len() {
+                        break;
+                    }
+                    let i = selected[selected_index];
+
+                    let result = read_file_with_retries(&mut reader, &infos[i], &mut status);
+                    if !matches!(result, OpenResult::Ok(_)) {
+                        abort.store(true, Ordering::Relaxed);
+                    }
+                    if let Ok(mut slot) = result_slots[i].lock() {
+                        *slot = result;
+                    }
+                }
+            });
+
+            match worker {
+                Ok(worker) => workers.push(worker),
+                Err(_) => break,
+            }
+        }
+
+        // A failed worker leaves its unclaimed slots uncached. The normal
+        // on-demand path will retry them without failing the build.
+        for worker in workers {
+            let _ = worker.join();
+        }
+    });
+
+    result_slots
+        .into_iter()
+        .map(|slot| slot.into_inner().unwrap_or(OpenResult::NotAvailable))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefetch_concurrency_is_bounded() {
+        assert_eq!(prefetch_concurrency(None, 100), 16);
+        assert_eq!(prefetch_concurrency(Some("4"), 100), 4);
+        assert_eq!(prefetch_concurrency(Some("0"), 100), 16);
+        assert_eq!(prefetch_concurrency(Some("invalid"), 100), 16);
+        assert_eq!(prefetch_concurrency(Some("1000"), 1000), 64);
+        assert_eq!(prefetch_concurrency(Some("1000"), 3), 3);
+        assert_eq!(prefetch_concurrency(Some("4"), 0), 0);
+    }
+
+    #[test]
+    fn prefetch_selection_caps_total_bytes() {
+        let mib = 1024 * 1024;
+        let infos = [
+            ItarFileInfo {
+                name: "first".into(),
+                offset: 0,
+                length: 40 * mib,
+            },
+            ItarFileInfo {
+                name: "too-large-for-remainder".into(),
+                offset: 0,
+                length: 30 * mib,
+            },
+            ItarFileInfo {
+                name: "fits".into(),
+                offset: 0,
+                length: 20 * mib,
+            },
+        ];
+
+        assert_eq!(prefetch_indices(&infos), vec![0, 2]);
+    }
+}

--- a/crates/bundles/src/lib.rs
+++ b/crates/bundles/src/lib.rs
@@ -121,14 +121,22 @@ impl<B: Bundle + ?Sized> Bundle for Box<B> {
 
 /// A bundle that may be cached.
 ///
-/// These methods do not implement any new features.
-/// Instead, they give the [`cache::BundleCache`] wrapper
-/// more direct access to existing bundle functionality.
+/// These methods give the [`cache::BundleCache`] wrapper direct access to
+/// bundle operations, including optional concurrent batch fetching.
 pub trait CachableBundle<'this, T>
 where
     Self: Bundle + 'this,
     T: FileIndex<'this>,
 {
+    /// Whether this backend provides a concurrent [`Self::batch_open`]
+    /// implementation suitable for cache prefetching.
+    ///
+    /// Backends are opt-in so that the cache never turns ordinary on-demand
+    /// reads into a large serial prefetch.
+    fn supports_batch_open(&self) -> bool {
+        false
+    }
+
     /// Initialize this bundle's file index from an external reader
     /// This allows us to retrieve the FileIndex from the cache WITHOUT
     /// touching the network.
@@ -150,6 +158,22 @@ where
         status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle>;
 
+    /// Fetch a batch of files, returning the raw bytes of each one in the same
+    /// order as `infos`.
+    ///
+    /// This exists so that network bundles can download many files concurrently
+    /// instead of one-at-a-time. Unsupported backends retain their normal
+    /// on-demand behavior because the cache only calls this method when
+    /// [`Self::supports_batch_open`] is true. Per-file failures are reported
+    /// in-band so that one bad file doesn't sink the whole batch.
+    fn batch_open(
+        &mut self,
+        infos: &[T::InfoType],
+        _status: &mut dyn StatusBackend,
+    ) -> Vec<OpenResult<Vec<u8>>> {
+        infos.iter().map(|_| OpenResult::NotAvailable).collect()
+    }
+
     /// Search for a file in this bundle.
     /// This should foward the call to `self.index`
     fn search(&mut self, name: &str) -> Option<T::InfoType>;
@@ -162,6 +186,10 @@ where
 impl<'this, T: FileIndex<'this>, B: CachableBundle<'this, T> + ?Sized> CachableBundle<'this, T>
     for Box<B>
 {
+    fn supports_batch_open(&self) -> bool {
+        (**self).supports_batch_open()
+    }
+
     fn initialize_index(&mut self, source: &mut dyn Read) -> Result<()> {
         (**self).initialize_index(source)
     }
@@ -184,6 +212,14 @@ impl<'this, T: FileIndex<'this>, B: CachableBundle<'this, T> + ?Sized> CachableB
         status: &mut dyn StatusBackend,
     ) -> OpenResult<InputHandle> {
         (**self).open_fileinfo(info, status)
+    }
+
+    fn batch_open(
+        &mut self,
+        infos: &[T::InfoType],
+        status: &mut dyn StatusBackend,
+    ) -> Vec<OpenResult<Vec<u8>>> {
+        (**self).batch_open(infos, status)
     }
 
     fn search(&mut self, name: &str) -> Option<T::InfoType> {


### PR DESCRIPTION
## Summary

This PR lets the indexed-tar bundle cache refetch a previously used working set concurrently when its metadata is still present but the cached file blobs are missing.

It does not change a first-ever build on a new cache because there is no learned manifest to replay. `TTBNetBundle` is also unchanged.

## Why

The TeX engine discovers support files synchronously. With an indexed-tar bundle, every cache miss becomes a separate HTTP byte-range request, so a high-latency connection pays the round-trip cost once per file.

After one successful build, the cache already knows which names were requested. Replaying that bounded list concurrently turns the later engine requests into local cache hits.

## Implementation

- `BundleCache` keeps an append-only manifest keyed by bundle location. It records successful warm hits and downloads, deduplicates entries when loading, and caps the learned set at 512 names.
- Prefetching is opt-in through `CachableBundle::supports_batch_open`, so backends without a concurrent implementation retain their existing on-demand behavior.
- `ItarBundle` uses a bounded worker pool with one range reader per worker. The default is 16 workers, with a hard cap of 64.
- Cache batches contain at most 64 files. The Itar backend further caps one batch at 64 MiB of declared file data.
- Files are written to a process-specific temporary path and renamed into place. Partial temporary files are removed.

## Failure behavior

- `only_cached` mode never starts a network prefetch.
- A missing, malformed, or stale manifest falls back to the existing on-demand path.
- The first final network or local-write failure stops new prefetch work. Files left uncached are retried normally if the engine requests them.
- A worker panic or spawn failure leaves its entries uncached instead of failing the build.

## Review guide

The two commits are intentionally separated:

1. `bundles: connect Itar reader for cached indexes` fixes the cached-index `reader == None` panic and adds its regression test.
2. `bundles: prefetch retained Itar cache entries` adds the opt-in API, cache-side manifest handling, and Itar worker pool.

For the feature commit, the shortest review path is:

1. `crates/bundles/src/lib.rs`: the optional batch capability.
2. `crates/bundles/src/cache/prefetch.rs`: manifest rules, cache filtering, fallback, and temporary-file placement.
3. `crates/bundles/src/itar/batch.rs`: concurrency and memory bounds.
4. The small call-site changes in `cache.rs` and `itar.rs`.

## Validation

```console
cargo fmt --all -- --check
cargo test -p tectonic_bundles --all-features
# 5 passed
cargo clippy --all --all-targets --all-features -- --deny warnings
```

A manual high-latency measurement used the same patched binary and identical cache state in both arms: retained bundle index and manifest, missing file blobs. Only `TECTONIC_PREFETCH_CONCURRENCY` changed.

| concurrency | wall time |
| ---: | ---: |
| 1 | 125.31 s |
| 16 | 9.87 s |

These absolute times depend on network latency. The relevant result is the reduction in serialized range-request waits for this specific retained-metadata cache state.

Related: #446.
