### PR TITLE
Add changelog stubs for new libraries

### DIFF
--- a/crates/bridge_fontconfig/CHANGELOG.md
+++ b/crates/bridge_fontconfig/CHANGELOG.md
@@ -1,0 +1,8 @@
+                            # See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_fontconfig/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/bridge_png/CHANGELOG.md
+++ b/crates/bridge_png/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/bridge_png/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases

--- a/crates/mac_core/CHANGELOG.md
+++ b/crates/mac_core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# See elsewhere for changelog
+
+This project’s release notes are curated from the Git history of its main
+branch. You can find them by looking at [the version of this file on the
+`release` branch][branch] or the [GitHub release history][gh-releases].
+
+[branch]: https://github.com/tectonic-typesetting/tectonic/blob/release/crates/mac_core/CHANGELOG.md
+[gh-releases]: https://github.com/tectonic-typesetting/tectonic/releases


### PR DESCRIPTION
Some libraries were missing their CHANGELOG.md stub files. Now all crates should have one.